### PR TITLE
magnet only pulls in wrecks

### DIFF
--- a/Content.Shared/Salvage/SharedSalvageSystem.Magnet.cs
+++ b/Content.Shared/Salvage/SharedSalvageSystem.Magnet.cs
@@ -42,62 +42,68 @@ public abstract partial class SharedSalvageSystem
     {
         var rand = new System.Random(seed);
 
-        var type = SharedRandomExtensions.Pick(_offeringWeights, rand);
-        switch (type)
+        var id = rand.Pick(_debrisConfigs);
+        return new DebrisOffering
         {
-            case AsteroidOffering:
-                var configId = _asteroidConfigs[rand.Next(_asteroidConfigs.Count)];
-                var configProto =_proto.Index(configId);
-                var layers = new Dictionary<string, int>();
+            Id = id
+        };
 
-                var config = new DungeonConfig
-                {
-                    Layers = new(configProto.Layers),
-                    MaxCount = configProto.MaxCount,
-                    MaxOffset = configProto.MaxOffset,
-                    MinCount = configProto.MinCount,
-                    MinOffset = configProto.MinOffset,
-                    ReserveTiles = configProto.ReserveTiles
-                };
-
-                var count = _asteroidOreCount.Next(rand);
-                var weightedProto = _proto.Index(_asteroidOreWeights);
-                for (var i = 0; i < count; i++)
-                {
-                    var ore = weightedProto.Pick(rand);
-                    config.Layers.Add(_proto.Index<OreDunGenPrototype>(ore));
-
-                    var layerCount = layers.GetOrNew(ore);
-                    layerCount++;
-                    layers[ore] = layerCount;
-                }
-
-                return new AsteroidOffering
-                {
-                    Id = configId,
-                    DungeonConfig = config,
-                    MarkerLayers = layers,
-                };
-            case DebrisOffering:
-                var id = rand.Pick(_debrisConfigs);
-                return new DebrisOffering
-                {
-                    Id = id
-                };
-            case SalvageOffering:
-                // Salvage map seed
-                _salvageMaps.Clear();
-                _salvageMaps.AddRange(_proto.EnumeratePrototypes<SalvageMapPrototype>());
-                _salvageMaps.Sort((x, y) => string.Compare(x.ID, y.ID, StringComparison.Ordinal));
-                var mapIndex = rand.Next(_salvageMaps.Count);
-                var map = _salvageMaps[mapIndex];
-
-                return new SalvageOffering
-                {
-                    SalvageMap = map,
-                };
-            default:
-                throw new NotImplementedException($"Salvage type {type} not implemented!");
-        }
+        // var type = SharedRandomExtensions.Pick(_offeringWeights, rand); // # Persistence: Magnet only spawns wrecks
+        // switch (type)
+        // {
+        //     case AsteroidOffering:
+        //         var configId = _asteroidConfigs[rand.Next(_asteroidConfigs.Count)];
+        //         var configProto =_proto.Index(configId);
+        //         var layers = new Dictionary<string, int>();
+        //
+        //         var config = new DungeonConfig
+        //         {
+        //             Layers = new(configProto.Layers),
+        //             MaxCount = configProto.MaxCount,
+        //             MaxOffset = configProto.MaxOffset,
+        //             MinCount = configProto.MinCount,
+        //             MinOffset = configProto.MinOffset,
+        //             ReserveTiles = configProto.ReserveTiles
+        //         };
+        //
+        //         var count = _asteroidOreCount.Next(rand);
+        //         var weightedProto = _proto.Index(_asteroidOreWeights);
+        //         for (var i = 0; i < count; i++)
+        //         {
+        //             var ore = weightedProto.Pick(rand);
+        //             config.Layers.Add(_proto.Index<OreDunGenPrototype>(ore));
+        //
+        //             var layerCount = layers.GetOrNew(ore);
+        //             layerCount++;
+        //             layers[ore] = layerCount;
+        //         }
+        //
+        //         return new AsteroidOffering
+        //         {
+        //             Id = configId,
+        //             DungeonConfig = config,
+        //             MarkerLayers = layers,
+        //         };
+        //     case DebrisOffering:
+        //         var id = rand.Pick(_debrisConfigs);
+        //         return new DebrisOffering
+        //         {
+        //             Id = id
+        //         };
+        //     case SalvageOffering:
+        //         // Salvage map seed
+        //         _salvageMaps.Clear();
+        //         _salvageMaps.AddRange(_proto.EnumeratePrototypes<SalvageMapPrototype>());
+        //         _salvageMaps.Sort((x, y) => string.Compare(x.ID, y.ID, StringComparison.Ordinal));
+        //         var mapIndex = rand.Next(_salvageMaps.Count);
+        //         var map = _salvageMaps[mapIndex];
+        //
+        //         return new SalvageOffering
+        //         {
+        //             SalvageMap = map,
+        //         };
+        //     default:
+        //         throw new NotImplementedException($"Salvage type {type} not implemented!");
+        // }
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Salvage magnet can no longer generate offers for POIs or Asteroids

## Why / Balance


## Technical details
Commented the code that chooses between Wrecks, Asteroids, and POIs, in favor of just picking wrekcs

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
none

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: stinky
- tweak: Salvage magnet can no longer get POI or asteroid jobs