### PR TITLE
Fixed refueling welders

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/furniture/generic_tank.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/furniture/generic_tank.yml
@@ -28,5 +28,5 @@
             - !type:EntityAnchored
               anchored: false
           steps:
-            - tool: Welding
+            - tool: Screwing
               doAfter: 10


### PR DESCRIPTION
When refueling welders, the game was also trying to also complete the construction graph to deconstruct the tank.

Fixed By changing the Deconstruction step from Welding to Screwing.
One line change.