### PR TITLE
Missing barsignelectronics tag

### DIFF
--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -60,6 +60,9 @@
   id: Bandana # CargoBounty: BountyBandana
 
 - type: Tag
+  id: BarSignElectronics # 
+
+- type: Tag
   id: BaseballBat # CargoBounty: BountyBaseballBat
 
 - type: Tag


### PR DESCRIPTION
Adds a missing tag for BarSignElectronics to fix a crash related to the autolathe