### PR TITLE
Bananium fix

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/materials.yml
@@ -624,7 +624,7 @@
         maxVol: 10
         reagents:
         - ReagentId: Bananium
-          Quantity: 6.5
+          Quantity: 10
   - type: Extractable
     grindableSolutionName: food
     juiceSolution:

--- a/Resources/Prototypes/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/materials.yml
@@ -621,15 +621,12 @@
   - type: SolutionContainerManager
     solutions:
       food:
-        maxVol: 11
+        maxVol: 10
         reagents:
-        - ReagentId: Nutriment
+        - ReagentId: Bananium
           Quantity: 4
-        - ReagentId: Vitamin
-          Quantity: 2
-        - ReagentId: Honk
-          Quantity: 5
   - type: Extractable
+    grindableSolutionName: food
     juiceSolution:
       reagents:
       - ReagentId: JuiceBanana

--- a/Resources/Prototypes/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/materials.yml
@@ -624,7 +624,7 @@
         maxVol: 10
         reagents:
         - ReagentId: Bananium
-          Quantity: 10
+          Quantity: 6.5
   - type: Extractable
     grindableSolutionName: food
     juiceSolution:

--- a/Resources/Prototypes/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/materials.yml
@@ -624,7 +624,7 @@
         maxVol: 10
         reagents:
         - ReagentId: Bananium
-          Quantity: 4
+          Quantity: 10
   - type: Extractable
     grindableSolutionName: food
     juiceSolution:

--- a/Resources/Prototypes/Entities/Objects/Materials/ore.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ore.yml
@@ -310,7 +310,7 @@
       bananiumore:
         reagents:
         - ReagentId: Bananium
-          Quantity: 10
+          Quantity: 6.5
   - type: Item
     heldPrefix: bananium
   - type: Tag

--- a/Resources/Prototypes/Entities/Objects/Materials/ore.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/ore.yml
@@ -309,12 +309,8 @@
     solutions:
       bananiumore:
         reagents:
-        - ReagentId: Nutriment
-          Quantity: 4
-        - ReagentId: Vitamin
-          Quantity: 2
-        - ReagentId: Honk
-          Quantity: 5
+        - ReagentId: Bananium
+          Quantity: 10
   - type: Item
     heldPrefix: bananium
   - type: Tag

--- a/Resources/Prototypes/Reagents/elements.yml
+++ b/Resources/Prototypes/Reagents/elements.yml
@@ -315,16 +315,15 @@
   metabolisms:
     Food:
       effects:
-      - !type:SatiateHunger
-        conditions:
-        - !type:MetabolizerTypeCondition
-          type: [ Human, Animal ]
-    Poison:
-      effects:
-      - !type:HealthChange
-        damage:
-          types:
-            Poison: 0.5
+      - !type:AdjustReagent
+        reagent: Nutriment
+        amount: 0.15
+      - !type:AdjustReagent
+        reagent: Vitamin
+        amount: 0.1
+      - !type:AdjustReagent
+        reagent: Honk
+        amount: 0.25
 
 - type: reagent
   id: Radium

--- a/Resources/Prototypes/Recipes/Reactions/fun.yml
+++ b/Resources/Prototypes/Recipes/Reactions/fun.yml
@@ -251,15 +251,15 @@
     intensitySlope: 2.7
     maxTotalIntensity: 50
 
-  - type: reaction
-    id: BananiumBreakdown
-    source: true
-    requiredMixerCategories:
-    - Centrifuge
-    reactants:
-      Bananium:
-        amount: 10
-    products:
-      Nutriment: 3
-      Vitamin: 2
-      Honk: 5
+- type: reaction
+  id: BananiumBreakdown
+  source: true
+  requiredMixerCategories:
+  - Electrolysis
+  reactants:
+    Bananium:
+      amount: 10
+  products:
+    Nutriment: 4
+    Vitamin: 2
+    Honk: 5

--- a/Resources/Prototypes/Recipes/Reactions/fun.yml
+++ b/Resources/Prototypes/Recipes/Reactions/fun.yml
@@ -250,3 +250,16 @@
     intensityPerUnit: 1
     intensitySlope: 2.7
     maxTotalIntensity: 50
+
+  - type: reaction
+    id: BananiumBreakdown
+    source: true
+    requiredMixerCategories:
+    - Centrifuge
+    reactants:
+      Bananium:
+        amount: 10
+    products:
+      Nutriment: 3
+      Vitamin: 2
+      Honk: 5


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Bananium can now be grinded into the bananium reagent.
The bananium reagent now digests into honk, nutriment, and vitamin.

## Why / Balance
Consistency with other materials

## Technical details
YAML

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->