### PR TITLE
Moved Tank Construction Graph Recipe

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Tanks/base_structuretanks.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Tanks/base_structuretanks.yml
@@ -69,9 +69,6 @@
     solution: tank  
   - type: Transform
     noRot: true
-  - type: Construction
-    graph: GenericTankGraph
-    node: generictank
 
 # For highcap tanks
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Storage/Tanks/tanks.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Tanks/tanks.yml
@@ -33,6 +33,9 @@
   - type: Explosive
     explosionType: Default
     totalIntensity: 60 # Mediocre explosion. Not enough to do any meaningful structural damage to anything other then windows, provided you're only using one tank.
+  - type: Construction
+    graph: GenericTankGraph
+    node: generictank
 
 - type: entity
   id: WeldingFuelTankFull
@@ -100,6 +103,9 @@
     fillBaseName: watertank-2-
   - type: ExaminableSolution
     solution: tank
+  - type: Construction
+    graph: GenericTankGraph
+    node: generictank
 
 - type: entity
   parent: WaterTank
@@ -219,3 +225,6 @@
     - type: Icon
       sprite: Structures/Storage/tanks.rsi
       state: "generictank-1"
+    - type: Construction
+      graph: GenericTankGraph
+      node: generictank


### PR DESCRIPTION
Title.

Barrels no longer share the same construction graph as Reagent Tanks I moved construction graphs from the 'BaseTank' entity, and moved it to the three seperate tanks. now only the Tanks themselves can only be deconstructed.

Barrels retain the ability to be recycled.