### PR TITLE
Moves the administration glasses from the circuit imprinter to the protolathe

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/service.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/service.yml
@@ -74,4 +74,3 @@
   - JukeboxCircuitBoard
   - DawInstrumentMachineCircuitboard
   - ComputerTelevisionCircuitboard
-  - ClothingEyesGlassesCommand

--- a/Resources/Prototypes/Recipes/Lathes/Packs/shared.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/shared.yml
@@ -76,6 +76,7 @@
   - ClothingEyesGlassesSunglasses
   - ClothingHandsGlovesColorYellow
   - ClothingEyesGlassesMeson
+  - ClothingEyesGlassesCommand
 
 - type: latheRecipePack
   id: SalvageSecurityBoards


### PR DESCRIPTION
Two line YAML change that just moves the administration glasses from the circuit imprinter to the protolathe.

Previously, the admin glasses were appearing in the wrong lathe when researched.
<img width="1563" height="157" alt="image" src="https://github.com/user-attachments/assets/4a825bac-f929-404b-9087-1fb05eb028fa" />
