### PR TITLE
feat: Gas Recycling Refactor (Yml-fied Recipes + Reagent Skimming!)

### DIFF
--- a/Content.Server/Atmos/Piping/Binary/Components/GasRecyclerComponent.cs
+++ b/Content.Server/Atmos/Piping/Binary/Components/GasRecyclerComponent.cs
@@ -17,10 +17,10 @@ namespace Content.Server.Atmos.Piping.Binary.Components
         [DataField("outlet")]
         public string OutletName { get; set; } = "outlet";
 
-        [DataField, ViewVariables(VVAccess.ReadWrite)]
-        public float MinTemp = 300 + Atmospherics.T0C;
+        [DataField("recipes"), ViewVariables(VVAccess.ReadWrite)]
+        public List<string> EnabledRecipes { get; set; } = new();
 
-        [DataField, ViewVariables(VVAccess.ReadWrite)]
-        public float MinPressure = 30 * Atmospherics.OneAtmosphere;
+        [DataField("containerSlot"), ViewVariables(VVAccess.ReadWrite)]
+        public string ContainerSlotId { get; set; } = "beaker_slot";
     }
 }

--- a/Content.Shared/Atmos/Piping/Binary/GasRecyclingRecipePrototype.cs
+++ b/Content.Shared/Atmos/Piping/Binary/GasRecyclingRecipePrototype.cs
@@ -1,0 +1,62 @@
+using Content.Shared.Atmos;
+using Content.Shared.Chemistry.Reagent;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Dictionary;
+
+namespace Content.Shared.Atmos.Piping.Binary;
+
+/// <summary>
+/// Prototype for gas recycling recipe definitions.
+/// Defines which gases can be recycled, under what conditions, what outputs are produced,
+/// and what reagents can be scrubbed from the gas into containers.
+/// </summary>
+[Prototype]
+public sealed partial class GasRecyclingRecipePrototype : IPrototype
+{
+    [ViewVariables]
+    [IdDataField]
+    public string ID { get; private set; } = default!;
+
+    /// <summary>
+    /// The input gas to be recycled.
+    /// </summary>
+    [DataField("inputGas", required: true)]
+    public Gas InputGas { get; private set; } = Gas.Oxygen;
+
+    /// <summary>
+    /// The output gas produced by recycling.
+    /// </summary>
+    [DataField("outputGas", required: true)]
+    public Gas OutputGas { get; private set; } = Gas.Oxygen;
+
+    /// <summary>
+    /// The conversion ratio from input to output (e.g., 1.0 means 1:1 conversion).
+    /// </summary>
+    [DataField("conversionRatio")]
+    public float ConversionRatio { get; private set; } = 1.0f;
+
+    /// <summary>
+    /// Minimum temperature required for recycling to occur (in Kelvin).
+    /// </summary>
+    [DataField("minTemp")]
+    public float MinimumTemperature { get; private set; } = Atmospherics.T20C;
+
+    /// <summary>
+    /// Minimum pressure required for recycling to occur (in kPa).
+    /// </summary>
+    [DataField("minPressure")]
+    public float MinimumPressure { get; private set; } = Atmospherics.OneAtmosphere;
+
+    /// <summary>
+    /// Reagents that can be scrubbed from the gas into containers.
+    /// Maps reagent IDs to their conversion ratios (how much reagent is produced per unit of input gas).
+    /// </summary>
+    [DataField("scrubbedReagents", customTypeSerializer: typeof(PrototypeIdDictionarySerializer<float, ReagentPrototype>))]
+    public Dictionary<string, float> ScrubbedReagents { get; private set; } = new();
+
+    /// <summary>
+    /// Whether this recipe is enabled by default.
+    /// </summary>
+    [DataField("enabled")]
+    public bool Enabled { get; private set; } = true;
+}

--- a/Resources/Locale/en-US/atmos/gas-recycler-system.ftl
+++ b/Resources/Locale/en-US/atmos/gas-recycler-system.ftl
@@ -1,3 +1,5 @@
 gas-recycler-reacting = It is [color=green]converting[/color] waste gases.
 gas-recycler-low-pressure = The input pressure is [color=darkred]too low[/color].
 gas-recycler-low-temperature = The input temperature is [color=darkred]too low[/color].
+gas-recycler-container-loaded = A [color=green]container is loaded[/color] to collect reagents.
+gas-recycler-no-container = No container is loaded.

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/binary.yml
@@ -507,7 +507,7 @@
   parent: [ BaseMachine, ConstructibleMachine ]
   id: GasRecycler
   name: gas recycler
-  description: Recycles carbon dioxide and nitrous oxide. Heater and compressor not included.
+  description: Recycles waste gases into useful gases. Can hold a beaker to collect reagents skimmed from the gas stream. Requires high temperature and pressure to operate.
   placement:
     mode: SnapgridCenter
   components:
@@ -539,6 +539,17 @@
   - type: PipeColorVisuals
   - type: Rotatable
   - type: GasRecycler
+  - type: ItemSlots
+    slots:
+      beaker_slot:
+        name: Beaker
+        ejectOnInteract: true
+        whitelist:
+          components:
+          - FitsInDispenser
+  - type: ContainerContainer
+    containers:
+      beaker_slot: !type:ContainerSlot
   - type: PipeRestrictOverlap
   - type: NodeContainer
     nodes:

--- a/Resources/Prototypes/Recipes/GasRecycling/recycling.yml
+++ b/Resources/Prototypes/Recipes/GasRecycling/recycling.yml
@@ -1,0 +1,29 @@
+# Gas Recycling Recipes
+# These recipes define how gases can be recycled through a gas recycler.
+# Each recipe specifies:
+# - inputGas: The waste gas to be recycled
+# - outputGas: The useful gas produced
+# - conversionRatio: The ratio of input to output (1.0 = 1:1 conversion)
+# - minTemp: Minimum temperature (in K) required for recycling
+# - minPressure: Minimum pressure (in kPa) required for recycling
+# - scrubbedReagents: (Optional) Reagents that can be scrubbed from the gas into containers
+
+- type: gasRecyclingRecipe
+  id: RecycleCarbonDioxide
+  inputGas: CarbonDioxide
+  outputGas: Oxygen
+  conversionRatio: 1.0
+  minTemp: 673.15  # 400°C (CO2 decomposition)
+  minPressure: 2000  # 20 atmospheres
+  scrubbedReagents:
+    Carbon: 0.01  # 0.01 moles of Carbon per mole of CO2 when container is present
+
+- type: gasRecyclingRecipe
+  id: RecycleNitrousOxide
+  inputGas: NitrousOxide
+  outputGas: Nitrogen
+  conversionRatio: 1.0
+  minTemp: 523.15  # 250°C (N2O catalytic decomposition)
+  minPressure: 1500  # 15 atmospheres
+  scrubbedReagents:
+    Oxygen: 0.01  # 0.01 moles of Oxygen per mole of N2O when container is present


### PR DESCRIPTION
Refactors the entire Gas Recycler system to be entirely customizable using yml in a new prototype: Recipes/GasRecycling/recycling.yml

# Each recipe specifies:
- inputGas: The waste gas to be recycled
- outputGas: The gas produced
- conversionRatio: The ratio of input to output (1.0 = 1:1 conversion)
- minTemp: Minimum temperature (in K) required for recycling
- minPressure: Minimum pressure (in kPa) required for recycling
- scrubbedReagents: (Optional) Reagents that can be scrubbed from the gas into a loaded container

Current implemented recipes for the refactor are for CO2 and N2O (the same as the old recycler).

Also feat new examine text!
<img width="403" height="356" alt="image" src="https://github.com/user-attachments/assets/ceeed868-6f46-42e2-8064-e992419b0871" />
<img width="1204" height="551" alt="image" src="https://github.com/user-attachments/assets/6fe6720f-7b75-4fcb-a503-10f0411d6e4d" />
<img width="408" height="269" alt="image" src="https://github.com/user-attachments/assets/e849477a-0dc0-4255-beae-5af0c60b748a" />

