### PR TITLE
Tiny Fan Flatpack missing parent

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/flatpack.yml
@@ -343,6 +343,7 @@
     entity: ComputerCargoBounty
     
 - type: entity
+  parent: BaseFlatpack
   id: TinyFanFlatpack
   name: tiny fan flatpack
   description: A flatpack used for constructing a tiny fan. Useful for keeping gases in or out.


### PR DESCRIPTION
## About the PR
Gives the TinyFanFlatpack the BaseFlatpack parent to fix a missing sprite error.

## Media
<img width="347" height="122" alt="Screenshot 2026-01-07 003138" src="https://github.com/user-attachments/assets/f71f70bf-a0bc-4eea-92d3-e66f1f38e2da" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
