### PR TITLE
You can now make Ethanol and Welding Fuel

### DIFF
--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -154,6 +154,7 @@
   id: Ethanol
   name: reagent-name-ethanol
   parent: BaseAlcohol
+  group: Biological
   desc: reagent-desc-ethanol
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: alcohol

--- a/Resources/Prototypes/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/Recipes/Reactions/chemicals.yml
@@ -542,3 +542,30 @@
       amount: 1
   products:
     Lye: 2
+
+- type: reaction # moved this from drinks.yml -beridot
+  id: EthanolBreakdown
+  source: true
+  requiredMixerCategories:
+  - Electrolysis
+  reactants:
+    Ethanol:
+      amount: 9
+  products:
+    Hydrogen: 6
+    Carbon: 2
+    Oxygen: 1
+
+- type: reaction # moved this from drinks.yml -beridot
+  id: EthanolCreation
+  requiredMixerCategories:
+  - Stir
+  reactants:
+    Hydrogen:
+      amount: 6
+    Carbon:
+      amount: 2
+    Oxygen:
+      amount: 1
+  products:
+    Ethanol: 9

--- a/Resources/Prototypes/Recipes/Reactions/drinks.yml
+++ b/Resources/Prototypes/Recipes/Reactions/drinks.yml
@@ -445,19 +445,6 @@
     ErikaSurprise: 6
 
 - type: reaction
-  id: EthanolBreakdown
-  source: true
-  requiredMixerCategories:
-  - Electrolysis
-  reactants:
-    Ethanol:
-      amount: 9
-  products:
-    Hydrogen: 6
-    Carbon: 2
-    Oxygen: 1
-
-- type: reaction
   id: FourteenLoko
   reactants:
     Coffee:

--- a/Resources/Prototypes/Recipes/Reactions/pyrotechnic.yml
+++ b/Resources/Prototypes/Recipes/Reactions/pyrotechnic.yml
@@ -73,3 +73,16 @@
     Ethanol: 5
     Hydrogen: 3
     Sulfur: 2
+
+- type: reaction
+  id: WeldingFuelCreation
+  minTemp: 420
+  reactants:
+    Hydrogen:
+      amount: 3
+    Sulfur:
+      amount: 2
+    Ethanol:
+      amount: 5
+  products:
+    WeldingFuel: 10


### PR DESCRIPTION
Title.

Ethanol and Welding Fuel is now craftable.

Recipes can be found in the chemical guidebook

Also moved Ethanol to the Chemical Guidebook (why was it in drinks?) 

(also yes I know ethanol production is created using a spoon, I cant do hotplates cause of conflicting recipes.. Distilling when?)
