### PR TITLE
Sun randomizes once

### DIFF
--- a/Content.Server/Solar/Components/SolarLocationComponent.cs
+++ b/Content.Server/Solar/Components/SolarLocationComponent.cs
@@ -1,5 +1,4 @@
 using Content.Server.Solar.EntitySystems;
-using Content.Server.StationEvents.Events;
 
 namespace Content.Server.Solar.Components
 {

--- a/Content.Server/Solar/Components/SolarLocationComponent.cs
+++ b/Content.Server/Solar/Components/SolarLocationComponent.cs
@@ -1,4 +1,5 @@
 using Content.Server.Solar.EntitySystems;
+using Content.Server.StationEvents.Events;
 
 namespace Content.Server.Solar.Components
 {
@@ -7,6 +8,13 @@ namespace Content.Server.Solar.Components
     [Access(typeof(SolarPositioningSystem))]
     public sealed partial class SolarLocationComponent : Component
     {
+        /// <summary>
+        /// This is set to true when the SolarLocationComponent's angle & vel
+        /// are randomized, and is used to prevent resetting these when loading a save
+        /// </summary>
+        [DataField]
+        public bool WasInitialized = false;
+
         /// <summary>
         /// The current sun angle.
         /// </summary>

--- a/Content.Server/Solar/EntitySystems/SolarPositioningSystem.cs
+++ b/Content.Server/Solar/EntitySystems/SolarPositioningSystem.cs
@@ -44,9 +44,14 @@ namespace Content.Server.Solar.EntitySystems
 
         private void RandomizeSun(EntityUid eid, SolarLocationComponent solarLocation)
         {
+            // If the sun has already been randomized
+            if (solarLocation.WasInitialized)
+                return;
+
             // Initialize the sun to something random
             solarLocation.TowardsSun = MathHelper.TwoPi * _robustRandom.NextDouble();
             solarLocation.SunAngularVelocity = Angle.FromDegrees(0.1 + ((_robustRandom.NextDouble() - 0.5) * 0.05));
+            solarLocation.WasInitialized = true;
         }
 
         public SolarLocationComponent? GetSolarLocation(EntityUid gridUid)

--- a/Content.Server/Solar/EntitySystems/SolarPositioningSystem.cs
+++ b/Content.Server/Solar/EntitySystems/SolarPositioningSystem.cs
@@ -44,6 +44,10 @@ namespace Content.Server.Solar.EntitySystems
 
         private void RandomizeSun(EntityUid eid, SolarLocationComponent solarLocation)
         {
+            // If the sun has already been randomized
+            if (solarLocation.WasInitialized)
+                return;
+
             // Initialize the sun to something random
             solarLocation.TowardsSun = MathHelper.TwoPi * _robustRandom.NextDouble();
             solarLocation.SunAngularVelocity = Angle.FromDegrees(0.1 + ((_robustRandom.NextDouble() - 0.5) * 0.05));


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The map's sun (not the sun) angle & velocity are no longer reset on map-load if the map has had these values randomized previously

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
`SolarLocation` component now has a `WasInitialized` bool
A map's `WasInitialized` is checked & set by `SolarPositioningSystem`'s `RandomizeSun`

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
none

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: stinky
- fix: the map's star no longer has a random location when loading an existing save
