### PR TITLE
fix: Circuitboard Recipes actually Printable now!

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/cargo.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/cargo.yml
@@ -13,6 +13,9 @@
   - OreProcessorMachineCircuitboard
   - SalvageMagnetMachineCircuitboard
   - RecyclerMachineCircuitboard
+  - CargoBountyComputerCircuitboard
+  - SalvageJobBoardComputerCircuitboard
+  - RadarConsoleCircuitboard
 
 ## Dynamic
 

--- a/Resources/Prototypes/Recipes/Lathes/Packs/engineering.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/engineering.yml
@@ -53,6 +53,10 @@
   id: EngineeringBoardsStatic
   recipes:
   - SpaceHeaterMachineCircuitBoard
+  - AlertsComputerCircuitboard
+  - AtmosMonitoringComputerCircuitboard
+  - SolarControlComputerCircuitboard
+  - PowerComputerCircuitboard
 
 ## Dynamic
 

--- a/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
@@ -84,6 +84,10 @@
   - ChemMasterMachineCircuitboard
   - CondenserMachineCircuitBoard
   - HotplateMachineCircuitboard
+  - CrewMonitoringComputerCircuitboard
+  - MedicalRecordsComputerCircuitboard
+  - BodyScannerComputerCircuitboard
+  - CloningConsoleComputerCircuitboard
 
 ## Dynamic
 

--- a/Resources/Prototypes/Recipes/Lathes/Packs/science.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/science.yml
@@ -83,6 +83,9 @@
   - APECircuitboard
   - ArtifactAnalyzerMachineCircuitboard
   - ArtifactCrusherMachineCircuitboard
+  - RoboticsConsoleCircuitboard
+  - ResearchComputerCircuitboard
+  - ResearchAndDevelopmentServerMachineCircuitboard
 
 - type: latheRecipePack
   id: CameraBoards

--- a/Resources/Prototypes/Recipes/Lathes/Packs/service.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/service.yml
@@ -39,6 +39,10 @@
   - SodaDispenserMachineCircuitboard
   - SmartFridgeCircuitboard
   - IdPrinterCircuitboard
+  - BlockGameArcadeComputerCircuitboard
+  - SpaceVillainArcadeComputerCircuitboard
+  - InvoicePrinterCircuitboard
+  - ComputerTelevisionCircuitboard
 
 ## Dynamic
 

--- a/Resources/Prototypes/Research/experimental.yml
+++ b/Resources/Prototypes/Research/experimental.yml
@@ -11,6 +11,7 @@
   cost: 5000
   recipeUnlocks:
   - ProximitySensor
+  - RoboticsConsoleCircuitboard
 
 - type: technology
   id: BasicAnomalousResearch
@@ -41,6 +42,8 @@
   - NodeScanner
   - AnalysisComputerCircuitboard
   - ArtifactAnalyzerMachineCircuitboard
+  - ResearchComputerCircuitboard
+  - ResearchAndDevelopmentServerMachineCircuitboard
 
 - type: technology
   id: AlternativeResearch


### PR DESCRIPTION
What it says on the tin. Now things are actually printable! Research items are locked behind very low level Research in Experimental.

