### PR TITLE
Add safe-bolt signal sink to airlock

### DIFF
--- a/Content.Server/DeviceLinking/Components/DoorSignalControlComponent.cs
+++ b/Content.Server/DeviceLinking/Components/DoorSignalControlComponent.cs
@@ -18,6 +18,9 @@ namespace Content.Server.DeviceLinking.Components
         [DataField("boltPort", customTypeSerializer: typeof(PrototypeIdSerializer<SinkPortPrototype>))]
         public string InBolt = "DoorBolt";
 
+        [DataField("safeBoltPort", customTypeSerializer: typeof(PrototypeIdSerializer<SinkPortPrototype>))]
+        public string SafeBolt = "SafeDoorBolt";
+
         [DataField("onOpenPort", customTypeSerializer: typeof(PrototypeIdSerializer<SourcePortPrototype>))]
         public string OutOpen = "DoorStatus";
     }

--- a/Content.Server/DeviceLinking/Systems/DoorSignalControlSystem.cs
+++ b/Content.Server/DeviceLinking/Systems/DoorSignalControlSystem.cs
@@ -81,6 +81,24 @@ namespace Content.Server.DeviceLinking.Systems
 
                 _doorSystem.SetBoltsDown((uid, bolts), bolt);
             }
+            else if (args.Port == component.SafeBolt) // only extends the bolts if the door is closed
+            {
+                if (!TryComp<DoorBoltComponent>(uid, out var bolts) || door.State != DoorState.Closed)
+                    return;
+
+                // if its a pulse toggle, otherwise set bolts to high/low
+                bool bolt;
+                if (state == SignalState.Momentary)
+                {
+                    bolt = !bolts.BoltsDown;
+                }
+                else
+                {
+                    bolt = state == SignalState.High;
+                }
+
+                _doorSystem.SetBoltsDown((uid, bolts), bolt);
+            }
         }
 
         private void OnStateChanged(EntityUid uid, DoorSignalControlComponent door, DoorStateChangedEvent args)

--- a/Resources/Locale/en-US/machine-linking/receiver_ports.ftl
+++ b/Resources/Locale/en-US/machine-linking/receiver_ports.ftl
@@ -25,6 +25,9 @@ signal-port-description-close = Closes a device.
 signal-port-name-doorbolt = Door bolt
 signal-port-description-doorbolt = Bolts door when HIGH.
 
+signal-port-name-safedoorbolt = Safe door bolt
+signal-port-description-safedoorbolt = Bolts door when HIGH. Cannot change bolts on an open door.
+
 signal-port-name-trigger-receiver = Trigger
 signal-port-description-trigger-receiver = Triggers some mechanism on the device.
 

--- a/Resources/Prototypes/DeviceLinking/sink_ports.yml
+++ b/Resources/Prototypes/DeviceLinking/sink_ports.yml
@@ -44,6 +44,11 @@
   description: signal-port-description-doorbolt
 
 - type: sinkPort
+  id: SafeDoorBolt
+  name: signal-port-name-safedoorbolt
+  description: signal-port-description-safedoorbolt
+
+- type: sinkPort
   id: Trigger
   name: signal-port-name-trigger-receiver
   description: signal-port-description-trigger-receiver
@@ -112,7 +117,7 @@
   id: RandomGateInput
   name: signal-port-name-logic-random-input
   description: signal-port-description-logic-random-input
-  
+
 - type: sinkPort
   id: SetParticleDelta
   name: signal-port-name-set-particle-delta

--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
@@ -122,6 +122,7 @@
       - Toggle
       - AutoClose
       - DoorBolt
+      - SafeDoorBolt
   - type: DeviceLinkSource
     ports:
       - DoorStatus


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## Why Draft?
Signals can be either momentary or high/low. Unfortunately if you provide a high signal (engage the bolts) to the safebolt while a door is open, it will not bolt once it closes until the signal is refreshed (sent again). As I see it fixing this will require one of two things:
- Logic in the `DoorSignalControlSystem` that tries to close the door, and if the door can close, bolt the door once it is closed (needs an event or some kind of waiting period, otherwise it bolts doors _open_.)
- A new bool on the `DoorBoltComponent`, something like `BoltWhenClosed`
  - Complementary logic in some part of the code that knows when the door has finished closing that checks this value if it exists & bolts the door


## About the PR
Adds a new signal to airlocks which has nearly identical behavior to the existing Door Bolt signal, the difference being the new signal cannot change the bolt state on a door that is not closed.

Tested on an existing save & airlocks seem to load the new signal sink properly without requiring rebuilding the airlocks.

## Why / Balance
Engineers from the Threshold and beyond have struggled to make simple airlock designs which don't have any catastrophic failure states (both doors bolted open, for example). In many of the designs I've seen, this has been the only significant failure state.

## Technical details
Adds a new signal sink, behavior duplicated from existing DoorBolt sink. New signal sink has logic that checks if the door is closed. If the door is not closed, the signal causes no action.

## Media
<img width="562" height="87" alt="image" src="https://github.com/user-attachments/assets/be628f32-3a6e-4cbc-916f-41baf4556921" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: stinky
- add: new signal sink on airlocks; change the bolt status only if the door is closed
