### PR TITLE
Significant prices nerfs to a variety of items related to easy money printers

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/base_clothingbelt.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/base_clothingbelt.yml
@@ -16,7 +16,7 @@
     materialComposition:
       Cloth: 50
   - type: StaticPrice
-    price: 20
+    price: 10
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -129,7 +129,7 @@
   - type: VisionCorrection
   - type: IdentityBlocker
   - type: StaticPrice
-    price: 500
+    price: 10
 
 - type: entity
   parent: ClothingEyesBase

--- a/Resources/Prototypes/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hats.yml
@@ -506,7 +506,7 @@
   - type: Clothing
     sprite: Clothing/Head/Hats/outlawhat.rsi
   - type: StaticPrice
-    price: 500
+    price: 10
   - type: Tag
     tags:
     - PetWearable

--- a/Resources/Prototypes/Entities/Clothing/Head/welding.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/welding.yml
@@ -15,7 +15,7 @@
       Steel: 200
       Glass: 100
   - type: StaticPrice
-    price: 50
+    price: 20
   - type: Tag
     tags:
     - WhitelistChameleon

--- a/Resources/Prototypes/Entities/Clothing/Masks/base_clothingmask.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/base_clothingmask.yml
@@ -10,7 +10,7 @@
   - type: Clothing
     slots: [mask]
   - type: StaticPrice
-    price: 25
+    price: 10
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -307,7 +307,7 @@
     materialComposition:
       Plastic: 25
   - type: StaticPrice
-    price: 5
+    price: 2
 
 - type: entity
   parent: ClothingMaskBase

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -170,7 +170,7 @@
   - type: ExplosionResistance
     damageCoefficient: 0.9
   - type: StaticPrice
-    price: 1500
+    price: 200
 
 #Elite web vest
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/base_clothingouter.yml
@@ -41,7 +41,7 @@
       enum.StorageUiKey.Key:
         type: StorageBoundUserInterface
   - type: StaticPrice
-    price: 70
+    price: 10
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -36,7 +36,7 @@
     - Recyclable
     - WhitelistChameleon
   - type: StaticPrice
-    price: 50
+    price: 10
 
 - type: entity
   parent: ClothingOuterWinterCoat

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -18,7 +18,7 @@
   - type: CombatMode
   - type: NoSlip
   - type: StaticPrice
-    price: 500
+    price: 200
   - type: Fixtures
     fixtures:
       fix1:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/miscellaneous.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/miscellaneous.yml
@@ -230,4 +230,4 @@
       types:
         Blunt: 0.11
   - type: StaticPrice
-    price: 400
+    price: 10

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -1,4 +1,4 @@
-﻿# Be careful with these as they get removed on shutdown too!
+# Be careful with these as they get removed on shutdown too!
 - type: entity
   id: AiHeld
   description: Components added / removed from an entity that gets inserted into an AI core.
@@ -319,7 +319,7 @@
       board:
       - StationAiCoreElectronics
   - type: StaticPrice
-    price: 1500
+    price: 500
 
 # The job-ready version of an AI spawn.
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/tin.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/tin.yml
@@ -49,7 +49,7 @@
   - type: Damageable
     damageContainer: Inorganic
   - type: StaticPrice
-    price: 50
+    price: 15
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
@@ -769,7 +769,7 @@
     count: 3
     slice: FoodMeatTomatoCutlet
   - type: StaticPrice
-    price: 100
+    price: 90
   - type: Item
     storedOffset: 0,-2
     inhandVisuals:

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/base_machineboard.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/base_machineboard.yml
@@ -12,7 +12,7 @@
     - type: Item
       storedRotation: -90
     - type: StaticPrice
-      price: 100
+      price: 90
     - type: PhysicalComposition
       materialComposition:
         Glass: 230

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
@@ -11,7 +11,7 @@
     - type: Item
       storedRotation: -90
     - type: StaticPrice
-      price: 20
+      price: 90
     - type: PhysicalComposition
       materialComposition:
         Glass: 230
@@ -96,7 +96,7 @@
     - type: ComputerBoard
       prototype: ComputerCargoOrders
     - type: StaticPrice
-      price: 750
+      price: 90
 
 - type: entity
   parent: BaseComputerCircuitboard
@@ -109,7 +109,7 @@
     - type: ComputerBoard
       prototype: ComputerStationModification
     - type: StaticPrice
-      price: 750
+      price: 90
 
 - type: entity
   parent: BaseComputerCircuitboard
@@ -122,7 +122,7 @@
     - type: ComputerBoard
       prototype: ComputerStationModification
     - type: StaticPrice
-      price: 750
+      price: 90
 
 - type: entity
   parent: BaseComputerCircuitboard
@@ -135,7 +135,7 @@
     - type: ComputerBoard
       prototype: ComputerIdPrinter
     - type: StaticPrice
-      price: 750
+      price: 90
 
 
 - type: entity
@@ -149,7 +149,7 @@
     - type: ComputerBoard
       prototype: ComputerInvoicePrinter
     - type: StaticPrice
-      price: 750
+      price: 90
 
 - type: entity
   parent: BaseComputerCircuitboard
@@ -162,7 +162,7 @@
   - type: ComputerBoard
     prototype: ComputerCargoOrdersEngineering
   - type: StaticPrice
-    price: 750
+    price: 90
 
 - type: entity
   parent: BaseComputerCircuitboard
@@ -175,7 +175,7 @@
   - type: ComputerBoard
     prototype: ComputerCargoOrdersMedical
   - type: StaticPrice
-    price: 750
+    price: 90
 
 - type: entity
   parent: BaseComputerCircuitboard
@@ -188,7 +188,7 @@
   - type: ComputerBoard
     prototype: ComputerCargoOrdersScience
   - type: StaticPrice
-    price: 750
+    price: 90
 
 - type: entity
   parent: BaseComputerCircuitboard
@@ -201,7 +201,7 @@
   - type: ComputerBoard
     prototype: ComputerCargoOrdersSecurity
   - type: StaticPrice
-    price: 750
+    price: 90
 
 - type: entity
   parent: BaseComputerCircuitboard
@@ -214,7 +214,7 @@
   - type: ComputerBoard
     prototype: ComputerCargoOrdersService
   - type: StaticPrice
-    price: 750
+    price: 90
 
 - type: entity
   parent: BaseComputerCircuitboard
@@ -227,7 +227,7 @@
   - type: ComputerBoard
     prototype: ComputerFundingAllocation
   - type: StaticPrice
-    price: 750
+    price: 90
 
 - type: entity
   parent: BaseComputerCircuitboard
@@ -392,7 +392,7 @@
     - type: ComputerBoard
       prototype: ComputerId
     - type: StaticPrice
-      price: 750
+      price: 90
     - type: Tag
       tags:
       - HighRiskItem
@@ -566,7 +566,7 @@
     - type: Sprite
       state: cpu_service
     - type: StaticPrice
-      price: 150
+      price: 90
     - type: ComputerBoard
       prototype: ComputerMassMedia
 

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
@@ -11,7 +11,7 @@
     - type: Item
       storedRotation: -90
     - type: StaticPrice
-      price: 100
+      price: 20
     - type: PhysicalComposition
       materialComposition:
         Glass: 230

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/law_boards.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/law_boards.yml
@@ -122,7 +122,7 @@
     laws: AntimovLawset
     lawUploadSound: /Audio/Ambience/Antag/silicon_lawboard_antimov.ogg
   - type: StaticPrice
-    price: 10000
+    price: 90
 
 - type: entity
   id: NutimovCircuitBoard

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/intercom.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/intercom.yml
@@ -11,4 +11,4 @@
     tags:
       - IntercomElectronics
   - type: StaticPrice
-    price: 55
+    price: 20

--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/station_ai_core.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/station_ai_core.yml
@@ -11,4 +11,4 @@
     tags:
       - StationAiCoreElectronics
   - type: StaticPrice
-    price: 404
+    price: 90

--- a/Resources/Prototypes/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/flatpack.yml
@@ -34,7 +34,7 @@
       cpu_science: "#D381C9"
       cpu_supply: "#A46106"
   - type: StaticPrice
-    price: 250
+    price: 100
 
 - type: entity
   parent: BaseFlatpack

--- a/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/holoprojectors.yml
@@ -165,7 +165,7 @@
         - HolofanProjector
         - SecBeltEquip
     - type: StaticPrice
-      price: 50
+      price: 20
 
 - type: entity
   parent: HoloprojectorSecurity

--- a/Resources/Prototypes/Entities/Objects/Devices/station_beacon.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/station_beacon.yml
@@ -76,7 +76,7 @@
         - !type:DoActsBehavior
           acts: ["Breakage"]
   - type: StaticPrice
-    price: 25
+    price: 10
 
 - type: entity
   parent: DefaultStationBeacon

--- a/Resources/Prototypes/Entities/Objects/Misc/rubber_stamp.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/rubber_stamp.yml
@@ -219,7 +219,7 @@
   - type: Sprite
     state: stamp-syndicate
   - type: StaticPrice
-    price: 1000
+    price: 200
 
 - type: entity
   name: warden's rubber stamp

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -60,7 +60,7 @@
                   min: 2
                   max: 2
     - type: StaticPrice
-      price: 100
+      price: 50
 
 - type: entity
   name: base repairable shield
@@ -88,7 +88,7 @@
   description: A large tower shield. Good for controlling crowds.
   components:
     - type: StaticPrice
-      price: 90
+      price: 40
     - type: Blocking
       passiveBlockModifier:
         coefficients:
@@ -197,7 +197,7 @@
                   min: 5
                   max: 5
     - type: StaticPrice
-      price: 150
+      price: 20
 
 - type: entity
   name: cardboard shield

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -230,7 +230,7 @@
       Plastic: 50
   - type: SpaceGarbage
   - type: StaticPrice
-    price: 75 # These are limited supply items.
+    price: 20
   - type: TrashOnSolutionEmpty
     solution: pen
 
@@ -592,7 +592,7 @@
     changeColor: false
     emptySpriteName: stimpen_empty
   - type: StaticPrice
-    price: 1500
+    price: 50
 
 - type: entity
   parent: [ChemicalMedipen, BaseSyndicateContraband]
@@ -631,7 +631,7 @@
     changeColor: false
     emptySpriteName: microstimpen_empty
   - type: StaticPrice
-    price: 583 # 3500 for 6 as a freaky fraction
+    price: 50
 
 - type: entity
   parent: [ChemicalMedipen, BaseSyndicateContraband]
@@ -670,7 +670,7 @@
         - ReagentId: TranexamicAcid
           Quantity: 5
   - type: StaticPrice
-    price: 1500
+    price: 50
 
 - type: entity
   parent: Pen # It is just like normal pen, isn't it?

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -1258,7 +1258,7 @@
       - state: base-stripes-inhand-right
         color: "#7B0F12"
   - type: StaticPrice
-    price: 2500
+    price: 100
 
 - type: entity
   parent: [ BaseBorgModuleSyndicate, BaseProviderBorgModule, BaseSyndicateContraband ]
@@ -1381,7 +1381,7 @@
         - state: base-stripes-inhand-right
           color: "#7B0F12"
     - type: StaticPrice
-      price: 2000
+      price: 100
 
 # mothership module
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry-vials.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry-vials.yml
@@ -72,7 +72,7 @@
   - type: TrashOnSolutionEmpty
     solution: beaker
   - type: StaticPrice
-    price: 100
+    price: 20
   - type: DamageOnLand
     damage:
       types:

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry.yml
@@ -95,7 +95,7 @@
       types:
         Blunt: 5
   - type: StaticPrice
-    price: 30
+    price: 10
   - type: DnaSubstanceTrace
 
 - type: entity
@@ -161,7 +161,7 @@
     damageContainer: Inorganic
     damageModifierSet: Glass
   - type: StaticPrice
-    price: 30
+    price: 10
   - type: DnaSubstanceTrace
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Tools/blueprint.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/blueprint.yml
@@ -17,7 +17,7 @@
       state: storage
   - type: Blueprint
   - type: StaticPrice
-    price: 1000
+    price: 200
   - type: Tag
     tags:
     - BlueprintAutolathe

--- a/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/jetpacks.yml
@@ -127,7 +127,7 @@
     slots:
       - Back
   - type: StaticPrice
-    price: 1000
+    price: 100
 
 # Filled black
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   id: BasePlasticExplosive
   parent: BaseItem
   abstract: true
@@ -92,7 +92,7 @@
     sprite:
       festive: Objects/Weapons/Bombs/c4gift.rsi
   - type: StaticPrice
-    price: 625 # 5000 for a bundle of 8
+    price: 200
 
 - type: entity
   name: seismic charge

--- a/Resources/Prototypes/Entities/Structures/Furniture/bench.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/bench.yml
@@ -16,7 +16,7 @@
   - type: Physics
     bodyType: Static
   - type: StaticPrice
-    price: 35
+    price: 10
 
 - type: entity
   id: BenchColorfulComfy

--- a/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/chairs.yml
@@ -48,7 +48,7 @@
         sound:
           collection: MetalBreak
   - type: StaticPrice
-    price: 50
+    price: 10
   - type: GravityAffected
 
 #Starts unanchored, cannot be rotated while anchored
@@ -240,7 +240,7 @@
     tags:
     - Wooden
   - type: StaticPrice
-    price: 75
+    price: 24
 
 - type: entity
   name: ritual chair
@@ -473,7 +473,7 @@
             min: 2
             max: 4
   - type: StaticPrice
-    price: 50
+    price: 24
 
 - type: entity
   parent: StoolBase

--- a/Resources/Prototypes/Entities/Structures/Furniture/toilet.yml
+++ b/Resources/Prototypes/Entities/Structures/Furniture/toilet.yml
@@ -72,7 +72,7 @@
   - type: Drain
     autoDrain: false
   - type: StaticPrice
-    price: 100
+    price: 60
   - type: ActivatableUI
     key: enum.DisposalUnitUiKey.Key
     verbOnly: true # Not strictly needed, but we want E to toggle lid

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/arcades.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/arcades.yml
@@ -42,7 +42,7 @@
   - type: Anchorable
   - type: Pullable
   - type: StaticPrice
-    price: 300
+    price: 200
   - type: SpamEmitSoundRequirePower
   - type: SpamEmitSound
     minInterval: 30

--- a/Resources/Prototypes/Entities/Structures/Machines/anomaly_equipment.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/anomaly_equipment.yml
@@ -323,7 +323,7 @@
           False: { visible: false }
   - type: WiresVisuals
   - type: StaticPrice
-    price: 5000
+    price: 100
   - type: AccessReader
     access: [["Research"]]
   - type: GuideHelp

--- a/Resources/Prototypes/Entities/Structures/Machines/cloning_machine.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/cloning_machine.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   id: CloningPod
   parent: BaseMachinePowered
   name: cloning pod
@@ -65,7 +65,7 @@
           Idle: { state: pod_0 }
   - type: Climbable
   - type: StaticPrice
-    price: 1000
+    price: 200
   - type: ContainerContainer
     containers:
       machine_board: !type:Container

--- a/Resources/Prototypes/Entities/Structures/Machines/fatextractor.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/fatextractor.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   id: FatExtractor
   parent: BaseMachinePowered
   name: lipid extractor
@@ -107,7 +107,7 @@
   - type: DatasetVocalizer
     dataset: FatExtractorFacts
   - type: StaticPrice
-    price: 1000
+    price: 160
   - type: ResistLocker
   - type: EntityStorage
     capacity: 1

--- a/Resources/Prototypes/Entities/Structures/Machines/flatpacker.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/flatpacker.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   id: MachineFlatpacker
   parent: [ BaseMachinePowered, ConstructibleMachine ]
   name: Flatpacker 1001
@@ -80,7 +80,7 @@
     - machine_board
     - board_slot
   - type: StaticPrice
-    price: 500
+    price: 184
 
 - type: entity
   id: FlatpackerNoBoardEffect

--- a/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/gravity_generator.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   id: GravityGenerator
   parent: BaseMachinePowered
   name: gravity generator
@@ -78,7 +78,7 @@
     castShadows: false
     color: "#a8ffd9"
   - type: StaticPrice
-    price: 5000
+    price: 200
 
 - type: entity
   id: GravityGeneratorMini
@@ -138,4 +138,4 @@
     lightRadiusMin: 0.75
     lightRadiusMax: 2.5
   - type: StaticPrice
-    price: 2000
+    price: 350

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -46,7 +46,7 @@
     anchored: true
   - type: Pullable
   - type: StaticPrice
-    price: 800
+    price: 360
   - type: ResearchClient
   - type: TechnologyDatabase
 

--- a/Resources/Prototypes/Entities/Structures/Machines/nuke.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/nuke.yml
@@ -184,4 +184,4 @@
   - type: ReagentTank
     transferAmount: 100
   - type: StaticPrice
-    price: 5000 # That's a pretty fancy keg you got there.
+    price: 1000 # That's a pretty fancy keg you got there.

--- a/Resources/Prototypes/Entities/Structures/Machines/silo.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/silo.yml
@@ -62,4 +62,4 @@
   - type: WiresVisuals
   - type: WiresPanel
   - type: StaticPrice
-    price: 1500
+    price: 360

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/pipes.yml
@@ -64,7 +64,7 @@
     canCollide: false
     bodyType: static
   - type: StaticPrice
-    price: 30
+    price: 14
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/portable_generator.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/portable_generator.yml
@@ -14,7 +14,7 @@
     - type: Physics
       bodyType: Dynamic
     - type: StaticPrice
-      price: 500
+      price: 200
     - type: AmbientSound
       range: 5
       volume: -5

--- a/Resources/Prototypes/Entities/Structures/Power/apc.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/apc.yml
@@ -150,7 +150,7 @@
   - type: LightningTarget
     priority: 1
   - type: StaticPrice
-    price: 500
+    price: 60
   - type: GuideHelp
     guides:
     - VoltageNetworks

--- a/Resources/Prototypes/Entities/Structures/Power/chargers.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/chargers.yml
@@ -151,7 +151,7 @@
   - type: Machine
     board: PowerCageRechargerCircuitboard
   - type: StaticPrice
-    price: 500
+    price: 200
 
 - type: entity
   parent: BaseItemRecharger

--- a/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/cannons.yml
@@ -32,7 +32,7 @@
   - type: AutoShootGun
   - type: GunSignalControl
   - type: StaticPrice
-    price: 1500
+    price: 250
 
 # ---- Laser weapon branch ----
 # naming: LSE (Laser) + conventional power + suffix (c for PowerCage, e for wired energy) + Name

--- a/Resources/Prototypes/Entities/Structures/Shuttles/station_anchor.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/station_anchor.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   id: StationAnchorBase
   abstract: true
   name: station anchor
@@ -94,7 +94,7 @@
           sound:
             collection: MetalBreak
     - type: StaticPrice
-      price: 10000
+      price: 300
     - type: Machine
       board: StationAnchorCircuitboard
     - type: ContainerContainer

--- a/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
@@ -54,7 +54,7 @@
             sound:
               collection: MetalBreak
     - type: StaticPrice
-      price: 300
+      price: 80
     - type: GuideHelp
       guides:
       - ShuttleCraft
@@ -170,7 +170,7 @@
   - type: Anchorable
     flags: None
   - type: StaticPrice
-    price: 1500
+    price: 90
 
 - type: entity
   id: ThrusterUnanchored
@@ -269,7 +269,7 @@
     damageContainer: StructuralInorganic
     damageModifierSet: Electronic
   - type: StaticPrice
-    price: 2000
+    price: 150
 
 - type: entity
   id: GyroscopeUnanchored

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/base_structureclosets.yml
@@ -101,7 +101,7 @@
     stateDoorOpen: generic_open
     stateDoorClosed: generic_door
   - type: StaticPrice
-    price: 75
+    price: 60
 
 # steel closet base (that can be constructed/deconstructed)
 - type: entity
@@ -127,7 +127,7 @@
   - type: ResistLocker
   - type: Weldable
   - type: StaticPrice
-    price: 75
+    price: 60
   - type: Sprite
     drawdepth: WallMountedItems
     noRot: false
@@ -227,7 +227,7 @@
   - type: Anchorable
     delay: 2
   - type: StaticPrice
-    price: 80
+    price: 60
   - type: ResistLocker
   - type: Transform
     noRot: true

--- a/Resources/Prototypes/Entities/Structures/Storage/Tanks/tanks.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Tanks/tanks.yml
@@ -8,7 +8,7 @@
   suffix: Empty
   components:
   - type: StaticPrice
-    price: 750
+    price: 300
   - type: Sprite
     sprite: Structures/Storage/tanks.rsi
     layers:
@@ -89,7 +89,7 @@
   suffix: Empty
   components:
   - type: StaticPrice
-    price: 500
+    price: 300
   - type: Sprite
     sprite: Structures/Storage/tanks.rsi
     layers:
@@ -208,7 +208,7 @@
   suffix: Empty
   components:
     - type: StaticPrice
-      price: 500
+      price: 300
     - type: Sprite
       sprite: Structures/Storage/tanks.rsi
       layers:

--- a/Resources/Prototypes/Entities/Structures/Storage/filing_cabinets.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/filing_cabinets.yml
@@ -103,7 +103,7 @@
             min: 1
             max: 2
   - type: StaticPrice
-    price: 80
+    price: 40
   - type: Construction
     graph: FilingCabinet
 

--- a/Resources/Prototypes/Entities/Structures/Storage/morgue.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/morgue.yml
@@ -71,7 +71,7 @@
     anchored: true
   - type: AntiRottingContainer
   - type: StaticPrice
-    price: 200
+    price: 80
   - type: Construction
     graph: MorgueGraph
     node: morgue
@@ -109,7 +109,7 @@
   - type: Transform
     anchored: true
   - type: StaticPrice
-    price: 200
+    price: 0
   - type: Construction
     graph: MorgueGraph
     node: cables
@@ -220,7 +220,7 @@
   - type: Transform
     anchored: true
   - type: StaticPrice
-    price: 200
+    price: 0
   - type: Construction
     graph: CrematoriumGraph
     node: crematorelectronics

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/surveillance_camera.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/surveillance_camera.yml
@@ -74,7 +74,7 @@
       enum.WiresUiKey.Key:
         type: WiresBoundUserInterface
   - type: StaticPrice
-    price: 200
+    price: 100
   - type: Destructible
     thresholds:
       - trigger:

--- a/Resources/Prototypes/Entities/Structures/Walls/girders.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/girders.yml
@@ -53,7 +53,7 @@
         sound:
           collection: MetalBreak
   - type: StaticPrice
-    price: 30
+    price: 28
 
 - type: entity
   id: GirderDiagonal
@@ -126,7 +126,7 @@
               sound:
                 collection: MetalBreak
     - type: StaticPrice
-      price: 130
+      price: 80
 
 - type: entity
   id: ReinforcedGirderDiagonal
@@ -171,7 +171,7 @@
       graph: ClockworkGirder
       node: clockGirder
     - type: StaticPrice
-      price: 75
+      price: 40
     - type: Destructible
       thresholds:
         - trigger:


### PR DESCRIPTION
## About the PR
Nerfs the sell prices of an extremely wide variety of items ranging from circuit boards to full on machines. Some highlights include:
certain circuit boards(command/persistence-related) used to be made of worth $45 of mats and sold for $375
chairs cost $7.50 to construct and sold for $25
vials worth worth 5x. $55 mats > $250
toilets were profitable by about $20 
arcade machines were profitable by $93
lipid extractors were profitable by $462
flatpackers were profitable by $211
minigrav gens: $800 profit
Pipes were $7.50 to make and sold for $15
cage rechargers profitable by $100 credits
Station anchor machine boards, though requiring research to craft, were able to be crafted. The full machine would sell for a $4961 profit compared to the $280 it cost to make it.
Gyroscopes also sold for about a $900 profit

## Why / Balance
This PR is made in the hopes of stemming the flow of extremely easy money printers from the game loop.

## Technical details
Affects the StaticPrice components of a number of prototypes, including Bases.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- remove:: A significant amount of easy-to-replicate cargo money printers.
