### PR TITLE
disables mobs ashing from heat damage & gibbing from blunt damage

### DIFF
--- a/Resources/Prototypes/Body/Species/vox.yml
+++ b/Resources/Prototypes/Body/Species/vox.yml
@@ -179,28 +179,28 @@
       amount: 5
   - type: Destructible
     thresholds:
-    - trigger:
-        !type:DamageTypeTrigger
-        damageType: Blunt
-        damage: 400
-      behaviors:
-      - !type:GibBehavior { }
-    - trigger:
-        !type:DamageTypeTrigger
-        damageType: Heat
-        damage: 1500
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawnInContainer: true
-        spawn:
-          FoodMeatChickenFriedVox:
-            min: 3
-            max: 5
-      - !type:BurnBodyBehavior
-        popupMessage: bodyburn-vox-text-others
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MeatLaserImpact
+#    - trigger: # Persistence: Disabled gibbing from blunt damage
+#        !type:DamageTypeTrigger
+#        damageType: Blunt
+#        damage: 400
+#      behaviors:
+#      - !type:GibBehavior { }
+#    - trigger: # Persistence: Disabled ashing from heat damage
+#        !type:DamageTypeTrigger
+#        damageType: Heat
+#        damage: 1500
+#      behaviors:
+#      - !type:SpawnEntitiesBehavior
+#        spawnInContainer: true
+#        spawn:
+#          FoodMeatChickenFriedVox:
+#            min: 3
+#            max: 5
+#      - !type:BurnBodyBehavior
+#        popupMessage: bodyburn-vox-text-others
+#      - !type:PlaySoundBehavior
+#        sound:
+#          collection: MeatLaserImpact
     - trigger:
         !type:DamageTypeTrigger
         damageType: Radiation

--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -73,27 +73,27 @@
     damageContainer: Biological
   - type: Destructible
     thresholds:
-    - trigger:
-        !type:DamageTypeTrigger
-        damageType: Blunt
-        damage: 400
-      behaviors:
-      - !type:GibBehavior { }
-    - trigger:
-        !type:DamageTypeTrigger
-        damageType: Heat
-        damage: 1500
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawnInContainer: true
-        spawn:
-          Ash:
-            min: 1
-            max: 1
-      - !type:BurnBodyBehavior
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MeatLaserImpact
+#    - trigger: # Persistence: Disabled gibbing from blunt damage
+#        !type:DamageTypeTrigger
+#        damageType: Blunt
+#        damage: 400
+#      behaviors:
+#      - !type:GibBehavior { }
+#    - trigger: # Persistence: Disabled ashing from heat damage
+#        !type:DamageTypeTrigger
+#        damageType: Heat
+#        damage: 1500
+#      behaviors:
+#      - !type:SpawnEntitiesBehavior
+#        spawnInContainer: true
+#        spawn:
+#          Ash:
+#            min: 1
+#            max: 1
+#      - !type:BurnBodyBehavior
+#      - !type:PlaySoundBehavior
+#        sound:
+#          collection: MeatLaserImpact
     - trigger:
         !type:DamageTypeTrigger
         damageType: Radiation


### PR DESCRIPTION
does what it says on the tin. referenced https://github.com/space-wizards/space-station-14/pull/42474

will definitely also make it so non-player mobs can't be gibbed by blunt or ashed by heat damage. should be fine, we have the biomass reclaimer which can eat corpses
