### PR TITLE
DeltaP thresholds for weak walls and fans, and more

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/special.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/special.yml
@@ -1,6 +1,7 @@
 # Devices which are not portable but don't link up to anything
 - type: entity
   id: AtmosDeviceFanTiny
+  parent: BaseDeltaPressureGlass # Screw you. No more fan burn chambers.
   name: tiny fan
   description: A tiny fan, releasing a thin gust of air.
   placement:
@@ -43,9 +44,27 @@
   - type: Tag
     tags:
       - SpreaderIgnore
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 20
+      behaviors:
+        - !type:SpawnEntitiesBehavior
+          spawn:
+            TinyFanFlatpack:
+              min: 0
+              max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
+        - !type:PlaySoundBehavior
+          sound:
+            collection: MetalSlam
+
 
 - type: entity
   id: AtmosDeviceFanDirectional
+  parent: BaseDeltaPressureReinforcedGlassQuarter # Screw you. No more fan burn chambers.
   name: directional fan
   description: A thin fan, stopping the movement of gases across it.
   placement:
@@ -91,3 +110,19 @@
   - type: Tag
     tags:
       - SpreaderIgnore
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 20
+      behaviors:
+        - !type:SpawnEntitiesBehavior
+          spawn:
+            DirectionalFanFlatpack:
+              min: 0
+              max: 1
+        - !type:DoActsBehavior
+          acts: [ "Destruction" ]
+        - !type:PlaySoundBehavior
+          sound:
+            collection: MetalSlam

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -97,7 +97,7 @@
         - WallLayer
 
 - type: entity
-  parent: BaseWall
+  parent: [BaseDeltaPressureReinforcedPlasma, BaseWall]
   id: WallBrick
   name: brick wall
   components:
@@ -127,7 +127,7 @@
     base: brick
 
 - type: entity
-  parent: BaseWall
+  parent: [BaseDeltaPressureReinforcedPlasma, BaseWall]
   id: WallBronze
   name: bronze wall
   components:
@@ -169,7 +169,7 @@
     base: solidbronze
 
 - type: entity
-  parent: BaseWall
+  parent: [BaseDeltaPressureReinforcedPlasma, BaseWall]
   id: WallClock
   name: clock wall
   components:
@@ -198,7 +198,7 @@
     base: clock
 
 - type: entity
-  parent: BaseWall
+  parent: [BaseDeltaPressureReinforcedPhoron, BaseWall]
   id: WallClown
   name: bananium wall
   components:
@@ -242,7 +242,7 @@
         density: 8000 # really good ramming wall, bananium is rare so it's probably fine
 
 - type: entity
-  parent: BaseWall
+  parent: [BaseDeltaPressureReinforcedGlass, BaseWall]
   id: WallMeat
   name: meat wall
   description: Sticky.
@@ -276,7 +276,7 @@
     base: meat
 
 - type: entity
-  parent: BaseWall
+  parent: [BaseDeltaPressureReinforcedPhoron, BaseWall] # Has 100 extra health so it gets some extra pressure resistance
   id: WallCult
   name: cult wall
   components:
@@ -332,7 +332,7 @@
     base: debug
 
 - type: entity
-  parent: BaseWall
+  parent: BaseWall # No deltaP threshold. Diamonds are tough.
   id: WallDiamond
   name: diamond wall
   components:
@@ -362,7 +362,7 @@
     base: diamond
 
 - type: entity
-  parent: BaseWall
+  parent: [BaseDeltaPressureReinforcedPhoron, BaseWall] # you can have your solid gold burn chamber I guess.  
   id: WallGold
   name: gold wall
   components:
@@ -413,9 +413,11 @@
   - type: IconSmooth
     key: walls
     base: gold
+  - type: RadiationBlocker
+    resistance: 5 # Gold is heavy.
 
 - type: entity
-  parent: BaseWall
+  parent: [BaseDeltaPressureReinforcedPlasma, BaseWall]
   id: WallIce
   name: ice wall
   components:
@@ -441,7 +443,7 @@
     base: ice
 
 - type: entity
-  parent: BaseWall
+  parent: [BaseDeltaPressureReinforcedPlasma, BaseWall]
   id: WallPlasma
   name: plasma wall
   components:
@@ -482,10 +484,10 @@
     key: walls
     base: plasma
   - type: RadiationBlocker
-    resistance: 5
+    resistance: 6 # Slightly better than basic r-wall.
 
 - type: entity
-  parent: BaseWall
+  parent: [BaseDeltaPressureGlass, BaseWall]
   id: WallPlastic
   name: plastic wall
   components:
@@ -522,6 +524,8 @@
         node: girder
       - !type:DoActsBehavior
         acts: ["Destruction"]
+  - type: RadiationBlocker
+    resistance: 1 # plastic is light
   - type: IconSmooth
     key: walls
     base: plastic
@@ -751,8 +755,8 @@
       - !type:DoActsBehavior
         acts: ["Destruction"]
   - type: ReinforcedWallReplacementMarker
-  - type: RadiationBlocker
-    resistance: 5
+  - type: RadiationBlocker 
+    resistance: 3 # Titanium is light
   - type: Fixtures
     fixtures:
       fix1:
@@ -763,7 +767,7 @@
         - FullTileMask
         layer:
         - WallLayer
-        density: 2000
+        density: 1000 # Titanium is light
 
 - type: entity
   parent: WallReinforced
@@ -880,7 +884,7 @@
     price: 150
 
 - type: entity
-  parent: BaseWall
+  parent: [BaseDeltaPressureReinforcedPlasma, BaseWall] # no idea when this would be exposed to pressure, but it would be silly for it to be unbreakable
   id: WallSandstone
   name: sandstone wall
   components:
@@ -910,7 +914,7 @@
     base: sandstone
 
 - type: entity
-  parent: BaseWall
+  parent: [BaseDeltaPressureReinforcedPlasma, BaseWall]
   id: WallSilver
   name: silver wall
   components:
@@ -1091,7 +1095,7 @@
         density: 2000
 
 - type: entity
-  parent: BaseWall
+  parent: [BaseDeltaPressureReinforcedPlasma, BaseWall]
   id: WallSolid
   name: solid wall
   components:
@@ -1134,7 +1138,7 @@
     base: solid
 
 - type: entity
-  parent: WallDiagonalBase
+  parent: [BaseDeltaPressureReinforcedPlasma, WallDiagonalBase]
   id: WallSolidDiagonal
   name: solid wall
   components:
@@ -1172,7 +1176,7 @@
         acts: ["Destruction"]
 
 - type: entity
-  parent: WallSolid
+  parent: [BaseDeltaPressureReinforcedPlasma, WallSolid]
   id: WallSolidRust
   suffix: rusted
   components:
@@ -1211,7 +1215,7 @@
         acts: ["Destruction"]
 
 - type: entity
-  parent: BaseWall
+  parent: [BaseDeltaPressureReinforcedPlasma, BaseWall]
   id: WallSolidChitin
   name: solid chitin
   components:
@@ -1341,7 +1345,7 @@
     state: state0
 
 - type: entity
-  parent: BaseWall
+  parent: [BaseDeltaPressureReinforcedPlasma, BaseWall]
   id: WallUranium
   name: uranium wall
   components:
@@ -1389,10 +1393,10 @@
     key: walls
     base: uranium
   - type: RadiationBlocker
-    resistance: 6
+    resistance: 7 # Slightly better than plasma
 
 - type: entity
-  parent: BaseWall
+  parent: [BaseDeltaPressureReinforcedGlass, BaseWall]
   id: WallWood
   name: wood wall
   description: The traditional greytide defense.
@@ -1426,12 +1430,14 @@
         node: Barricade
       - !type:DoActsBehavior
         acts: ["Destruction"]
+  - type: RadiationBlocker
+    resistance: 1 # Wood is light
   - type: IconSmooth
     key: woods
     base: wood
 
 - type: entity
-  parent: BaseWall
+  parent: [BaseDeltaPressureGlass, BaseWall]
   id: WallWeb
   name: web wall
   description: Keeps the spiders in and the greytide out.
@@ -1475,6 +1481,8 @@
   - type: IconSmooth
     key: webs
     base: wall
+  - type: RadiationBlocker
+    resistance: 1 # Spiderwebs are light
   - type: Construction
     graph: WebStructures
     node: wall
@@ -1673,7 +1681,7 @@
     state: forcewall
 
 - type: entity
-  parent: BaseWall
+  parent: [BaseDeltaPressureReinforcedGlass, BaseWall]
   id: WallCobblebrick
   name: cobblestone brick wall
   description: Stone by stone, perfectly fitted together to form a wall.

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -198,7 +198,7 @@
     base: clock
 
 - type: entity
-  parent: [BaseDeltaPressureReinforcedPhoron, BaseWall]
+  parent: [BaseDeltaPressureReinforcedPhoronGlass, BaseWall]
   id: WallClown
   name: bananium wall
   components:
@@ -276,7 +276,7 @@
     base: meat
 
 - type: entity
-  parent: [BaseDeltaPressureReinforcedPhoron, BaseWall] # Has 100 extra health so it gets some extra pressure resistance
+  parent: [BaseDeltaPressureReinforcedPhoronGlass, BaseWall] # Has 100 extra health so it gets some extra pressure resistance
   id: WallCult
   name: cult wall
   components:
@@ -362,7 +362,7 @@
     base: diamond
 
 - type: entity
-  parent: [BaseDeltaPressureReinforcedPhoron, BaseWall] # you can have your solid gold burn chamber I guess.  
+  parent: [BaseDeltaPressureReinforcedPhoronGlass, BaseWall] # you can have your solid gold burn chamber I guess.  
   id: WallGold
   name: gold wall
   components:


### PR DESCRIPTION
DO NOT MERGE YET; NEEDS TESTING & FIXES
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Basic walls & fans are no longer immune to high pressure; certain walls are now more(gold, plasma, and uranium walls) or less(plastic, wood, titanium, and web walls) effective in blocking radiation. Fans have a chance to revert to their flatpack when broken.
Solid walls have the same deltaP threshold as reinforced plasma windows, so they are still able to withstand typical pressure-regulated burn chamber pressures. Any walls with structuralMetallicStrong are still completely immune to pressure.
I also made titanium walls lighter because why not.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fans that you can walk through being able to withstand unlimited pressure when reinforced windows can't is silly.
It doesn't make sense for plastic & wood walls to provide the same radiation protection as steel. I have never seen plasma or uranium walls used, so I slightly improved their radiation resistances (plasma from 5->6 and uranium from 6->7). 

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Pressure chambers using any of the following for containment should have their pressure regulators updated with the following thresholds:
Tiny fans, plastic walls, and web walls: 750 kPa
Directional fans: 2.5 MPa
Wood, meat, and cobblestone brick walls: 10 MPa
Solid(basic steel walls), brick, bronze, clockwork, ice, silver, plasma(wall), uranium(wall), and chitin: 150 MPa
Gold and cult walls: 300 MPa 

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- tweak: Fans and some weaker walls are no longer completely immune to pressure.
- tweak: Plasma and uranium walls now make better radiation shielding.
- tweak: Titanium walls are now lighter weight.
-->
