### PR TITLE
Flavor text edits after character creation + character window is useful for persistence

### DIFF
--- a/Content.Client/CharacterInfo/CharacterInfoSystem.cs
+++ b/Content.Client/CharacterInfo/CharacterInfoSystem.cs
@@ -29,10 +29,15 @@ public sealed class CharacterInfoSystem : EntitySystem
         RaiseNetworkEvent(new RequestCharacterInfoEvent(GetNetEntity(entity.Value)));
     }
 
+    public void UpdateDetailExaminable(string content)
+    {
+        RaiseNetworkEvent(new UpdateDetailExaminableEvent(content));
+    }
+
     private void OnCharacterInfoEvent(CharacterInfoEvent msg, EntitySessionEventArgs args)
     {
         var entity = GetEntity(msg.NetEntity);
-        var data = new CharacterData(entity, msg.JobTitle, msg.Objectives, msg.Briefing, Name(entity));
+        var data = new CharacterData(entity, msg.JobTitle, msg.Objectives, msg.Briefing, msg.DetailExaminable, Name(entity));
 
         OnCharacterUpdate?.Invoke(data);
     }
@@ -49,6 +54,7 @@ public sealed class CharacterInfoSystem : EntitySystem
         string Job,
         Dictionary<string, List<ObjectiveInfo>> Objectives,
         string? Briefing,
+        string? DetailExaminable,
         string EntityName
     );
 

--- a/Content.Client/CharacterInfo/CharacterInfoSystem.cs
+++ b/Content.Client/CharacterInfo/CharacterInfoSystem.cs
@@ -37,7 +37,7 @@ public sealed class CharacterInfoSystem : EntitySystem
     private void OnCharacterInfoEvent(CharacterInfoEvent msg, EntitySessionEventArgs args)
     {
         var entity = GetEntity(msg.NetEntity);
-        var data = new CharacterData(entity, msg.JobTitle, msg.Objectives, msg.Briefing, msg.DetailExaminable, Name(entity));
+        var data = new CharacterData(entity, msg.JobTitle, msg.Faction, msg.BankBal, msg.Objectives, msg.Briefing, msg.DetailExaminable, Name(entity));
 
         OnCharacterUpdate?.Invoke(data);
     }
@@ -52,6 +52,8 @@ public sealed class CharacterInfoSystem : EntitySystem
     public readonly record struct CharacterData(
         EntityUid Entity,
         string Job,
+        string? Faction,
+        string BankBal,
         Dictionary<string, List<ObjectiveInfo>> Objectives,
         string? Briefing,
         string? DetailExaminable,

--- a/Content.Client/UserInterface/Systems/Character/CharacterUIController.cs
+++ b/Content.Client/UserInterface/Systems/Character/CharacterUIController.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Content.Client.CharacterInfo;
+using Content.Shared.CharacterInfo;
 using Content.Client.Gameplay;
 using Content.Client.Stylesheets;
 using Content.Client.UserInterface.Controls;
@@ -53,6 +54,7 @@ public sealed class CharacterUIController : UIController, IOnStateEntered<Gamepl
 
         _window.OnClose += DeactivateButton;
         _window.OnOpen += ActivateButton;
+        _window.DetailExaminableSubmitButton.OnPressed += OnDetailExaminableSubmit;
 
         CommandBinds.Builder
             .Bind(ContentKeyFunctions.OpenCharacterMenu,
@@ -64,6 +66,9 @@ public sealed class CharacterUIController : UIController, IOnStateEntered<Gamepl
     {
         if (_window != null)
         {
+            _window.OnClose -= DeactivateButton;
+            _window.OnOpen -= ActivateButton;
+            _window.DetailExaminableSubmitButton.OnPressed -= OnDetailExaminableSubmit;
             _window.Close();
             _window = null;
         }
@@ -130,7 +135,7 @@ public sealed class CharacterUIController : UIController, IOnStateEntered<Gamepl
             return;
         }
 
-        var (entity, job, objectives, briefing, entityName) = data;
+        var (entity, job, objectives, briefing, detailExaminable, entityName) = data;
 
         _window.SpriteView.SetEntity(entity);
 
@@ -140,6 +145,11 @@ public sealed class CharacterUIController : UIController, IOnStateEntered<Gamepl
         _window.SubText.Text = job;
         _window.Objectives.RemoveAllChildren();
         _window.ObjectivesLabel.Visible = objectives.Any();
+
+        if (detailExaminable != null)
+        {
+            _window.DetailExaminableTextEdit.TextRope = new Rope.Leaf(detailExaminable);
+        }
 
         foreach (var (groupId, conditions) in objectives)
         {
@@ -254,5 +264,14 @@ public sealed class CharacterUIController : UIController, IOnStateEntered<Gamepl
             _characterInfo.RequestCharacterInfo();
             _window.Open();
         }
+    }
+
+    private void OnDetailExaminableSubmit(ButtonEventArgs args)
+    {
+        if (_window == null)
+            return;
+
+        var text = Rope.Collapse(_window.DetailExaminableTextEdit.TextRope).Trim();
+        _characterInfo.UpdateDetailExaminable(text);
     }
 }

--- a/Content.Client/UserInterface/Systems/Character/CharacterUIController.cs
+++ b/Content.Client/UserInterface/Systems/Character/CharacterUIController.cs
@@ -135,14 +135,15 @@ public sealed class CharacterUIController : UIController, IOnStateEntered<Gamepl
             return;
         }
 
-        var (entity, job, objectives, briefing, detailExaminable, entityName) = data;
+        var (entity, job, faction, bankBal, objectives, briefing, detailExaminable, entityName) = data;
 
         _window.SpriteView.SetEntity(entity);
 
         UpdateRoleType();
 
         _window.NameLabel.Text = entityName;
-        _window.SubText.Text = job;
+        _window.SubText.Text = (faction != null) ? job + " | " + faction : job; // If off-duty don't show faction
+        _window.SubTextBankBal.Text = bankBal;
         _window.Objectives.RemoveAllChildren();
         _window.ObjectivesLabel.Visible = objectives.Any();
 
@@ -206,7 +207,7 @@ public sealed class CharacterUIController : UIController, IOnStateEntered<Gamepl
             _window.Objectives.AddChild(control);
         }
 
-        _window.RolePlaceholder.Visible = briefing == null && !controls.Any() && !objectives.Any();
+        _window.RolePlaceholder.Visible = false;  // Persistence: briefing == null && !controls.Any() && !objectives.Any(); < false;
     }
 
     private void OnRoleTypeChanged(MindRoleTypeChangedEvent ev, EntitySessionEventArgs _)

--- a/Content.Client/UserInterface/Systems/Character/Windows/CharacterWindow.xaml
+++ b/Content.Client/UserInterface/Systems/Character/Windows/CharacterWindow.xaml
@@ -18,6 +18,11 @@
             <Label Name="ObjectivesLabel" Access="Public" Text="{Loc 'character-info-objectives-label'}" HorizontalAlignment="Center"/>
             <BoxContainer Orientation="Vertical" Name="Objectives" Access="Public"/>
             <cc:Placeholder Name="RolePlaceholder" Access="Public" PlaceholderText="{Loc 'character-info-roles-antagonist-text'}"/>
+            <BoxContainer Orientation="Vertical" Name="DetailExaminableContainer" Access="Public" Margin="0 10 0 0">
+                <Label Text="{Loc 'character-info-detail-examinable-label'}" StyleClasses="LabelHeading"/>
+                <TextEdit Name="DetailExaminableTextEdit" Access="Public" MinHeight="100" Margin="0 5" VerticalExpand="True"/>
+                <Button Name="DetailExaminableSubmitButton" Access="Public" Text="{Loc 'character-info-detail-examinable-submit'}" HorizontalAlignment="Right"/>
+            </BoxContainer>
         </BoxContainer>
     </ScrollContainer>
 </windows:CharacterWindow>

--- a/Content.Client/UserInterface/Systems/Character/Windows/CharacterWindow.xaml
+++ b/Content.Client/UserInterface/Systems/Character/Windows/CharacterWindow.xaml
@@ -7,22 +7,32 @@
     MinHeight="545">
     <ScrollContainer>
         <BoxContainer Orientation="Vertical">
-            <Label Name="RoleType" VerticalAlignment="Top" Margin="0 6 0 10" HorizontalAlignment="Center" StyleClasses="LabelHeading" Access="Public"/>
-            <BoxContainer Orientation="Horizontal">
-                <SpriteView OverrideDirection="South" Scale="2 2" Name="SpriteView" Access="Public" SetSize="64 64"/>
-                <BoxContainer Orientation="Vertical" VerticalAlignment="Top">
-                    <Label Name="NameLabel" Access="Public"/>
-                    <Label Name="SubText" VerticalAlignment="Top" StyleClasses="LabelSubText" Access="Public"/>
+            <Label Name="RoleType" VerticalAlignment="Top" Margin="0 6 0 10" HorizontalAlignment="Center" StyleClasses="LabelHeading" Access="Public" Visible="False"/> <!-- Persistence: Add Visible=False  -->
+            <PanelContainer StyleClasses="PanelLight" Margin="0 2 0 0">
+                <BoxContainer Orientation="Horizontal" Margin="0 6 0 6">
+                    <SpriteView OverrideDirection="South" Scale="2 2" Name="SpriteView" Access="Public" SetSize="64 64"/>
+                    <BoxContainer Orientation="Vertical" VerticalAlignment="Top">
+                        <Label Name="NameLabel" Access="Public"/>
+                        <Label Name="SubText" VerticalAlignment="Top" StyleClasses="LabelSubText" Access="Public"/>
+                        <Label Name="SubTextBankBal" VerticalAlignment="Top" StyleClasses="LabelSubText" Access="Public"/>
+                    </BoxContainer>
                 </BoxContainer>
-            </BoxContainer>
-            <Label Name="ObjectivesLabel" Access="Public" Text="{Loc 'character-info-objectives-label'}" HorizontalAlignment="Center"/>
-            <BoxContainer Orientation="Vertical" Name="Objectives" Access="Public"/>
-            <cc:Placeholder Name="RolePlaceholder" Access="Public" PlaceholderText="{Loc 'character-info-roles-antagonist-text'}"/>
-            <BoxContainer Orientation="Vertical" Name="DetailExaminableContainer" Access="Public" Margin="0 10 0 0">
-                <Label Text="{Loc 'character-info-detail-examinable-label'}" StyleClasses="LabelHeading"/>
-                <TextEdit Name="DetailExaminableTextEdit" Access="Public" MinHeight="100" Margin="0 5" VerticalExpand="True"/>
-                <Button Name="DetailExaminableSubmitButton" Access="Public" Text="{Loc 'character-info-detail-examinable-submit'}" HorizontalAlignment="Right"/>
-            </BoxContainer>
+            </PanelContainer>
+            <Label Name="ObjectivesLabel" Access="Public" Text="{Loc 'character-info-objectives-label'}" HorizontalAlignment="Center" Visible="False"/> <!-- Persistence: Add Visible=False  -->
+            <BoxContainer Orientation="Vertical" Name="Objectives" Access="Public" Visible="False"/> <!-- Persistence: Add Visible=False  -->
+            <cc:Placeholder Name="RolePlaceholder" Access="Public" PlaceholderText="{Loc 'character-info-roles-antagonist-text'}" Visible="False"/> <!-- Persistence: Add Visible=False  -->
+            <PanelContainer StyleClasses="PanelLight" Margin = "0 4 0 0">
+                <BoxContainer Orientation="Vertical" Name="DetailExaminableContainer" Access="Public" Margin="10 2 10 0">
+                    <BoxContainer Orientation="Horizontal">
+                        <Label Text="{Loc 'character-info-detail-examinable-label'}" StyleClasses="LabelKeyText" VerticalAlignment="Bottom"/>
+                        <Control HorizontalExpand="True"/>
+                        <Button Name="DetailExaminableSubmitButton" Access="Public" Text="{Loc 'character-info-detail-examinable-submit'}" HorizontalAlignment="Right"/>
+                    </BoxContainer>
+                    <PanelContainer StyleClasses="PanelDark" Margin = "0 0 0 6">
+                        <TextEdit Name="DetailExaminableTextEdit" Access="Public" MinHeight="200" Margin="5 5" VerticalExpand="True"/>
+                    </PanelContainer>
+                </BoxContainer>
+            </PanelContainer>
         </BoxContainer>
     </ScrollContainer>
 </windows:CharacterWindow>

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
@@ -135,7 +135,7 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
         if (!_charInfoIsAttach)
             return;
 
-        var (_, job, _, _, entityName) = data;
+        var (_, job, _, _, _, entityName) = data;
 
         // Mark this entity's name as our character name for the "UpdateHighlights" function.
         var newHighlights = "@" + entityName;

--- a/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatUIController.Highlighting.cs
@@ -135,7 +135,7 @@ public sealed partial class ChatUIController : IOnSystemChanged<CharacterInfoSys
         if (!_charInfoIsAttach)
             return;
 
-        var (_, job, _, _, _, entityName) = data;
+        var (_, job, _, _, _, _, _, entityName) = data;
 
         // Mark this entity's name as our character name for the "UpdateHighlights" function.
         var newHighlights = "@" + entityName;

--- a/Content.Server/CharacterInfo/CharacterInfoSystem.cs
+++ b/Content.Server/CharacterInfo/CharacterInfoSystem.cs
@@ -2,6 +2,7 @@
 using Content.Server.Roles;
 using Content.Server.Roles.Jobs;
 using Content.Shared.CharacterInfo;
+using Content.Shared.DetailExaminable;
 using Content.Shared.Objectives;
 using Content.Shared.Objectives.Components;
 using Content.Shared.Objectives.Systems;
@@ -20,6 +21,7 @@ public sealed class CharacterInfoSystem : EntitySystem
         base.Initialize();
 
         SubscribeNetworkEvent<RequestCharacterInfoEvent>(OnRequestCharacterInfoEvent);
+        SubscribeNetworkEvent<UpdateDetailExaminableEvent>(OnUpdateDetailExaminableEvent);
     }
 
     private void OnRequestCharacterInfoEvent(RequestCharacterInfoEvent msg, EntitySessionEventArgs args)
@@ -56,6 +58,20 @@ public sealed class CharacterInfoSystem : EntitySystem
             briefing = _roles.MindGetBriefing(mindId);
         }
 
-        RaiseNetworkEvent(new CharacterInfoEvent(GetNetEntity(entity), jobTitle, objectives, briefing), args.SenderSession);
+        var detailExaminable = EnsureComp<DetailExaminableComponent>(entity, out var detail) ? detail.Content : Loc.GetString("flavor-text-placeholder");
+
+        RaiseNetworkEvent(new CharacterInfoEvent(GetNetEntity(entity), jobTitle, objectives, briefing, detailExaminable), args.SenderSession);
+
+        Dirty(entity, detail);
+    }
+
+    private void OnUpdateDetailExaminableEvent(UpdateDetailExaminableEvent msg, EntitySessionEventArgs args)
+    {
+        if (args.SenderSession.AttachedEntity is not { } entity)
+            return;
+
+        var detail = EnsureComp<DetailExaminableComponent>(entity);
+        detail.Content = msg.Content;
+        Dirty(entity, detail);
     }
 }

--- a/Content.Server/CharacterInfo/CharacterInfoSystem.cs
+++ b/Content.Server/CharacterInfo/CharacterInfoSystem.cs
@@ -1,6 +1,8 @@
 ﻿using Content.Server.Mind;
 using Content.Server.Roles;
 using Content.Server.Roles.Jobs;
+using Content.Server._NF.Bank;
+using Content.Server.CrewAssignments.Systems;
 using Content.Shared.CharacterInfo;
 using Content.Shared.DetailExaminable;
 using Content.Shared.Objectives;
@@ -15,6 +17,8 @@ public sealed class CharacterInfoSystem : EntitySystem
     [Dependency] private readonly MindSystem _minds = default!;
     [Dependency] private readonly RoleSystem _roles = default!;
     [Dependency] private readonly SharedObjectivesSystem _objectives = default!;
+    [Dependency] private readonly BankSystem _bank = default!;
+    [Dependency] private readonly JobNetSystem _jobNet = default!;
 
     public override void Initialize()
     {
@@ -33,7 +37,13 @@ public sealed class CharacterInfoSystem : EntitySystem
         var entity = args.SenderSession.AttachedEntity.Value;
 
         var objectives = new Dictionary<string, List<ObjectiveInfo>>();
-        var jobTitle = Loc.GetString("character-info-no-profession");
+
+        var (jobTitle, faction) = _jobNet.GetJobNetStrings(entity); // Persistence: Job & faction names from implant
+        if (jobTitle == null)
+            jobTitle = Loc.GetString("character-info-off-duty");
+
+        _bank.TryGetBalance(entity, out var bankBal);
+
         string? briefing = null;
         if (_minds.TryGetMind(entity, out var mindId, out var mind))
         {
@@ -60,7 +70,16 @@ public sealed class CharacterInfoSystem : EntitySystem
 
         var detailExaminable = EnsureComp<DetailExaminableComponent>(entity, out var detail) ? detail.Content : Loc.GetString("flavor-text-placeholder");
 
-        RaiseNetworkEvent(new CharacterInfoEvent(GetNetEntity(entity), jobTitle, objectives, briefing, detailExaminable), args.SenderSession);
+        RaiseNetworkEvent(new CharacterInfoEvent(
+            GetNetEntity(entity),
+            jobTitle,
+            faction,
+            "$" + bankBal.ToString(),
+            objectives,
+            briefing,
+            detailExaminable),
+            args.SenderSession
+        );
 
         Dirty(entity, detail);
     }

--- a/Content.Server/CharacterInfo/CharacterInfoSystem.cs
+++ b/Content.Server/CharacterInfo/CharacterInfoSystem.cs
@@ -3,11 +3,14 @@ using Content.Server.Roles;
 using Content.Server.Roles.Jobs;
 using Content.Server._NF.Bank;
 using Content.Server.CrewAssignments.Systems;
+using Content.Shared.CCVar;
 using Content.Shared.CharacterInfo;
 using Content.Shared.DetailExaminable;
 using Content.Shared.Objectives;
 using Content.Shared.Objectives.Components;
 using Content.Shared.Objectives.Systems;
+using Robust.Shared.Configuration;
+using Robust.Shared.Utility;
 
 namespace Content.Server.CharacterInfo;
 
@@ -19,6 +22,7 @@ public sealed class CharacterInfoSystem : EntitySystem
     [Dependency] private readonly SharedObjectivesSystem _objectives = default!;
     [Dependency] private readonly BankSystem _bank = default!;
     [Dependency] private readonly JobNetSystem _jobNet = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
 
     public override void Initialize()
     {
@@ -89,8 +93,29 @@ public sealed class CharacterInfoSystem : EntitySystem
         if (args.SenderSession.AttachedEntity is not { } entity)
             return;
 
+        string newContent = "";
+        var maxFlavorTextLength = _cfg.GetCVar(CCVars.MaxFlavorTextLength);
+        if (msg.Content.Length > maxFlavorTextLength)
+        {
+            newContent = FormattedMessage.RemoveMarkupOrThrow(msg.Content)[..maxFlavorTextLength];
+        }
+        else
+        {
+            newContent = FormattedMessage.RemoveMarkupOrThrow(msg.Content);
+        }
+
         var detail = EnsureComp<DetailExaminableComponent>(entity);
-        detail.Content = msg.Content;
+        detail.Content = newContent;
         Dirty(entity, detail);
     }
+
+//     var maxFlavorTextLength = configManager.GetCVar(CCVars.MaxFlavorTextLength);
+//         if (FlavorText.Length > maxFlavorTextLength)
+//     {
+//         flavortext = FormattedMessage.RemoveMarkupOrThrow(FlavorText)[..maxFlavorTextLength];
+//     }
+// else
+// {
+//     flavortext = FormattedMessage.RemoveMarkupOrThrow(FlavorText);
+// }
 }

--- a/Content.Server/CrewAssignments/Systems/JobNetSystem.Ui.cs
+++ b/Content.Server/CrewAssignments/Systems/JobNetSystem.Ui.cs
@@ -19,6 +19,7 @@ using Robust.Shared.Audio.Systems;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using System.Linq;
+using Content.Shared.Implants.Components;
 
 namespace Content.Server.CrewAssignments.Systems;
 
@@ -41,7 +42,7 @@ public sealed partial class JobNetSystem
         SubscribeLocalEvent<JobNetComponent, JobNetRequestUpdateInterfaceMessage>(OnRequestUpdate);
     }
 
-    
+
 
 
     public void ToggleUi(EntityUid user, EntityUid jobnetEnt, JobNetComponent? component = null)
@@ -65,6 +66,54 @@ public sealed partial class JobNetSystem
             return;
 
         _ui.CloseUi(uid, JobNetUiKey.Key);
+    }
+
+    public (string? jobTitle, string? factionName) GetJobNetStrings(EntityUid? user)
+    {
+        if(!TryComp<ImplantedComponent>(user, out var implanted)) return (null, null);
+
+        EntityUid? jobNet = null;
+        JobNetComponent? component = null;
+
+        foreach (var implant in implanted.ImplantContainer.ContainedEntities)
+        {
+            if (TryComp<JobNetComponent>(implant, out var comp))
+            {
+                jobNet = implant;
+                component = comp;
+            }
+        }
+
+        if (component == null || jobNet == null)
+            return (null, null);
+
+        var stations = _station.GetStationsSet();
+        string? jobTitle = null;
+        string? factionName = null;
+        foreach (var station in stations)
+        {
+            if (!TryComp<CrewRecordsComponent>(station, out var crewRecord)
+                || (!crewRecord.TryGetRecord(Name(user.Value), out var record)
+                || record == null)
+                || !TryComp<StationDataComponent>(station, out var stationData)
+                || stationData.StationName == null
+                || (component.WorkingFor == null || component.WorkingFor == 0)
+                || !TryComp<CrewAssignmentsComponent>(station, out var crewAssignments))
+                continue;
+
+            if (stationData.UID == component.WorkingFor)
+            {
+                factionName = stationData.StationName;
+            }
+
+            if (crewAssignments.TryGetAssignment(record.AssignmentID, out var assignment) &&
+                assignment != null)
+            {
+                jobTitle = assignment.Name;
+            }
+        }
+
+        return (jobTitle, factionName);
     }
 
     public void UpdateUserInterface(EntityUid? user, EntityUid jobnet, JobNetComponent? component = null)

--- a/Content.Shared/CharacterInfo/SharedCharacterInfoSystem.cs
+++ b/Content.Shared/CharacterInfo/SharedCharacterInfoSystem.cs
@@ -21,12 +21,25 @@ public sealed class CharacterInfoEvent : EntityEventArgs
     public readonly string JobTitle;
     public readonly Dictionary<string, List<ObjectiveInfo>> Objectives;
     public readonly string? Briefing;
+    public readonly string? DetailExaminable;
 
-    public CharacterInfoEvent(NetEntity netEntity, string jobTitle, Dictionary<string, List<ObjectiveInfo>> objectives, string? briefing)
+    public CharacterInfoEvent(NetEntity netEntity, string jobTitle, Dictionary<string, List<ObjectiveInfo>> objectives, string? briefing, string? detailExaminable)
     {
         NetEntity = netEntity;
         JobTitle = jobTitle;
         Objectives = objectives;
         Briefing = briefing;
+        DetailExaminable = detailExaminable;
+    }
+}
+
+[Serializable, NetSerializable]
+public sealed class UpdateDetailExaminableEvent : EntityEventArgs
+{
+    public readonly string Content;
+
+    public UpdateDetailExaminableEvent(string content)
+    {
+        Content = content;
     }
 }

--- a/Content.Shared/CharacterInfo/SharedCharacterInfoSystem.cs
+++ b/Content.Shared/CharacterInfo/SharedCharacterInfoSystem.cs
@@ -19,14 +19,18 @@ public sealed class CharacterInfoEvent : EntityEventArgs
 {
     public readonly NetEntity NetEntity;
     public readonly string JobTitle;
+    public readonly string? Faction;
+    public readonly string BankBal;
     public readonly Dictionary<string, List<ObjectiveInfo>> Objectives;
     public readonly string? Briefing;
     public readonly string? DetailExaminable;
 
-    public CharacterInfoEvent(NetEntity netEntity, string jobTitle, Dictionary<string, List<ObjectiveInfo>> objectives, string? briefing, string? detailExaminable)
+    public CharacterInfoEvent(NetEntity netEntity, string jobTitle, string? faction, string bankBal, Dictionary<string, List<ObjectiveInfo>> objectives, string? briefing, string? detailExaminable)
     {
         NetEntity = netEntity;
         JobTitle = jobTitle;
+        Faction = faction;
+        BankBal = bankBal;
         Objectives = objectives;
         Briefing = briefing;
         DetailExaminable = detailExaminable;

--- a/Resources/Locale/en-US/character-info/components/character-info-component.ftl
+++ b/Resources/Locale/en-US/character-info/components/character-info-component.ftl
@@ -2,5 +2,6 @@ character-info-title = Character
 character-info-roles-antagonist-text = You have no special Roles
 character-info-objectives-label = Objectives
 character-info-no-profession = No Profession
+character-info-off-duty = Off Duty
 character-info-detail-examinable-label = Flavor Text
 character-info-detail-examinable-submit = Submit

--- a/Resources/Locale/en-US/character-info/components/character-info-component.ftl
+++ b/Resources/Locale/en-US/character-info/components/character-info-component.ftl
@@ -2,3 +2,5 @@ character-info-title = Character
 character-info-roles-antagonist-text = You have no special Roles
 character-info-objectives-label = Objectives
 character-info-no-profession = No Profession
+character-info-detail-examinable-label = Flavor Text
+character-info-detail-examinable-submit = Submit


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds a TextEdit to the character window
Character window shows your bank balance & the currently clocked in job + faction

## Why / Balance
Character window was essentially unused for persistence. Upstream only really uses this for antag objectives.

## Technical details
<!-- Summary of code changes for easier review. -->
- `CharacterWindow`'s elements that are important for upstream round-based stuff but not for us have been made invisible. I deliberately avoided outright deleting elements as there is existing logic which depends on it, but is not used.
- `CharacterInfoEvent` now carries the currently clocked-in faction, job title, bank balance, and flavor text
-  Added `GetJobNetStrings` to `JobNetSystem.Ui`. I used the logic from `UpdateUserInterface` but did not change the behavior of `UpdateUserInterface` as I'm scared to break things
- New content for the `DetailExaminable` is trimmed of whitespace & compared against the cvar controlling the limit for this field before saving to the server.


## Media
<img width="365" height="501" alt="image" src="https://github.com/user-attachments/assets/da8a1f94-c3c5-4711-b95b-1a04f27c9b99" />

<img width="781" height="651" alt="image" src="https://github.com/user-attachments/assets/21edd017-3684-4505-8836-bd57ec4e30b6" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Future merges/ports which depend on `CharacterInfoEvent` might be impacted.


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: stinky
- add: Character window is useful for persistence! See your bank balance, current job & faction, and edit your flavor text!
