### PR TITLE
fix: Adds Most Unobtainable Boards!

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_armory.yml
@@ -77,3 +77,39 @@
   cost: 8000
   category: cargoproduct-category-name-armory
   group: market
+
+- type: cargoProduct
+  id: CommsComputerCircuitboard
+    sprite: Objects/Misc/module.rsi
+    state: cpu_command
+  product: CommsComputerCircuitboard
+  cost: 10000
+  category: cargoproduct-category-name-armory
+  group: market
+
+- type: cargoProduct
+  id: StationRecordsComputerCircuitboard
+    sprite: Objects/Misc/module.rsi
+    state: cpu_command
+  product: StationRecordsComputerCircuitboard
+  cost: 7500
+  category: cargoproduct-category-name-armory
+  group: market
+
+- type: cargoProduct
+  id: SecurityTechFabCircuitboard
+    sprite: Objects/Misc/module.rsi
+    state: cpu_security
+  product: SecurityTechFabCircuitboard
+  cost: 10000
+  category: cargoproduct-category-name-armory
+  group: market
+
+- type: cargoProduct
+  id: AmmoTechFabCircuitboard
+    sprite: Objects/Misc/module.rsi
+    state: cpu_security
+  product: AmmoTechFabCircuitboard
+  cost: 8000
+  category: cargoproduct-category-name-armory
+  group: market

--- a/Resources/Prototypes/Catalog/Cargo/cargo_medical.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_medical.yml
@@ -167,3 +167,13 @@
   cost: 12500
   category: cargoproduct-category-name-medical
   group: market
+
+- type: cargoProduct
+  id: MedicalTechFabCircuitboard
+  icon:
+    sprite: Objects/Misc/module.rsi
+    state: cpu_medical
+  product: MedicalTechFabCircuitboard
+  cost: 7500
+  category: cargoproduct-category-name-medical
+  group: market

--- a/Resources/Prototypes/Catalog/Cargo/cargo_shuttle.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_shuttle.yml
@@ -34,7 +34,7 @@
     sprite: Objects/Devices/flatpack.rsi
     state: base
   product: ComputerStationModificationFlatpack
-  cost: 1000
+  cost: 10000
   category: cargoproduct-category-name-shuttle
   group: market
 
@@ -65,6 +65,6 @@
     sprite: Objects/Misc/module.rsi
     state: cpu_command
   product: ComputerIFFCircuitboard
-  cost: 2500
+  cost: 7500
   category: cargoproduct-category-name-shuttle
   group: market

--- a/Resources/Prototypes/Recipes/Lathes/computer_boards.yml
+++ b/Resources/Prototypes/Recipes/Lathes/computer_boards.yml
@@ -52,14 +52,51 @@
 ## Recipes
 
 # Engineering
+
+- type: latheRecipe
+  parent: [ BaseCircuitboardRecipe, BaseEngineeringComputerRecipeCategory ]
+  id: AlertsComputerCircuitboard
+  result: AlertsComputerCircuitboard
+
+- type: latheRecipe
+  parent: [ BaseCircuitboardRecipe, BaseEngineeringComputerRecipeCategory ]
+  id: AtmosMonitoringComputerCircuitboard
+  result: AtmosMonitoringComputerCircuitboard
+
 - type: latheRecipe
   parent: [ BaseCircuitboardRecipe, BaseEngineeringComputerRecipeCategory ]
   id: SolarControlComputerCircuitboard
   result: SolarControlComputerCircuitboard
 
+- type: latheRecipe
+  parent: [ BaseCircuitboardRecipe, BaseEngineeringComputerRecipeCategory ]
+  id: PowerComputerCircuitboard
+  result: PowerComputerCircuitboard
+
 # Medical
 
+  - type: latheRecipe
+  parent: [ BaseCircuitboardRecipe, BaseMedicalComputerRecipeCategory ]
+  id: CrewMonitoringComputerCircuitboard
+  result: CrewMonitoringComputerCircuitboard
+
+- type: latheRecipe
+  parent: [ BaseCircuitboardRecipe, BaseMedicalComputerRecipeCategory ]
+  id: MedicalRecordsComputerCircuitboard
+  result: MedicalRecordsComputerCircuitboard
+
+  - type: latheRecipe
+  parent: [ BaseCircuitboardRecipe, BaseMedicalComputerRecipeCategory ]
+  id: BodyScannerComputerCircuitboard
+  result: BodyScannerComputerCircuitboard
+
+  - type: latheRecipe
+  parent: [ BaseSilverCircuitboardRecipe, BaseMedicalComputerRecipeCategory ]
+  id: CloningConsoleComputerCircuitboard
+  result: CloningConsoleComputerCircuitboard
+
 # Science
+
 - type: latheRecipe
   parent: [ BaseGoldCircuitboardRecipe, BaseResearchComputerRecipeCategory ]
   id: AnalysisComputerCircuitboard
@@ -70,7 +107,18 @@
   id: TechDiskComputerCircuitboard
   result: TechDiskComputerCircuitboard
 
+- type: latheRecipe
+  parent: [ BaseGoldCircuitboardRecipe, BaseResearchComputerRecipeCategory ]
+  id: RoboticsConsoleCircuitboard
+  result: RoboticsConsoleCircuitboard
+
+- type: latheRecipe
+  parent: [ BaseSilverCircuitboardRecipe, BaseResearchComputerRecipeCategory ]
+  id: ResearchComputerCircuitboard
+  result: ResearchComputerCircuitboard
+
 # Cameras
+
 - type: latheRecipe
   parent: [ BaseCircuitboardRecipe, BaseSecurityComputerRecipeCategory ]
   id: SurveillanceCameraMonitorCircuitboard
@@ -82,12 +130,24 @@
   result: SurveillanceWirelessCameraMonitorCircuitboard
 
 # Service
+
 - type: latheRecipe
   parent: [ BaseCircuitboardRecipe, BaseServiceComputerRecipeCategory ]
   id: MassMediaCircuitboard
   result: ComputerMassMediaCircuitboard
 
+  - type: latheRecipe
+  parent: [ BaseCircuitboardRecipe, BaseServiceComputerRecipeCategory ]
+  id: BlockGameArcadeComputerCircuitboard
+  result: BlockGameArcadeComputerCircuitboard
+
+  - type: latheRecipe
+  parent: [ BaseCircuitboardRecipe, BaseServiceComputerRecipeCategory ]
+  id: SpaceVillainArcadeComputerCircuitboard
+  result: SpaceVillainArcadeComputerCircuitboard
+
 # Shuttle
+
 - type: latheRecipe
   parent: [ BaseGoldCircuitboardRecipe, BaseSupplyComputerRecipeCategory ]
   id: ShuttleConsoleCircuitboard
@@ -97,6 +157,16 @@
   parent: [ BaseCircuitboardRecipe, BaseSupplyComputerRecipeCategory ]
   id: RadarConsoleCircuitboard
   result: RadarConsoleCircuitboard
+
+- type: latheRecipe
+  parent: [ BaseGoldCircuitboardRecipe, BaseSupplyComputerRecipeCategory ]
+  id: SalvageJobBoardComputerCircuitboard
+  result: SalvageJobBoardComputerCircuitboard
+
+- type: latheRecipe
+  parent: [ BaseGoldCircuitboardRecipe, BaseSupplyComputerRecipeCategory ]
+  id: CargoBountyComputerCircuitboard
+  result: CargoBountyComputerCircuitboard
 
 # Civilian
 - type: latheRecipe

--- a/Resources/Prototypes/Recipes/Lathes/machine_boards.yml
+++ b/Resources/Prototypes/Recipes/Lathes/machine_boards.yml
@@ -212,6 +212,11 @@
 
 ## Science
 
+- type: latheRecipe
+  parent: [ BaseGoldCircuitboardRecipe, BaseResearchMachineRecipeCategory ]
+  id: ResearchAndDevelopmentServerMachineCircuitboard
+  result: ResearchAndDevelopmentServerMachineCircuitboard
+
 # Artifact
 - type: latheRecipe
   parent: [ BaseGoldCircuitboardRecipe, BaseResearchMachineRecipeCategory ]


### PR DESCRIPTION
Adds most boards that were unobtainable (minus ones that are currently being depreciated temporarily).

Boards are as follows:

**AS CIRCUIT LATHE RECIPES:**
RnD Server
Atmos Alerts Computer
Atmos Monitoring Computer
Power Monitoring Computer
Medical Records Computer
Crew Monitoring Computer
Body Scanner Computer
Cloning Console Computer
Robotics Console Computer
Research Computer
Block Game Arcade Cabinet
Space Villain Arcade Cabinet
Salvage Job Board Computer
Cargo Bounty Computer

**AS PURCHASABLES FROM TRADE OUTPOSTS:**
Comms Computer
Station Records Computer
Security TechFab
Ammo TechFab
Medical TechFab

MODIFIED:
Price for ComputerStationModFlatpack has increased to 10000 (creating a station will be expensive)
Price for ComputerIFFCircuitboard increased to 7500 (The IFF console can be used to hide your IFF. It should be a bit more exclusive so not everybody hides themselves from view off the rip.)