### PR TITLE
Fixes reagent slime chem dupe

### DIFF
--- a/Resources/Prototypes/Damage/containers.yml
+++ b/Resources/Prototypes/Damage/containers.yml
@@ -8,6 +8,15 @@
     - Genetic
 
 - type: damageContainer
+  id: BiologicalNoBloodPacks # Biological type that isn't whitelisted for bloodpacks, used by Reagent Slimes to prevent chem duplication
+  supportedGroups:
+  - Brute
+  - Burn
+  - Toxin
+  - Airloss
+  - Genetic
+
+- type: damageContainer
   id: Inorganic
   supportedGroups:
     - Brute

--- a/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/elemental.yml
@@ -386,6 +386,9 @@
     solution: bloodstream
   - type: DrainableSolution
     solution: bloodstream
+  - type: Damageable # override BaseMobAdultSlimes' Biological damageContainer, so reagent slimes can't be healed by bloodpacks
+    damageContainer: BiologicalNoBloodPacks
+    damageModifierSet: Slime
 
 - type: entity
   name: Reagent Slime Spawner


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Bloodpacks no longer work on reagent slimes

## Why / Balance
Without this PR, reagent slimes have a bloodstream containing the chemical of their type. Since this is the case you can use a bloodpack on a dead reagent slime to regenerate the chemical inside.

## Technical details
Adds a new damage container `BiologicalNoBloodPacks` which is a duplicate of `Biological`, and forces reagent slimes to use this damage container. This new damage container is not whitelisted by the bloodpack's healing component

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: reagent slimes can't be healed by bloodpacks
