### PR TITLE
More clothes

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -508,6 +508,12 @@
     - ClothingSecurity
     - ClothingService
     - ClothingMilitary
+    - ClothingLabCoats
+    - ClothingCentComm
+    - ClothingAssortedHats
+    - ClothingAssortedOversuits
+    - Cloaks
+    - Mantles
     - WinterCoats
     - Ties
     - Scarves
@@ -516,7 +522,6 @@
     - NFWallets # Frontier
   - type: EmagLatheRecipes
     emagStaticPacks:
-    - ClothingCentComm
     - ClothingSyndie
   - type: MaterialStorage
     whitelist: *StandardMaterialWhitelist

--- a/Resources/Prototypes/Recipes/Lathes/Packs/clothing.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/clothing.yml
@@ -27,6 +27,99 @@
   - ClothingUniformGenericCollaredShirtAndSlacksBrownAlt
   - ClothingUniformGenericCollaredShirtAndSlacksWhite
   - ClothingUniformGenericCollaredShirtAndSlacksWhiteAlt
+  - ClothingUniformJumpsuitCossack
+  - ClothingUniformJumpsuitDameDane
+  - ClothingUniformJumpsuitKimono
+  - ClothingUniformJumpsuitMonasticRobeLight
+  - ClothingUniformJumpsuitMonasticRobeDark
+  - ClothingUniformJumpsuitSafari
+  - ClothingUniformJumpskirtBlackElegantDress
+  - ClothingUniformJumpskirtBlueElegantDress
+  - ClothingUniformJumpskirtBlueTurtleneckDress
+  - ClothingUniformJumpskirtCyanStripedDress
+  - ClothingUniformJumpskirtGreenElegantDress
+  - ClothingUniformJumpskirtGreenStripedDress
+  - ClothingUniformJumpskirtGreenTurtleneckDress
+  - ClothingUniformJumpskirtPinkStripedDress
+  - ClothingUniformJumpskirtOrangeStripedDress
+  - ClothingUniformJumpskirtPurpleElegantDress
+  - ClothingUniformJumpskirtRedElegantDress
+  - ClothingUniformJumpskirtRedStripedDress
+
+- type: latheRecipePack
+  id: ClothingAssortedOversuits
+  recipes:
+  - ClothingOuterCoatDetective
+  - ClothingOuterCoatTrench
+  - ClothingOuterCoatDetectiveLoadoutGrey
+  - ClothingOuterCoatBomber
+  - ClothingOuterCoatJensen
+  - ClothingOuterCoatPirate
+  - ClothingOuterDogi
+  - ClothingOuterCoatSpaceAsshole
+  - ClothingOuterCoatExpensive
+  - ClothingOuterSuitShrineMaiden
+  - ClothingOuterSuitWitchRobes
+  - ClothingOuterRobesJudge
+  - ClothingOuterPonchoClassic
+  - ClothingOuterPoncho
+  - ClothingOuterHoodieChaplain
+  - ClothingOuterJacketChef
+  - ClothingOuterNunRobe
+  - ClothingOuterApronBar
+  - ClothingOuterApron
+  - ClothingOuterApronBotanist
+  - ClothingOuterApronChef
+
+- type: latheRecipePack
+  id: ClothingAssortedHats
+  recipes:
+  - ClothingHeadHatHoodNunHood
+  - ClothingHeadSafari
+  - ClothingHeadHatCanadaBeanie
+  - ClothingHeadHatBeaverHat
+  - ClothingHeadHatBowlerHat
+  - ClothingHeadHatFedoraBrown
+  - ClothingHeadHatFedoraGrey
+  - ClothingHeadHatCasa
+  - ClothingHeadHatChef
+  - ClothingHeadHatCowboyBlack
+  - ClothingHeadHatCowboyBountyHunter
+  - ClothingHeadHatCowboyBrown
+  - ClothingHeadHatCowboyGrey
+  - ClothingHeadHatCowboyRed
+  - ClothingHeadHatFez
+  - ClothingHeadFishCap
+  - ClothingHeadHatBrownFlatcap
+  - ClothingHeadHatGreyFlatcap
+  - ClothingHeadHatMagician
+  - ClothingHeadNurseHat
+  - ClothingHeadHatPirateTricord
+  - ClothingHeadHatPirate
+  - ClothingHeadRastaHat
+  - ClothingHeadHatSombrero
+  - ClothingHeadHatStrawHat
+  - ClothingHeadHatSurgcapBlue
+  - ClothingHeadHatSurgcapGreen
+  - ClothingHeadHatSurgcapPurple
+  - ClothingHeadHatTophat
+  - ClothingHeadHatUshanka
+  - ClothingHeadHatWitch1
+  - ClothingHeadHatWitch
+
+- type: latheRecipePack
+  id: ClothingLabCoats
+  recipes:
+  - ClothingOuterCoatLabChem
+  - ClothingOuterCoatLabCmo
+  - ClothingOuterCoatLabGene
+  - ClothingOuterCoatLab
+  - ClothingOuterCoatLabSeniorPhysician
+  - ClothingOuterCoatRnd
+  - ClothingOuterCoatRobo
+  - ClothingOuterCoatRD
+  - ClothingOuterCoatLabSeniorResearcher
+  - ClothingOuterCoatLabViro
 
 - type: latheRecipePack
   id: ClothingCargo
@@ -72,6 +165,7 @@
   - ClothingUniformJumpskirtChiefEngineerTurtle
   - ClothingUniformJumpsuitEngineering
   - ClothingUniformJumpskirtEngineering
+  - ClothingUniformJumpsuitEngineeringHazard
   - ClothingUniformJumpsuitSeniorEngineer
   - ClothingUniformJumpskirtSeniorEngineer
 
@@ -88,6 +182,11 @@
   - ClothingHeadHatBeretSeniorPhysician
   - ClothingUniformJumpsuitMedicalDoctor
   - ClothingUniformJumpskirtMedicalDoctor
+  - ClothingUniformJumpsuitPsychologist
+  - ClothingUniformJumpskirtPsychologist
+  - UniformScrubsColorBlue
+  - UniformScrubsColorGreen
+  - UniformScrubsColorPurple
   - ClothingUniformJumpsuitSeniorPhysician
   - ClothingUniformJumpskirtSeniorPhysician
   - ClothingUniformJumpsuitParamedic
@@ -102,6 +201,9 @@
   - ClothingUniformJumpskirtResearchDirector
   - ClothingUniformJumpsuitScientist
   - ClothingUniformJumpskirtScientist
+  - ClothingUniformJumpsuitScientistFormal
+  - ClothingUniformJumpsuitRoboticist
+  - ClothingUniformJumpskirtRoboticist
   - ClothingUniformJumpsuitSeniorResearcher
   - ClothingUniformJumpskirtSeniorResearcher
 
@@ -112,6 +214,8 @@
   - ClothingUniformJumpskirtDetective
   - ClothingUniformJumpsuitSecDetectiveBlue
   - ClothingUniformJumpsuitSecDetectiveBlack
+  - ClothingUniformJumpsuitDetectiveGrey
+  - ClothingUniformJumpskirtDetectiveGrey
   - ClothingHeadHatBeretHoS
   - ClothingHeadHatHoshat
   - ClothingUniformJumpsuitHoS
@@ -158,6 +262,7 @@
   recipes:
   - ClothingUniformJumpsuitBartender
   - ClothingUniformJumpskirtBartender
+  - ClothingUniformJumpsuitBartenderPurple
   - ClothingUniformJumpsuitChaplain
   - ClothingUniformJumpskirtChaplain
   - ClothingUniformJumpsuitChef
@@ -170,7 +275,20 @@
   - ClothingUniformJumpskirtJanitor
   - ClothingUniformJumpsuitLawyerBlack
   - ClothingUniformJumpskirtLawyerBlack
+  - ClothingUniformJumpsuitLawyerBlue
+  - ClothingUniformJumpskirtLawyerBlue
+  - ClothingUniformJumpsuitLawyerGood
+  - ClothingUniformJumpskirtLawyerGood
+  - ClothingUniformJumpsuitLawyerPurple
+  - ClothingUniformJumpskirtLawyerPurple
+  - ClothingUniformJumpsuitLawyerRed
+  - ClothingUniformJumpskirtLawyerRed
   - ClothingUniformJumpsuitLibrarian
+  - ClothingUniformJumpskirtLibrarian
+  - ClothingUniformJumpsuitJournalist
+  - ClothingUniformJumpsuitReporter
+  - ClothingUniformJumpskirtCurator
+  - ClothingUniformJumpsuitCurator
   - ClothingUniformJumpskirtColorLightBrown
   - ClothingUniformJumpsuitMime
   - ClothingUniformJumpskirtMime
@@ -207,6 +325,17 @@
   - ClothingOuterWinterSci
   - ClothingOuterWinterRobo
   - ClothingOuterWinterSec
+  - ClothingOuterWinterColorBlue
+  - ClothingOuterWinterColorBlack
+  - ClothingOuterWinterColorGreen
+  - ClothingOuterWinterColorLightBrown
+  - ClothingOuterWinterColorOrange
+  - ClothingOuterWinterColorPurple
+  - ClothingOuterWinterColorRed
+  - ClothingOuterWinterColorWhite
+  - ClothingOuterWinterColorYellow
+  - ClothingOuterHoodieBlack
+  - ClothingOuterHoodieGrey
 
 - type: latheRecipePack
   id: Ties
@@ -226,6 +355,30 @@
   - ClothingNeckScarfStripedOrange
   - ClothingNeckScarfStripedBlack
   - ClothingNeckScarfStripedPurple
+
+- type: latheRecipePack
+  id: Cloaks
+  recipes:
+  - ClothingNeckCloakCap
+  - ClothingNeckCloakCapFormal
+  - ClothingNeckCloakCentcom
+  - ClothingNeckCloakHos
+  - ClothingNeckCloakQm
+  - ClothingNeckCloakPirateCap
+  - ClothingNeckCloakCe
+  - ClothingCloakCmo
+  - ClothingNeckCloakHop
+
+- type: latheRecipePack
+  id: Mantles
+  recipes:
+  - ClothingNeckMantleCap
+  - ClothingNeckMantleCE
+  - ClothingNeckMantleHOP
+  - ClothingNeckMantleCMO
+  - ClothingNeckMantle
+  - ClothingNeckMantleQM
+  - ClothingNeckMantleRD
 
 - type: latheRecipePack
   id: Carpets
@@ -271,6 +424,8 @@
   - ClothingOuterWinterSyndie
   - ClothingOuterWinterSyndieCap
   - BedsheetSyndie
+  - ClothingOuterCoatSyndieCap
+  - ClothingUniformJumpsuitChiefEngineerSyndie
 
 - type: latheRecipePack
   id: ClothingMilitary

--- a/Resources/Prototypes/Recipes/Lathes/clothing.yml
+++ b/Resources/Prototypes/Recipes/Lathes/clothing.yml
@@ -70,6 +70,15 @@
   materials:
     Cloth: 200
 
+- type: latheRecipe
+  abstract: true
+  id: BaseShoesClothingRecipe
+  categories:
+  - Shoes
+  completetime: 2
+  materials:
+    Durathread: 400
+
 ## Recipes
 
 # Jumpsuits/skirts
@@ -97,6 +106,11 @@
   parent: BaseJumpsuitRecipe
   id: ClothingUniformJumpskirtBartender
   result: ClothingUniformJumpskirtBartender
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpsuitBartenderPurple
+  result: ClothingUniformJumpsuitBartenderPurple
 
 - type: latheRecipe
   parent: BaseCommandJumpsuitRecipe
@@ -158,6 +172,169 @@
   id: ClothingUniformJumpsuitCentcomOfficial
   result: ClothingUniformJumpsuitCentcomOfficial
 
+# Assorted oversuits
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterCoatDetective
+  result: ClothingOuterCoatDetective
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterCoatTrench
+  result: ClothingOuterCoatTrench
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterCoatDetectiveLoadoutGrey
+  result: ClothingOuterCoatDetectiveLoadoutGrey
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterCoatBomber
+  result: ClothingOuterCoatBomber
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterCoatJensen
+  result: ClothingOuterCoatJensen
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterCoatPirate
+  result: ClothingOuterCoatPirate
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterDogi
+  result: ClothingOuterDogi
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterCoatSpaceAsshole
+  result: ClothingOuterCoatSpaceAsshole
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterCoatSyndieCap
+  result: ClothingOuterCoatSyndieCap
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterCoatExpensive
+  result: ClothingOuterCoatExpensive
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterSuitShrineMaiden
+  result: ClothingOuterSuitShrineMaiden
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterSuitWitchRobes
+  result: ClothingOuterSuitWitchRobes
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterRobesJudge
+  result: ClothingOuterRobesJudge
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterPonchoClassic
+  result: ClothingOuterPonchoClassic
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterPoncho
+  result: ClothingOuterPoncho
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterHoodieChaplain
+  result: ClothingOuterHoodieChaplain
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterJacketChef
+  result: ClothingOuterJacketChef
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterNunRobe
+  result: ClothingOuterNunRobe
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterApronBar
+  result: ClothingOuterApronBar
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterApron
+  result: ClothingOuterApron
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterApronBotanist
+  result: ClothingOuterApronBotanist
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterApronChef
+  result: ClothingOuterApronChef
+
+# Labcoats
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterCoatLabChem
+  result: ClothingOuterCoatLabChem
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterCoatLabCmo
+  result: ClothingOuterCoatLabCmo
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterCoatLabGene
+  result: ClothingOuterCoatLabGene
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterCoatLab
+  result: ClothingOuterCoatLab
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterCoatLabSeniorPhysician
+  result: ClothingOuterCoatLabSeniorPhysician
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterCoatRnd
+  result: ClothingOuterCoatRnd
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterCoatRobo
+  result: ClothingOuterCoatRobo
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterCoatRD
+  result: ClothingOuterCoatRD
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterCoatLabSeniorResearcher
+  result: ClothingOuterCoatLabSeniorResearcher
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterCoatLabViro
+  result: ClothingOuterCoatLabViro
+
 ## CE
 
 - type: latheRecipe
@@ -179,6 +356,11 @@
   parent: BaseCommandJumpsuitRecipe
   id: ClothingUniformJumpskirtChiefEngineerTurtle
   result: ClothingUniformJumpskirtChiefEngineerTurtle
+
+- type: latheRecipe
+  parent: BaseCommandJumpsuitRecipe
+  id: ClothingUniformJumpsuitChiefEngineerSyndie
+  result: ClothingUniformJumpsuitChiefEngineerSyndie
 
 ## Chaplain
 
@@ -274,6 +456,17 @@
   id: ClothingUniformJumpskirtDetective
   result: ClothingUniformJumpskirtDetective
 
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpsuitDetectiveGrey
+  result: ClothingUniformJumpsuitDetectiveGrey
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpskirtDetectiveGrey
+  result: ClothingUniformJumpskirtDetectiveGrey
+
+
 ## Engineer
 
 - type: latheRecipe
@@ -285,6 +478,11 @@
   parent: BaseJumpsuitRecipe
   id: ClothingUniformJumpskirtEngineering
   result: ClothingUniformJumpskirtEngineering
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpsuitEngineeringHazard
+  result: ClothingUniformJumpsuitEngineeringHazard
 
 - type: latheRecipe
   parent: BaseJumpsuitRecipe
@@ -396,12 +594,78 @@
   id: ClothingUniformJumpskirtLawyerBlack
   result: ClothingUniformJumpskirtLawyerBlack
 
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpsuitLawyerBlue
+  result: ClothingUniformJumpsuitLawyerBlue
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpskirtLawyerBlue
+  result: ClothingUniformJumpskirtLawyerBlue
+
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpskirtLawyerGood
+  result: ClothingUniformJumpskirtLawyerGood
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpsuitLawyerGood
+  result: ClothingUniformJumpsuitLawyerGood
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpsuitLawyerPurple
+  result: ClothingUniformJumpsuitLawyerPurple
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpskirtLawyerPurple
+  result: ClothingUniformJumpskirtLawyerPurple
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpsuitLawyerRed
+  result: ClothingUniformJumpsuitLawyerRed
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpskirtLawyerRed
+  result: ClothingUniformJumpskirtLawyerRed
+
 ## Librarian
 
 - type: latheRecipe
   parent: BaseJumpsuitRecipe
   id: ClothingUniformJumpsuitLibrarian
   result: ClothingUniformJumpsuitLibrarian
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpskirtLibrarian
+  result: ClothingUniformJumpskirtLibrarian
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpskirtCurator
+  result: ClothingUniformJumpskirtCurator
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpsuitCurator
+  result: ClothingUniformJumpsuitCurator
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpsuitJournalist
+  result: ClothingUniformJumpsuitJournalist
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpsuitReporter
+  result: ClothingUniformJumpsuitReporter
 
 - type: latheRecipe
   parent: BaseJumpsuitRecipe
@@ -429,6 +693,31 @@
   parent: BaseJumpsuitRecipe
   id: ClothingUniformJumpskirtSeniorPhysician
   result: ClothingUniformJumpskirtSeniorPhysician
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpsuitPsychologist
+  result: ClothingUniformJumpsuitPsychologist
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpskirtPsychologist
+  result: ClothingUniformJumpskirtPsychologist
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: UniformScrubsColorBlue
+  result: UniformScrubsColorBlue
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: UniformScrubsColorGreen
+  result: UniformScrubsColorGreen
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: UniformScrubsColorPurple
+  result: UniformScrubsColorPurple
 
 ## Mime
 
@@ -547,6 +836,26 @@
   parent: BaseJumpsuitRecipe
   id: ClothingUniformJumpskirtScientist
   result: ClothingUniformJumpskirtScientist
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpskirtScientistFormal
+  result: ClothingUniformJumpskirtScientistFormal
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpsuitRoboticist
+  result: ClothingUniformJumpsuitRoboticist
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpskirtRoboticist
+  result: ClothingUniformJumpskirtRoboticist
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpsuitScientistFormal
+  result: ClothingUniformJumpsuitScientistFormal
 
 - type: latheRecipe
   parent: BaseJumpsuitRecipe
@@ -673,6 +982,101 @@
   parent: BaseJumpsuitRecipe
   id: ClothingUniformJumpskirtWarden
   result: ClothingUniformJumpskirtWarden
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpsuitCossack
+  result: ClothingUniformJumpsuitCossack
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpsuitDameDane
+  result: ClothingUniformJumpsuitDameDane
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpsuitKimono
+  result: ClothingUniformJumpsuitKimono
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpsuitMonasticRobeLight
+  result: ClothingUniformJumpsuitMonasticRobeLight
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpsuitMonasticRobeDark
+  result: ClothingUniformJumpsuitMonasticRobeDark
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpsuitSafari
+  result: ClothingUniformJumpsuitSafari
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpskirtBlackElegantDress
+  result: ClothingUniformJumpskirtBlackElegantDress
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpskirtBlueElegantDress
+  result: ClothingUniformJumpskirtBlueElegantDress
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpskirtBlueTurtleneckDress
+  result: ClothingUniformJumpskirtBlueTurtleneckDress
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpskirtCyanStripedDress
+  result: ClothingUniformJumpskirtCyanStripedDress
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpskirtGreenElegantDress
+  result: ClothingUniformJumpskirtGreenElegantDress
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpskirtGreenStripedDress
+  result: ClothingUniformJumpskirtGreenStripedDress
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpskirtGreenTurtleneckDress
+  result: ClothingUniformJumpskirtGreenTurtleneckDress
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpskirtPinkStripedDress
+  result: ClothingUniformJumpskirtPinkStripedDress
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpskirtOrangeStripedDress
+  result: ClothingUniformJumpskirtOrangeStripedDress
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpskirtPurpleElegantDress
+  result: ClothingUniformJumpskirtPurpleElegantDress
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpskirtRedElegantDress
+  result: ClothingUniformJumpskirtRedElegantDress
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpskirtRedStripedDress
+  result: ClothingUniformJumpskirtRedStripedDress
+
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformJumpskirtRedTurtleneckDress
+  result: ClothingUniformJumpskirtRedTurtleneckDress
 
 #Generic
 
@@ -938,6 +1342,61 @@
   id: ClothingOuterWinterSyndieCap
   result: ClothingOuterWinterSyndieCap
 
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterWinterColorBlue
+  result: ClothingOuterWinterColorBlue
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterWinterColorBlack
+  result: ClothingOuterWinterColorBlack
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterWinterColorGreen
+  result: ClothingOuterWinterColorGreen
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterWinterColorLightBrown
+  result: ClothingOuterWinterColorLightBrown
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterWinterColorOrange
+  result: ClothingOuterWinterColorOrange
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterWinterColorRed
+  result: ClothingOuterWinterColorRed
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterWinterColorPurple
+  result: ClothingOuterWinterColorPurple
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterWinterColorWhite
+  result: ClothingOuterWinterColorWhite
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterWinterColorYellow
+  result: ClothingOuterWinterColorYellow
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterHoodieBlack
+  result: ClothingOuterHoodieBlack
+
+- type: latheRecipe
+  parent: BaseCoatRecipe
+  id: ClothingOuterHoodieGrey
+  result: ClothingOuterHoodieGrey
+
 # Hats
 - type: latheRecipe
   parent: BaseCommandHatRecipe
@@ -1096,6 +1555,176 @@
   id: ClothingHeadHatParamedicsoft
   result: ClothingHeadHatParamedicsoft
 
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingHeadHatHoodNunHood
+  result: ClothingHeadHatHoodNunHood
+
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingHeadSafari
+  result: ClothingHeadSafari
+
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingHeadHatCanadaBeanie
+  result: ClothingHeadHatCanadaBeanie
+
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingHeadHatBeaverHat
+  result: ClothingHeadHatBeaverHat
+
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingHeadHatBowlerHat
+  result: ClothingHeadHatBowlerHat
+
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingHeadHatFedoraBrown
+  result: ClothingHeadHatFedoraBrown
+
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingHeadHatFedoraGrey
+  result: ClothingHeadHatFedoraGrey
+
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingHeadHatCasa
+  result: ClothingHeadHatCasa
+
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingHeadHatChef
+  result: ClothingHeadHatChef
+
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingHeadHatCowboyBlack
+  result: ClothingHeadHatCowboyBlack
+
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingHeadHatCowboyBountyHunter
+  result: ClothingHeadHatCowboyBountyHunter
+
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingHeadHatCowboyBrown
+  result: ClothingHeadHatCowboyBrown
+
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingHeadHatCowboyGrey
+  result: ClothingHeadHatCowboyGrey
+
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingHeadHatCowboyRed
+  result: ClothingHeadHatCowboyRed
+
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingHeadHatCowboyWhite
+  result: ClothingHeadHatCowboyWhite
+
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingHeadHatFez
+  result: ClothingHeadHatFez
+
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingHeadFishCap
+  result: ClothingHeadFishCap
+
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingHeadHatBrownFlatcap
+  result: ClothingHeadHatBrownFlatcap
+
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingHeadHatGreyFlatcap
+  result: ClothingHeadHatGreyFlatcap
+
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingHeadHatMagician
+  result: ClothingHeadHatMagician
+
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingHeadNurseHat
+  result: ClothingHeadNurseHat
+
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingHeadHatOutlawHat
+  result: ClothingHeadHatOutlawHat
+
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingHeadHatPirateTricord
+  result: ClothingHeadHatPirateTricord
+
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingHeadHatPirate
+  result: ClothingHeadHatPirate
+
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingHeadRastaHat
+  result: ClothingHeadRastaHat
+
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingHeadHatSombrero
+  result: ClothingHeadHatSombrero
+
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingHeadHatStrawHat
+  result: ClothingHeadHatStrawHat
+
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingHeadHatSurgcapBlue
+  result: ClothingHeadHatSurgcapBlue
+
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingHeadHatSurgcapGreen
+  result: ClothingHeadHatSurgcapGreen
+
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingHeadHatSurgcapPurple
+  result: ClothingHeadHatSurgcapPurple
+
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingHeadHatTophat
+  result: ClothingHeadHatTophat
+
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingHeadHatUshanka
+  result: ClothingHeadHatUshanka
+
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingHeadHatWitch1
+  result: ClothingHeadHatWitch1
+
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingHeadHatWitch
+  result: ClothingHeadHatWitch
+
 # Ties
 - type: latheRecipe
   parent: BaseNeckClothingRecipe
@@ -1152,6 +1781,88 @@
   parent: BaseNeckClothingRecipe
   id: ClothingNeckScarfStripedPurple
   result: ClothingNeckScarfStripedPurple
+
+# Cloaks
+- type: latheRecipe
+  parent: BaseCommandCoatRecipe
+  id: ClothingNeckCloakCap
+  result: ClothingNeckCloakCap
+
+- type: latheRecipe
+  parent: BaseCommandCoatRecipe
+  id: ClothingNeckCloakCapFormal
+  result: ClothingNeckCloakCapFormal
+
+- type: latheRecipe
+  parent: BaseCommandCoatRecipe
+  id: ClothingNeckCloakCentcom
+  result: ClothingNeckCloakCentcom
+
+- type: latheRecipe
+  parent: BaseCommandCoatRecipe
+  id: ClothingNeckCloakHos
+  result: ClothingNeckCloakHos
+
+- type: latheRecipe
+  parent: BaseCommandCoatRecipe
+  id: ClothingNeckCloakQm
+  result: ClothingNeckCloakQm
+
+- type: latheRecipe
+  parent: BaseCommandCoatRecipe
+  id: ClothingNeckCloakPirateCap
+  result: ClothingNeckCloakPirateCap
+
+- type: latheRecipe
+  parent: BaseCommandCoatRecipe
+  id: ClothingNeckCloakCe
+  result: ClothingNeckCloakCe
+
+- type: latheRecipe
+  parent: BaseCommandCoatRecipe
+  id: ClothingCloakCmo
+  result: ClothingCloakCmo
+
+- type: latheRecipe
+  parent: BaseCommandCoatRecipe
+  id: ClothingNeckCloakHop
+  result: ClothingNeckCloakHop
+
+# Mantles
+- type: latheRecipe
+  parent: BaseCommandCoatRecipe
+  id: ClothingNeckMantleCap
+  result: ClothingNeckMantleCap
+
+- type: latheRecipe
+  parent: BaseCommandCoatRecipe
+  id: ClothingNeckMantleCE
+  result: ClothingNeckMantleCE
+
+- type: latheRecipe
+  parent: BaseCommandCoatRecipe
+  id: ClothingNeckMantleCMO
+  result: ClothingNeckMantleCMO
+
+- type: latheRecipe
+  parent: BaseCommandCoatRecipe
+  id: ClothingNeckMantleHOP
+  result: ClothingNeckMantleHOP
+
+- type: latheRecipe
+  parent: BaseCommandCoatRecipe
+  id: ClothingNeckMantle
+  result: ClothingNeckMantle
+
+- type: latheRecipe
+  parent: BaseCommandCoatRecipe
+  id: ClothingNeckMantleQM
+  result: ClothingNeckMantleQM
+
+- type: latheRecipe
+  parent: BaseCommandCoatRecipe
+  id: ClothingNeckMantleRD
+  result: ClothingNeckMantleRD
 
 # Military
 - type: latheRecipe


### PR DESCRIPTION
## About the PR
Adds most unobtainable clothing to the uniform printer.

Creates new recipe packs for Assorted Oversuits, Assorted Hats, Lab Coats, Cloaks, and Mantles.

Updates existing packs for Civilian, Engineering, Medical, Science, Security, Service, Winter Coats, Syndicate with some missing items.

Moves CentComm clothing from emag recipes to the standard list.

## Why / Balance
more clothes = good 
unobtainable clothes = bad

## Technical details
n/a

## Media
n/a

## Requirements
N/A

## Breaking changes
N/A

**Changelog**
:cl:
- add: Additional clothing options in uniform printers.
