### PR TITLE
fix: Species Redux 1

### DIFF
--- a/Resources/Locale/en-US/markings/vulpkanin.ftl
+++ b/Resources/Locale/en-US/markings/vulpkanin.ftl
@@ -1,136 +1,136 @@
 # Ears
-marking-VulpEar-vulp = Vulpkanin ears (Base)
-marking-VulpEar-vulp-inner = Vulpkanin ears (Inner)
-marking-VulpEar = Vulpkanin
+marking-VulpEar-vulp = Canidae ears (Base)
+marking-VulpEar-vulp-inner = Canidae ears (Inner)
+marking-VulpEar = Canidae
 
-marking-VulpEarFade-vulp = Vulpkanin ears (Base)
-marking-VulpEarFade-vulp-fade = Vulpkanin ears (Fade)
-marking-VulpEarFade-vulp-inner = Vulpkanin ears (Inner)
-marking-VulpEarFade = Vulpkanin (Fade)
+marking-VulpEarFade-vulp = Canidae ears (Base)
+marking-VulpEarFade-vulp-fade = Canidae ears (Fade)
+marking-VulpEarFade-vulp-inner = Canidae ears (Inner)
+marking-VulpEarFade = Canidae (Fade)
 
-marking-VulpEarSharp-vulp = Vulpkanin ears (Base)
-marking-VulpEarSharp-vulp-sharp = Vulpkanin ears (Sharp)
-marking-VulpEarSharp-vulp-inner = Vulpkanin ears (Inner)
-marking-VulpEarSharp = Vulpkanin (Sharp)
+marking-VulpEarSharp-vulp = Canidae ears (Base)
+marking-VulpEarSharp-vulp-sharp = Canidae ears (Sharp)
+marking-VulpEarSharp-vulp-inner = Canidae ears (Inner)
+marking-VulpEarSharp = Canidae (Sharp)
 
 marking-VulpEarCoyote-coyote = Coyote ears (Base)
 marking-VulpEarCoyote-coyote-inner = Coyote ears (Inner)
-marking-VulpEarCoyote = Vulpkanin Coyote
+marking-VulpEarCoyote = Canidae Coyote
 
 marking-VulpEarJackal-jackal = Jackal ears (Base)
 marking-VulpEarJackal-jackal-inner = Jackal ears (Inner)
-marking-VulpEarJackal = Vulpkanin Jackal
+marking-VulpEarJackal = Canidae Jackal
 
 marking-VulpEarTerrier-terrier = Terrier ears (Base)
 marking-VulpEarTerrier-terrier-inner = Terrier ears (Inner)
-marking-VulpEarTerrier = Vulpkanin Terrier
+marking-VulpEarTerrier = Canidae Terrier
 
 marking-VulpEarFennec-fennec = Fennec ears (Base)
 marking-VulpEarFennec-fennec-inner = Fennec ears (Inner)
-marking-VulpEarFennec = Vulpkanin Fennec
+marking-VulpEarFennec = Canidae Fennec
 
 marking-VulpEarFox-fox = Fox ears (Base)
 marking-VulpEarFox-fox-inner = Fox ears (Inner)
-marking-VulpEarFox = Vulpkanin Fox
+marking-VulpEarFox = Canidae Fox
 
 marking-VulpEarOtie-otie = Otie ears (Base)
 marking-VulpEarOtie-otie-inner = Otie ears (Inner)
-marking-VulpEarOtie = Vulpkanin Otie
+marking-VulpEarOtie = Canidae Otie
 
 marking-VulpEarShock-shock = Shock ears (Base)
 marking-VulpEarShock-shock-inner = Shock ears (Inner)
-marking-VulpEarShock = Vulpkanin Shock
+marking-VulpEarShock = Canidae Shock
 
 
 # Snout
 
 marking-VulpSnout-snout = Snout
-marking-VulpSnout = Vulpkanin Snout
+marking-VulpSnout = Canidae Snout
 
 marking-VulpSnoutNose-snout-nose = Nose
-marking-VulpSnoutNose = Vulpkanin Nose
+marking-VulpSnoutNose = Canidae Nose
 
 marking-VulpSnoutVulpine-vulpine = Vulpine
-marking-VulpSnoutVulpine = Vulpkanin Vulpine
+marking-VulpSnoutVulpine = Canidae Vulpine
 
 marking-VulpSnoutVulpineLines-vulpine-lines = Vulpine Lines
-marking-VulpSnoutVulpineLines = Vulpkanin Vulpine Lines
+marking-VulpSnoutVulpineLines = Canidae Vulpine Lines
 
 marking-VulpSnoutBlaze-blaze = Blaze
-marking-VulpSnoutBlaze = Vulpkanin Blaze
+marking-VulpSnoutBlaze = Canidae Blaze
 
 marking-VulpSnoutMask-mask = Mask
-marking-VulpSnoutMask = Vulpkanin Mask
+marking-VulpSnoutMask = Canidae Mask
 
 marking-VulpSnoutTop-snout-top = Top
-marking-VulpSnoutTop = Vulpkanin Snout Top
+marking-VulpSnoutTop = Canidae Snout Top
 
 marking-VulpSnoutPatch-patch = Patch
-marking-VulpSnoutPatch = Vulpkanin Patch
+marking-VulpSnoutPatch = Canidae Patch
 
 
 # Head
 
 marking-VulpHeadBlaze-blaze = Blaze
-marking-VulpHeadBlaze = Vulpkanin Blaze
+marking-VulpHeadBlaze = Canidae Blaze
 
 marking-VulpHeadMask-mask = Mask
-marking-VulpHeadMask = Vulpkanin Mask
+marking-VulpHeadMask = Canidae Mask
 
 marking-VulpPatch-patch = Patch
-marking-VulpPatch = Vulpkanin Patch
+marking-VulpPatch = Canidae Patch
 
 marking-VulpSlash-slash = Slash
-marking-VulpSlash = Vulpkanin Slash
+marking-VulpSlash = Canidae Slash
 
 marking-VulpStripes1-stripes_1 = Stripes
-marking-VulpStripes1 = Vulpkanin Stripes 1
+marking-VulpStripes1 = Canidae Stripes 1
 
 marking-VulpStripes2-stripes_2 = Stripes
-marking-VulpStripes2 = Vulpkanin Stripes 2
+marking-VulpStripes2 = Canidae Stripes 2
 
 marking-VulpVulpine-vulpine = Nose
-marking-VulpVulpine = Vulpkanin Nose
+marking-VulpVulpine = Canidae Nose
 
 
 # Tails
 
 marking-VulpTailFennec-fennec = Fennec tail (Base)
 marking-VulpTailFennec-fennec-tip = Fennec tail (Tip)
-marking-VulpTailFennec = Vulpkanin Fennec
+marking-VulpTailFennec = Canidae Fennec
 
 marking-VulpTailFluffy-fluffy = Fluffy tail (Base)
 marking-VulpTailFluffy-fluffy-tip = Fluffy tail (Tip)
-marking-VulpTailFluffy = Vulpkanin Fluffy
+marking-VulpTailFluffy = Canidae Fluffy
 
 marking-VulpTailHusky-husky = Husky tail (Base)
 marking-VulpTailHusky-husky-inner = Husky tail (Inner)
 marking-VulpTailHusky-husky-outer = Husky tail (Outer)
-marking-VulpTailHusky = Vulpkanin Husky
+marking-VulpTailHusky = Canidae Husky
 
 marking-VulpTailLong-long = Long tail (Base)
 marking-VulpTailLong-long-tip = Long tail (Tip)
-marking-VulpTailLong = Vulpkanin Long
+marking-VulpTailLong = Canidae Long
 
-marking-VulpTailVulp-vulp = Vulpkanin tail (Base)
-marking-VulpTailVulp-vulp-tip = Vulpkanin tail (Tip)
-marking-VulpTailVulp = Vulpkanin
+marking-VulpTailVulp-vulp = Canidae tail (Base)
+marking-VulpTailVulp-vulp-tip = Canidae tail (Tip)
+marking-VulpTailVulp = Canidae
 
-marking-VulpTailVulpFade-vulp = Vulpkanin tail (Base)
-marking-VulpTailVulpFade-vulp-fade = Vulpkanin tail (Fade)
-marking-VulpTailVulpFade = Vulpkanin (Fade)
+marking-VulpTailVulpFade-vulp = Canidae tail (Base)
+marking-VulpTailVulpFade-vulp-fade = Canidae tail (Fade)
+marking-VulpTailVulpFade = Canidae (Fade)
 
 
 # Chest
 
 marking-VulpBellyCrest-belly_crest = Belly
-marking-VulpBellyCrest = Vulpkanin Belly Crest
+marking-VulpBellyCrest = Canidae Belly Crest
 
 marking-VulpBellyFull-belly_full = Belly
-marking-VulpBellyFull = Vulpkanin Belly Full
+marking-VulpBellyFull = Canidae Belly Full
 
 marking-VulpBellyFox-belly_fox = Belly
-marking-VulpBellyFox = Vulpkanin Belly Fox
+marking-VulpBellyFox = Canidae Belly Fox
 
 
 # Arms

--- a/Resources/Locale/en-US/species/species.ftl
+++ b/Resources/Locale/en-US/species/species.ftl
@@ -10,7 +10,7 @@ species-name-moth = Moth Person
 species-name-skeleton = Skeleton
 species-name-vox = Vox
 species-name-gingerbread = delicious baked good
-species-name-vulpkanin = Vulpkanin
+species-name-vulpkanin = Canidae
 
 ## Misc species things
 

--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -336,5 +336,5 @@
 - type: damageModifierSet
   id: Vulpkanin
   coefficients:
-    Heat: 1.15
-    Cold: 0.85
+    Heat: 1.20
+    Cold: 0.80

--- a/Resources/ServerInfo/Guidebook/Mobs/Reptilian.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Reptilian.xml
@@ -1,11 +1,11 @@
 <Document>
-  # Reptilians
+  # Unathi
 
   <Box>
     <GuideEntityEmbed Entity="MobReptilian" Caption=""/>
   </Box>
 
-  They can ONLY eat fruits and meat, but can eat raw meat and drink blood without any ill effects.
+  Unathi can ONLY eat fruits and meat, but can eat raw meat and drink blood without any ill effects.
   They prefer a somewhat higher temperature range than humans.
   They can drag objects with their tail, keeping both their hands free.
 

--- a/Resources/ServerInfo/Guidebook/Mobs/Species.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Species.xml
@@ -11,12 +11,12 @@
   </Box>
   <Box>
   <GuideEntityEmbed Entity="MobMoth" Caption="Moth Person"/>
-  <GuideEntityEmbed Entity="MobReptilian" Caption="Reptilian"/>
+  <GuideEntityEmbed Entity="MobReptilian" Caption="Unathi"/>
   <GuideEntityEmbed Entity="MobSlimePerson" Caption="Slime Person"/>
   <GuideEntityEmbed Entity="MobVox" Caption="Vox"/>
   </Box>
   <Box>
-    <GuideEntityEmbed Entity="MobVulpkanin" Caption="Vulpkanin"/>
+    <GuideEntityEmbed Entity="MobVulpkanin" Caption="Canidae"/>
   </Box>
 
 </Document>

--- a/Resources/ServerInfo/Guidebook/Mobs/Vulpkanin.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Vulpkanin.xml
@@ -1,16 +1,16 @@
 <Document>
-  # Vulpkanin
+  # Canidae
 
   <Box>
     <GuideEntityEmbed Entity="MobVulpkanin" Caption=""/>
   </Box>
 
-  Vulpkanin, due to their dense fur, [color=#1e90ff]prefer colder temperatures[/color] and [color=#ffa500]heat up faster.[/color]
+  Canidae, due to their dense fur, [color=#1e90ff]prefer colder temperatures[/color] and [color=#ffa500]heat up faster.[/color]
   Their agile (but clumsy) legs allow them to leap short distances, be careful not to bump into anything!
 
-  Their diet allows them to safely eat raw meat but they get poisoned by theobromine.
+  Their diet allows them to safely eat raw meat but they get poisoned by theobromine (chocolate products) and allicin (garlic and onion).
 
   Their weirdly shaped muzzle leads to difficulties drinking, making them sometimes spill small amounts of whatever they drank onto the ground.
 
-  They take [color=#1e90ff]15% less Cold damage[/color] but [color=#ffa500]15% more Heat damage.[/color].
+  They take [color=#1e90ff]20% less Cold damage[/color] but [color=#ffa500]20% more Heat damage.[/color].
 </Document>


### PR DESCRIPTION
Renamed:

Vulpkanin to Canidae

Reworked:

Guidebook entries for Unathi and Canidae

Canidae resistance/weakness to 20% (too unnoticeable at 15% and much stronger races exist).

Strengthened Allicin toxin effect from 0.05 to 0.2 for Canidae (not nearly as toxic as Theobromine which should be more equalized. Theobromine is 0.4 for example).