### PR TITLE
no nuke disk in captain locker

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -63,7 +63,7 @@
     - id: BoxCaptainCircuitboards
     - id: DoorRemoteCustom
     - id: MedalCase
-    - id: NukeDisk
+#    - id: NukeDisk # Persistence: no nuke, no disk
     - id: PinpointerNuclear
     - id: PlushieNuke
       prob: 0.1

--- a/Resources/Prototypes/Entities/Objects/Misc/dat_fukken_disk.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/dat_fukken_disk.yml
@@ -42,3 +42,4 @@
   - type: Tag
     tags:
     - FakeNukeDisk
+    - Recyclable


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
commented nuke disk from captain's locker fill

## Why / Balance
no nuke, no disk
