### PR TITLE
Make Recycler Craftable

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -1009,6 +1009,19 @@
         Glass: 1
 
 - type: entity
+  id: RecyclerMachineCircuitboard
+  parent: BaseMachineCircuitboard
+  name: recycler machine board
+  components:
+    - type: Sprite
+      state: supply
+    - type: MachineBoard
+      prototype: Recycler
+      stackRequirements:
+        Manipulator: 3
+        Steel: 6
+
+- type: entity
   parent: BaseMachineCircuitboard
   id: OreProcessorIndustrialMachineCircuitboard
   name: industrial ore processor machine board

--- a/Resources/Prototypes/Entities/Structures/Machines/recycler.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/recycler.yml
@@ -1,6 +1,6 @@
 ﻿- type: entity
   id: Recycler
-  parent: BaseMachinePowered
+  parent: [ BaseMachinePowered, ConstructibleMachine ]
   name: recycler
   description: A large crushing machine used to recycle small items inefficiently. There are lights on the side.
   components:
@@ -11,6 +11,8 @@
     sound:
       # TODO: https://freesound.org/people/derjuli/sounds/448133/ CC-NC-
       path: /Audio/Ambience/Objects/circular_saw.ogg
+  - type: Machine
+    board: RecyclerMachineCircuitboard
   - type: Fixtures
     fixtures:
       brrt:

--- a/Resources/Prototypes/Recipes/Lathes/Packs/cargo.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/cargo.yml
@@ -12,6 +12,7 @@
   recipes:
   - OreProcessorMachineCircuitboard
   - SalvageMagnetMachineCircuitboard
+  - RecyclerMachineCircuitboard
 
 ## Dynamic
 

--- a/Resources/Prototypes/Recipes/Lathes/machine_boards.yml
+++ b/Resources/Prototypes/Recipes/Lathes/machine_boards.yml
@@ -397,6 +397,11 @@
   result: OreProcessorMachineCircuitboard
 
 - type: latheRecipe
+  parent: [ BaseCircuitboardRecipe, BaseSupplyMachineRecipeCategory ]
+  id: RecyclerMachineCircuitboard
+  result: RecyclerMachineCircuitboard
+
+- type: latheRecipe
   parent: [ BaseGoldCircuitboardRecipe, BaseSupplyMachineRecipeCategory ]
   id: OreProcessorIndustrialMachineCircuitboard
   result: OreProcessorIndustrialMachineCircuitboard


### PR DESCRIPTION
Title.

## About the PR
I made the Recycler able to be obtained

## Why / Balance
Because Recycler is a very important feature to salvaging. and it wasnt craftable before (bad)
