### PR TITLE
Jugs can now be Recycled for 2 plastic

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemical-containers.yml
@@ -87,6 +87,9 @@
       tags:
       - ChemDispensable
     - type: DnaSubstanceTrace
+    - type: PhysicalComposition
+      materialComposition:
+        Plastic: 200 # 2 sheets cause recycler sucks at its job - Beridot
 
 - type: entity
   parent: Jug


### PR DESCRIPTION
Jugs were not able to be Recycled, meaning we would have ALOT of jugs lying around... by the end of the next playtest.  

Jugs recycle into 2 plastic sheets. Which is half of what they cost.