### PR TITLE
Fixes typo in cryo announcement

### DIFF
--- a/Resources/Locale/en-US/round-end/cryostorage.ftl
+++ b/Resources/Locale/en-US/round-end/cryostorage.ftl
@@ -1,4 +1,4 @@
-cryostorage-insert-message-permanent = [color=white]You are now inside of a [bold][color=cyan]cryogenic sleep unit[/color][/bold]. If you [bold]disconnect[/bold], [bold]ghost[/bold], or [bold]wait {$time} seeconds[/bold], [color=red]your character will be saved and you will return to the lobby.[/color][/color]
+cryostorage-insert-message-permanent = [color=white]You are now inside of a [bold][color=cyan]cryogenic sleep unit[/color][/bold]. If you [bold]disconnect[/bold], [bold]ghost[/bold], or [bold]wait {$time} seconds[/bold], [color=red]your character will be saved and you will return to the lobby.[/color][/color]
 cryostorage-insert-message-temp = [color=white]You are now inside of a [bold][color=cyan]cryogenic sleep unit[/color][/bold]. If you [bold]ghost[/bold] or [bold]wait {$time} seconds[/bold], [color=red]your character will be saved and you will return to the lobby.[/color][/color]
 
 cryostorage-ui-window-title = Cryogenic Sleep Unit


### PR DESCRIPTION
Fixes a typo in the popup you get when entering a cryogenic sleep unit, literally unplayable

seeconds > seconds