### PR TITLE
feat: Gas Reactions Redux: ClF3 rework, burn colors rework + more

### DIFF
--- a/Content.Client/Atmos/Overlays/GasTileFireOverlay.cs
+++ b/Content.Client/Atmos/Overlays/GasTileFireOverlay.cs
@@ -6,6 +6,7 @@ using Robust.Shared.Enums;
 using Robust.Shared.Graphics.RSI;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
+using Robust.Shared.Maths;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using System.Numerics;
@@ -37,7 +38,7 @@ public sealed class GasTileFireOverlay : Overlay
     private readonly Texture[][] _frames;
 
     private const int FireStates = 3;
-    private const string FireRsiPath = "/Textures/Effects/fire.rsi";
+    private const string FireRsiPath = "/Textures/Effects/fire_greyscale.rsi";
 
     public const int GasOverlayZIndex = (int)Shared.DrawDepth.DrawDepth.Effects; // Under ghosts, above mostly everything else
 
@@ -156,7 +157,8 @@ public sealed class GasTileFireOverlay : Overlay
 
                         var fireState = gas.FireState - 1;
                         var texture = state.frames[fireState][state.frameCounter[fireState]];
-                        state.drawHandle.DrawTexture(texture, index);
+                        var fireColor = new Color(gas.FireColorR / 255f, gas.FireColorG / 255f, gas.FireColorB / 255f);
+                        state.drawHandle.DrawTexture(texture, index, fireColor);
                     }
                 }
 

--- a/Content.Client/Atmos/Overlays/GasTileFireOverlay.cs
+++ b/Content.Client/Atmos/Overlays/GasTileFireOverlay.cs
@@ -157,7 +157,7 @@ public sealed class GasTileFireOverlay : Overlay
 
                         var fireState = gas.FireState - 1;
                         var texture = state.frames[fireState][state.frameCounter[fireState]];
-                        var fireColor = new Color(gas.FireColorR / 255f, gas.FireColorG / 255f, gas.FireColorB / 255f);
+                        var fireColor = new Color(gas.FireColorR / 255f, gas.FireColorG / 255f, gas.FireColorB / 255f, gas.FireColorA / 255f);
                         state.drawHandle.DrawTexture(texture, index, fireColor);
                     }
                 }

--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Hotspot.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Hotspot.cs
@@ -3,7 +3,10 @@ using Content.Shared.Atmos;
 using Content.Shared.Atmos.Components;
 using Content.Shared.Atmos.Reactions;
 using Content.Shared.Database;
+using Content.Shared.Radiation.Components;
+using Content.Shared.Singularity.Components;
 using Robust.Shared.Audio;
+using Robust.Shared.Spawners;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Prototypes;
@@ -234,7 +237,8 @@ public sealed partial class AtmosphereSystem
                 Temperature = exposedTemperature,
                 SkippedFirstProcess = tile.CurrentCycle > gridAtmosphere.UpdateCounter,
                 Valid = true,
-                State = 1
+                State = 1,
+                FireColor = GetFuelBurnColor(tile.Air)
             };
 
             AddActiveTile(gridAtmosphere, tile);
@@ -273,6 +277,9 @@ public sealed partial class AtmosphereSystem
             Merge(tile.Air, affected);
         }
 
+        // Compute fire color from the proportional mix of fuel gases in the tile's air.
+        tile.Hotspot.FireColor = GetFuelBurnColor(tile.Air);
+
         var fireEvent = new TileFireEvent(tile.Hotspot.Temperature, tile.Hotspot.Volume);
         _entSet.Clear();
         _lookup.GetLocalEntitiesIntersecting(tile.GridIndex, tile.GridIndices, _entSet, 0f);
@@ -280,6 +287,68 @@ public sealed partial class AtmosphereSystem
         foreach (var entity in _entSet)
         {
             RaiseLocalEvent(entity, ref fireEvent);
+        }
+    }
+
+    /// <summary>
+    /// Exposes entities on a tile to ClF3 oxidation. Called from the ClF3 reaction
+    /// regardless of whether a hotspot exists — ClF3 corrodes items on contact.
+    /// </summary>
+    public void PerformClF3Exposure(TileAtmosphere tile, float clf3Moles, float temperature)
+    {
+        var evt = new TileClF3ExposureEvent(clf3Moles, temperature);
+        _entSet.Clear();
+        _lookup.GetLocalEntitiesIntersecting(tile.GridIndex, tile.GridIndices, _entSet, 0f);
+
+        foreach (var entity in _entSet)
+        {
+            RaiseLocalEvent(entity, ref evt);
+        }
+    }
+
+    /// <summary>
+    /// Spawns or refreshes a ClF3TritiumFlash entity — a gravitational-lensing
+    /// shimmer + radiation source. Only ONE flash entity is allowed per grid at a time.
+    /// Intensity scales with total tritium present on the reacting tile.
+    /// Uses smooth lerping so the visual doesn't pop between ticks.
+    /// </summary>
+    public void SpawnRadiationPulse(TileAtmosphere tile, float tritiumMoles)
+    {
+        if (!TryComp<MapGridComponent>(tile.GridIndex, out var grid))
+            return;
+
+        // Scale radiation intensity with tritium present. Cap at 15 rads/s.
+        var radIntensity = MathF.Min(tritiumMoles * 1f, 15f);
+        // Scale visual distortion with tritium. Range: 400 (moderate) to 3000 (dramatic).
+        var targetDistortion = MathF.Min(400f + tritiumMoles * 60f, 3000f);
+
+        // Only ONE visual entity per grid. Search for an existing flash to refresh.
+        var query = EntityQueryEnumerator<SingularityDistortionComponent, RadiationSourceComponent, TimedDespawnComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out var distortion, out var radSource, out var despawn, out var xform))
+        {
+            if (xform.GridUid == tile.GridIndex)
+            {
+                // Smooth lerp toward target intensity (fast rise, slower fall).
+                var lerpRate = targetDistortion > distortion.Intensity ? 0.4f : 0.15f;
+                distortion.Intensity = distortion.Intensity + (targetDistortion - distortion.Intensity) * lerpRate;
+                radSource.Intensity = radIntensity;
+                despawn.Lifetime = 6f;
+                Dirty(uid, distortion);
+                return;
+            }
+        }
+
+        // No existing flash on this grid — spawn a new one.
+        var coords = _mapSystem.GridTileToLocal(tile.GridIndex, grid, tile.GridIndices);
+        var flash = Spawn("ClF3TritiumFlash", coords);
+
+        if (TryComp<RadiationSourceComponent>(flash, out var newRadSource))
+            newRadSource.Intensity = radIntensity;
+
+        if (TryComp<SingularityDistortionComponent>(flash, out var newDistortion))
+        {
+            newDistortion.Intensity = targetDistortion;
+            Dirty(flash, newDistortion);
         }
     }
 }

--- a/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.ActionBlocker;
 using Content.Shared.Alert;
 using Content.Shared.Atmos;
 using Content.Shared.Atmos.Components;
+using Content.Shared.Damage;
 using Content.Shared.Damage.Systems;
 using Content.Shared.Database;
 using Content.Shared.FixedPoint;
@@ -71,6 +72,7 @@ namespace Content.Server.Atmos.EntitySystems
             SubscribeLocalEvent<FlammableComponent, StartCollideEvent>(OnCollide);
             SubscribeLocalEvent<FlammableComponent, IsHotEvent>(OnIsHot);
             SubscribeLocalEvent<FlammableComponent, TileFireEvent>(OnTileFire);
+            SubscribeLocalEvent<FlammableComponent, TileClF3ExposureEvent>(OnTileClF3Exposure);
             SubscribeLocalEvent<FlammableComponent, RejuvenateEvent>(OnRejuvenate);
             SubscribeLocalEvent<FlammableComponent, ResistFireAlertEvent>(OnResistFireAlert);
             Subs.SubscribeWithRelay<FlammableComponent, ExtinguishEvent>(OnExtinguishEvent);
@@ -247,6 +249,38 @@ namespace Content.Server.Atmos.EntitySystems
 
             if (tempDelta > maxTemp)
                 _fireEvents[ent] = tempDelta;
+        }
+
+        /// <summary>
+        /// Handles ClF3 oxidation exposure for flammable entities.
+        /// Applies Caustic + Heat damage scaled by ClF3 concentration.
+        /// Only affects entities that are AlwaysCombustible (organic/flammable materials).
+        /// </summary>
+        private void OnTileClF3Exposure(Entity<FlammableComponent> ent, ref TileClF3ExposureEvent args)
+        {
+            // Only oxidize materials that would realistically react — organic, flammable items.
+            // Metal structures, glass, etc. are not AlwaysCombustible and are spared.
+            if (!ent.Comp.AlwaysCombustible)
+                return;
+
+            // Damage scales with ClF3 concentration: more moles = faster destruction.
+            // Cap the scaling so it doesn't get absurd with huge volumes.
+            var moleScale = MathF.Min(args.Moles / 5f, 4f);
+
+            var damage = new DamageSpecifier
+            {
+                DamageDict =
+                {
+                    ["Caustic"] = FixedPoint2.New(3f * moleScale),
+                    ["Heat"] = FixedPoint2.New(2f * moleScale),
+                }
+            };
+
+            _damageableSystem.TryChangeDamage(ent.Owner, damage, interruptsDoAfters: false);
+
+            // ClF3 also ignites flammable materials.
+            if (!ent.Comp.OnFire)
+                Ignite(ent, ent, ent.Comp);
         }
 
         private void OnRejuvenate(EntityUid uid, FlammableComponent component, RejuvenateEvent args)

--- a/Content.Server/Atmos/EntitySystems/GasAnalyzerSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasAnalyzerSystem.cs
@@ -287,8 +287,7 @@ public sealed class GasAnalyzerSystem : EntitySystem
 
             if (mixture != null)
             {
-                var gasName = Loc.GetString(gas.Name);
-                gases.Add(new GasEntry(gasName, mixture[i], gas.Color));
+                gases.Add(new GasEntry(gas.Name, mixture[i], gas.Color));
             }
         }
 

--- a/Content.Server/Atmos/EntitySystems/GasTileOverlaySystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasTileOverlaySystem.cs
@@ -221,6 +221,11 @@ namespace Content.Server.Atmos.EntitySystems
 
             ThermalByte newByteTemp = new();
 
+            // Extract fire color as bytes from the hotspot's computed blended color.
+            var fireColorR = (byte)(tile.Hotspot.FireColor.R * 255);
+            var fireColorG = (byte)(tile.Hotspot.FireColor.G * 255);
+            var fireColorB = (byte)(tile.Hotspot.FireColor.B * 255);
+
             if (tile.Hotspot.Valid)
                 newByteTemp.SetTemperature(tile.Hotspot.Temperature);
             else if (!tile.Space && tile.Air?.TotalMoles <= 5f)
@@ -231,14 +236,15 @@ namespace Content.Server.Atmos.EntitySystems
             if (oldData.Equals(default))
             {
                 changed = true;
-                oldData = new GasOverlayData(tile.Hotspot.State, new byte[VisibleGasId.Length], newByteTemp);
+                oldData = new GasOverlayData(tile.Hotspot.State, new byte[VisibleGasId.Length], newByteTemp, fireColorR, fireColorG, fireColorB);
             }
             else if (oldData.FireState != tile.Hotspot.State ||
+                     oldData.FireColorR != fireColorR || oldData.FireColorG != fireColorG || oldData.FireColorB != fireColorB ||
                      Math.Abs(oldData.ByteGasTemperature.Value - newByteTemp.Value) > 1 || // Dirty Temperature when there is more then 1 byte difference. That should measure up to minimum 4 degreese difference, 6 degreese on average.
                      (oldData.ByteGasTemperature.Value != newByteTemp.Value && newByteTemp.Value > ThermalByte.TempResolution)) // change of special ThermalByte value
             {
                 changed = true;
-                oldData = new GasOverlayData(tile.Hotspot.State, oldData.Opacity, newByteTemp);
+                oldData = new GasOverlayData(tile.Hotspot.State, oldData.Opacity, newByteTemp, fireColorR, fireColorG, fireColorB);
             }
 
             if (tile is { Air: not null, NoGridTile: false })

--- a/Content.Server/Atmos/EntitySystems/GasTileOverlaySystem.cs
+++ b/Content.Server/Atmos/EntitySystems/GasTileOverlaySystem.cs
@@ -225,6 +225,7 @@ namespace Content.Server.Atmos.EntitySystems
             var fireColorR = (byte)(tile.Hotspot.FireColor.R * 255);
             var fireColorG = (byte)(tile.Hotspot.FireColor.G * 255);
             var fireColorB = (byte)(tile.Hotspot.FireColor.B * 255);
+            var fireColorA = (byte)(tile.Hotspot.FireColor.A * 255);
 
             if (tile.Hotspot.Valid)
                 newByteTemp.SetTemperature(tile.Hotspot.Temperature);
@@ -236,15 +237,15 @@ namespace Content.Server.Atmos.EntitySystems
             if (oldData.Equals(default))
             {
                 changed = true;
-                oldData = new GasOverlayData(tile.Hotspot.State, new byte[VisibleGasId.Length], newByteTemp, fireColorR, fireColorG, fireColorB);
+                oldData = new GasOverlayData(tile.Hotspot.State, new byte[VisibleGasId.Length], newByteTemp, fireColorR, fireColorG, fireColorB, fireColorA);
             }
             else if (oldData.FireState != tile.Hotspot.State ||
-                     oldData.FireColorR != fireColorR || oldData.FireColorG != fireColorG || oldData.FireColorB != fireColorB ||
+                     oldData.FireColorR != fireColorR || oldData.FireColorG != fireColorG || oldData.FireColorB != fireColorB || oldData.FireColorA != fireColorA ||
                      Math.Abs(oldData.ByteGasTemperature.Value - newByteTemp.Value) > 1 || // Dirty Temperature when there is more then 1 byte difference. That should measure up to minimum 4 degreese difference, 6 degreese on average.
                      (oldData.ByteGasTemperature.Value != newByteTemp.Value && newByteTemp.Value > ThermalByte.TempResolution)) // change of special ThermalByte value
             {
                 changed = true;
-                oldData = new GasOverlayData(tile.Hotspot.State, oldData.Opacity, newByteTemp, fireColorR, fireColorG, fireColorB);
+                oldData = new GasOverlayData(tile.Hotspot.State, oldData.Opacity, newByteTemp, fireColorR, fireColorG, fireColorB, fireColorA);
             }
 
             if (tile is { Air: not null, NoGridTile: false })

--- a/Content.Server/Atmos/Reactions/ChlorineFluorideProductionReaction.cs
+++ b/Content.Server/Atmos/Reactions/ChlorineFluorideProductionReaction.cs
@@ -5,13 +5,20 @@ using JetBrains.Annotations;
 
 namespace Content.Server.Atmos.Reactions
 {
+    /// <summary>
+    /// ClF3 synthesis: Cl2 + 3 F2 → 2 ClF3
+    /// Real-world ClF3 is produced industrially at ~250°C (523K) and is highly exothermic.
+    /// Formation enthalpy is approximately -163.2 kJ/mol of ClF3.
+    /// The reaction is prevented from running if a fire reaction already occurred this tick,
+    /// avoiding instant recombination of decomposition products.
+    /// </summary>
     [UsedImplicitly]
     [DataDefinition]
     public sealed partial class ChlorineFluorideProductionReaction : IGasReactionEffect
     {
         public ReactionResult React(GasMixture mixture, IGasMixtureHolder? holder, AtmosphereSystem atmosphereSystem, float heatScale)
         {
-            // Prevent immediate recombination into ClF3 if a fire reaction has just occurred this tick
+            // Prevent immediate recombination into ClF3 if a fire reaction has just occurred this tick.
             if (mixture.ReactionResults[(byte)GasReaction.Fire] != 0)
                 return ReactionResult.NoReaction;
 
@@ -22,6 +29,8 @@ namespace Content.Server.Atmos.Reactions
             var nCl2 = mixture.GetMoles(Gas.Chlorine);
             var nF2 = mixture.GetMoles(Gas.Fluorine);
 
+            // Stoichiometry: Cl2 + 3 F2 → 2 ClF3
+            // Limiting reagent: min(Cl2/1, F2/3)
             var limiting = MathF.Min(nCl2 / 1f, nF2 / 3f);
             var extent = limiting / Atmospherics.ClF3ProductionRate;
 
@@ -31,7 +40,8 @@ namespace Content.Server.Atmos.Reactions
                 mixture.AdjustMoles(Gas.Fluorine, -extent * 3f);
                 mixture.AdjustMoles(Gas.ChlorineTrifluoride, extent * 2f);
 
-                energyReleased = -325000f * extent * 2f;
+                // Exothermic: -163.2 kJ/mol of ClF3 formed (releases heat).
+                energyReleased = Atmospherics.ClF3FormationEnergy * extent * 2f;
                 energyReleased /= heatScale;
             }
 

--- a/Content.Server/Atmos/Reactions/ChlorineTrifluorideReaction.cs
+++ b/Content.Server/Atmos/Reactions/ChlorineTrifluorideReaction.cs
@@ -5,6 +5,20 @@ using JetBrains.Annotations;
 
 namespace Content.Server.Atmos.Reactions
 {
+    /// <summary>
+    /// ClF3 oxidation: ClF3 violently oxidizes any reactive gas it contacts.
+    /// Hypergolic — reacts on contact at room temperature, no ignition source needed.
+    ///
+    /// Per mole of ClF3 consumed, always produces 0.5 mol Cl₂ + 1.5 mol F₂ (toxic byproducts).
+    /// Additional oxidation products vary by target:
+    ///   WaterVapor → destroyed (2 ClF₃ per 3 H₂O)
+    ///   Hydrogen   → destroyed (ClF₃ per 1.5 H₂)
+    ///   Ammonia    → Nitrogen  (ClF₃ per NH₃, yields 0.5 N₂)
+    ///   Methane    → CO₂       (4 ClF₃ per 3 CH₄, yields 1 CO₂ per CH₄)
+    ///   Plasma     → CO₂       (ClF₃ per Plasma, yields 0.5 CO₂)
+    ///
+    /// Creates a hotspot on the tile representing the violent fire caused by oxidation.
+    /// </summary>
     [UsedImplicitly]
     [DataDefinition]
     public sealed partial class ChlorineTrifluorideReaction : IGasReactionEffect
@@ -17,49 +31,155 @@ namespace Content.Server.Atmos.Reactions
             var location = holder as TileAtmosphere;
             mixture.ReactionResults[(byte)GasReaction.Fire] = 0;
 
-            var initialCLF3Moles = mixture.GetMoles(Gas.ChlorineTrifluoride);
+            var initialClF3 = mixture.GetMoles(Gas.ChlorineTrifluoride);
+            if (initialClF3 < Atmospherics.GasMinMoles)
+                return ReactionResult.NoReaction;
 
-            // Use reaction temperature (hotspot preferred) and scale decomposition with temperature
+            var initialTritium = mixture.GetMoles(Gas.Tritium);
+
+
+            // Use hotspot temperature if available.
             var reactionTemperature = temperature;
             if (location?.Hotspot.Valid == true)
-            {
                 reactionTemperature = location.Hotspot.Temperature;
-            }
 
+            // ClF3 is hypergolic — scales from slow at room temp to full rate at 300°C.
             var temperatureScale = 0f;
-            if (reactionTemperature > Atmospherics.PlasmaUpperTemperature)
+            if (reactionTemperature > Atmospherics.ClF3OxidationUpperTemperature)
                 temperatureScale = 1f;
-            else if (reactionTemperature > Atmospherics.PlasmaMinimumBurnTemperature)
-                temperatureScale = (reactionTemperature - Atmospherics.PlasmaMinimumBurnTemperature) /
-                                   (Atmospherics.PlasmaUpperTemperature - Atmospherics.PlasmaMinimumBurnTemperature);
+            else if (reactionTemperature > Atmospherics.ClF3OxidationMinTemperature)
+                temperatureScale = (reactionTemperature - Atmospherics.ClF3OxidationMinTemperature) /
+                                   (Atmospherics.ClF3OxidationUpperTemperature - Atmospherics.ClF3OxidationMinTemperature);
 
-            var decompositionRate = initialCLF3Moles * 0.25f * temperatureScale; // increased for faster decomposition
+            if (temperatureScale <= 0f)
+                return ReactionResult.NoReaction;
 
-            if (decompositionRate > Atmospherics.MinimumHeatCapacity)
+            // Maximum ClF3 that can react this tick (for normal targets).
+            var remainingClF3 = initialClF3 * Atmospherics.ClF3OxidationRate * temperatureScale;
+            var totalClF3Consumed = 0f;
+
+            // Tritium is consumed FIRST with a separate, much larger budget.
+            // ClF3 + Tritium is fully hypergolic — no temperature scaling.
+            // Consumes up to 80% of available ClF3 per tick on tritium alone.
+            var tritiumBudget = initialClF3 * 0.8f;
+            var tritiumClF3Used = OxidizeGas(mixture, Gas.Tritium, ref tritiumBudget,
+                clf3PerTarget: 1f, product: Gas.WaterVapor, productPerTarget: 0.5f);
+            // Tritium oxidation also produces Hydrogen as a byproduct.
+            if (tritiumClF3Used > 0f)
+                mixture.AdjustMoles(Gas.Hydrogen, tritiumClF3Used * 0.5f);
+            totalClF3Consumed += tritiumClF3Used;
+            // Reduce the normal budget by whatever was used on tritium.
+            remainingClF3 = MathF.Max(0f, remainingClF3 - tritiumClF3Used);
+
+            // ClF3 oxidizes remaining target gases in priority order.
+            // WaterVapor: 2 ClF₃ + 3 H₂O → byproducts. ClF3 per H₂O = 2/3.
+            totalClF3Consumed += OxidizeGas(mixture, Gas.WaterVapor, ref remainingClF3,
+                clf3PerTarget: 2f / 3f, product: null, productPerTarget: 0f);
+
+            // Hydrogen: ClF₃ + 1.5 H₂ → byproducts. ClF3 per H₂ = 1/1.5.
+            totalClF3Consumed += OxidizeGas(mixture, Gas.Hydrogen, ref remainingClF3,
+                clf3PerTarget: 1f / 1.5f, product: null, productPerTarget: 0f);
+
+            // Ammonia: ClF₃ + NH₃ → 0.5 N₂. ClF3 per NH₃ = 1.
+            totalClF3Consumed += OxidizeGas(mixture, Gas.Ammonia, ref remainingClF3,
+                clf3PerTarget: 1f, product: Gas.Nitrogen, productPerTarget: 0.5f);
+
+            // Methane: 4 ClF₃ + 3 CH₄ → 3 CO₂. ClF3 per CH₄ = 4/3.
+            totalClF3Consumed += OxidizeGas(mixture, Gas.Methane, ref remainingClF3,
+                clf3PerTarget: 4f / 3f, product: Gas.CarbonDioxide, productPerTarget: 1f);
+
+            // Plasma: ClF₃ + Plasma → 0.5 CO₂. ClF3 per Plasma = 1.
+            totalClF3Consumed += OxidizeGas(mixture, Gas.Plasma, ref remainingClF3,
+                clf3PerTarget: 1f, product: Gas.CarbonDioxide, productPerTarget: 0.5f);
+
+            if (totalClF3Consumed > Atmospherics.GasMinMoles)
             {
-                mixture.SetMoles(Gas.ChlorineTrifluoride, initialCLF3Moles - decompositionRate);
-                mixture.AdjustMoles(Gas.Chlorine, decompositionRate * 0.5f);
-                mixture.AdjustMoles(Gas.Fluorine, decompositionRate * 1.5f);
+                // Remove consumed ClF3 and produce toxic byproducts.
+                mixture.AdjustMoles(Gas.ChlorineTrifluoride, -totalClF3Consumed);
+                mixture.AdjustMoles(Gas.Chlorine, totalClF3Consumed * 0.5f);
+                mixture.AdjustMoles(Gas.Fluorine, totalClF3Consumed * 1.5f);
 
-                // Release ~=319 kJ per mole of ClF3 decomposed (exothermic)
-                energyReleased = 319000f * decompositionRate;
+                // Base oxidation energy for non-tritium targets.
+                var nonTritiumClF3 = totalClF3Consumed - tritiumClF3Used;
+                energyReleased = Atmospherics.ClF3OxidationEnergy * nonTritiumClF3;
+
+                // ClF3 + Tritium is far more energetic — radiative flash.
+                energyReleased += Atmospherics.ClF3TritiumEnergy * tritiumClF3Used;
+
                 energyReleased /= heatScale;
-                mixture.ReactionResults[(byte)GasReaction.Fire] = decompositionRate * 1.5f;
+                mixture.ReactionResults[(byte)GasReaction.Fire] = totalClF3Consumed;
             }
 
-            if (energyReleased != 0f)
+            if (energyReleased > 0f)
             {
                 var newHeatCapacity = atmosphereSystem.GetHeatCapacity(mixture, true);
                 if (newHeatCapacity > Atmospherics.MinimumHeatCapacity)
                     mixture.Temperature = (temperature * oldHeatCapacity + energyReleased) / newHeatCapacity;
             }
 
-            if (location != null && decompositionRate > Atmospherics.MinimumHeatCapacity)
+            // ClF3 oxidation causes fire on the tile.
+            if (location != null && totalClF3Consumed > Atmospherics.GasMinMoles)
             {
                 atmosphereSystem.HotspotExpose(location, mixture.Temperature, mixture.Volume);
             }
 
-            return mixture.ReactionResults[(byte)GasReaction.Fire] != 0 ? (ReactionResult.Reacting | ReactionResult.StopReactions) : ReactionResult.NoReaction;
+            // ClF3 corrodes items on contact regardless of whether gases were consumed.
+            // Even without target gases, ClF3 vapour attacks nearby materials.
+            if (location != null && temperatureScale > 0f)
+            {
+                atmosphereSystem.PerformClF3Exposure(location, initialClF3, reactionTemperature);
+            }
+
+            // ClF3 + Tritium produces a radiation pulse — the fluorination of tritium
+            // releases intense ionizing radiation as a radiative flash.
+            // Pass the INITIAL tritium on the tile, not just the consumed amount,
+            // so the visual/radiation scales with the actual tritium present.
+            if (location != null && tritiumClF3Used > Atmospherics.GasMinMoles)
+            {
+                atmosphereSystem.SpawnRadiationPulse(location, initialTritium);
+            }
+
+            if (totalClF3Consumed <= Atmospherics.GasMinMoles)
+                return ReactionResult.NoReaction;
+
+            // When ClF3 oxidizes tritium, it dominates all chemistry on the tile.
+            // Prevent TritiumFire from competing for the remaining tritium.
+            if (tritiumClF3Used > Atmospherics.GasMinMoles)
+                return ReactionResult.Reacting | ReactionResult.StopReactions;
+
+            return ReactionResult.Reacting;
+        }
+
+        /// <summary>
+        /// Attempts to oxidize a target gas with ClF3. Consumes the target and deducts from
+        /// the remaining ClF3 budget. Returns the amount of ClF3 consumed.
+        /// </summary>
+        private static float OxidizeGas(
+            GasMixture mixture,
+            Gas target,
+            ref float remainingClF3,
+            float clf3PerTarget,
+            Gas? product,
+            float productPerTarget)
+        {
+            if (remainingClF3 < Atmospherics.GasMinMoles)
+                return 0f;
+
+            var targetMoles = mixture.GetMoles(target);
+            if (targetMoles < Atmospherics.GasMinMoles)
+                return 0f;
+
+            // How much target can we oxidize with remaining ClF3?
+            var maxTargetByClF3 = remainingClF3 / clf3PerTarget;
+            var targetConsumed = MathF.Min(targetMoles, maxTargetByClF3);
+            var clf3Consumed = targetConsumed * clf3PerTarget;
+
+            mixture.AdjustMoles(target, -targetConsumed);
+            if (product.HasValue && productPerTarget > 0f)
+                mixture.AdjustMoles(product.Value, targetConsumed * productPerTarget);
+
+            remainingClF3 -= clf3Consumed;
+            return clf3Consumed;
         }
     }
 }

--- a/Content.Server/Atmos/Reactions/HydrogenFireReaction.cs
+++ b/Content.Server/Atmos/Reactions/HydrogenFireReaction.cs
@@ -44,7 +44,7 @@ namespace Content.Server.Atmos.Reactions
                 // 2H2 + O2 -> 2H2O
                 var TMin = Atmospherics.PlasmaMinimumBurnTemperature;
                 var Tsen = 200f;
-                var baseRate = 0.06f; // increased for faster burn
+                var baseRate = 0.03f; // slower per-mole rate; H2 needs only 0.5 O2 so still burns fast overall
 
                 var hydrogenBurnRate = 0f;
 

--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -230,7 +230,12 @@ namespace Content.Shared.Atmos
         ///     Amount of heat released per mole of burnt methane (real-life: 890 kJ/mol, scaled for game balance)
         /// </summary>
         public const float FireMethaneEnergyReleased = 560e3f; // methane is 560 kJ/mol
-        public const float FireHydrogenEnergyReleased = 284e4f;
+
+        /// <summary>
+        ///     Amount of heat released per mole of burnt hydrogen (real-life: ~286 kJ/mol).
+        ///     Also used as the base energy for tritium combustion (tritium applies a 10× multiplier).
+        /// </summary>
+        public const float FireHydrogenEnergyReleased = 286e3f;
         public const float FireMinimumTemperatureToExist = T0C + 100f;
         public const float FireMinimumTemperatureToSpread = T0C + 150f;
         public const float FireSpreadRadiosityScale = 0.85f;
@@ -309,6 +314,43 @@ namespace Content.Shared.Atmos
         ///     4 means up to 25% of limiting reagent per tick.
         /// </summary>
         public const float ClF3ProductionRate = 4f;
+
+        /// <summary>
+        ///     Formation enthalpy of ClF3, approximately 163.2 kJ/mol.
+        ///     Positive value here because the reaction is exothermic (releases heat).
+        ///     Used by the ClF3 production (synthesis) reaction.
+        /// </summary>
+        public const float ClF3FormationEnergy = 163000f;
+
+        /// <summary>
+        ///     Minimum temperature (K) for ClF3 oxidation reactions to begin.
+        ///     ~-20°C (253 K) — ClF3 is hypergolic; reacts well below room temperature.
+        /// </summary>
+        public const float ClF3OxidationMinTemperature = T0C - 20f;
+
+        /// <summary>
+        ///     Temperature (K) at which ClF3 oxidation reaches full rate.
+        ///     ~300°C (573 K).
+        /// </summary>
+        public const float ClF3OxidationUpperTemperature = T0C + 300f;
+
+        /// <summary>
+        ///     Maximum fraction of ClF3 that reacts per tick at full temperature.
+        /// </summary>
+        public const float ClF3OxidationRate = 0.25f;
+
+        /// <summary>
+        ///     Energy released per mole of ClF3 consumed during oxidation (~400 kJ/mol).
+        ///     ClF3 oxidation reactions are extremely exothermic.
+        /// </summary>
+        public const float ClF3OxidationEnergy = 400000f;
+
+        /// <summary>
+        ///     Energy released per mole of ClF3 consumed when oxidizing Tritium (~2000 kJ/mol).
+        ///     The radiative fluorination of tritium is extraordinarily energetic,
+        ///     producing a massive thermal and radiation burst.
+        /// </summary>
+        public const float ClF3TritiumEnergy = 2000000f;
 
         /// <summary>
         ///     Divisor for Ammonia Oxygen reaction so that it doesn't happen instantaneously.

--- a/Content.Shared/Atmos/EntitySystems/SharedAtmosphereSystem.Gases.cs
+++ b/Content.Shared/Atmos/EntitySystems/SharedAtmosphereSystem.Gases.cs
@@ -2,6 +2,7 @@ using Content.Shared.Atmos.Prototypes;
 using Content.Shared.Atmos.Reactions;
 using Content.Shared.CCVar;
 using JetBrains.Annotations;
+using Robust.Shared.Maths;
 using System.Runtime.CompilerServices;
 
 namespace Content.Shared.Atmos.EntitySystems;
@@ -104,6 +105,49 @@ public abstract partial class SharedAtmosphereSystem
     public void GetFlammableMoles(GasMixture mixture, float[] buffer)
     {
         NumericsHelpers.Multiply(mixture.Moles, GasOxidiserFuelMask, buffer);
+    }
+
+    /// <summary>
+    /// Computes the blended fire color for a gas mixture based on the proportional
+    /// moles of each reactive gas present (fuels and oxidizers with burn colors).
+    /// Each gas contributes its <see cref="GasPrototype.BurnColor"/> weighted by mole fraction.
+    /// </summary>
+    /// <param name="mixture">The <see cref="GasMixture"/> to compute fire color for.</param>
+    /// <returns>A blended <see cref="Color"/> representing the combined burn colors.</returns>
+    [PublicAPI]
+    public Color GetFuelBurnColor(GasMixture mixture)
+    {
+        var defaultColor = Color.FromHex("#FFB733");
+        var totalMoles = 0f;
+        var r = 0f;
+        var g = 0f;
+        var b = 0f;
+
+        for (var i = 0; i < Atmospherics.TotalNumberOfGases; i++)
+        {
+            // Include fuels and oxidizers that have a non-default burn color.
+            if (GasFuelMask[i] == 0 && GasOxidizerMask[i] == 0)
+                continue;
+
+            var moles = mixture.GetMoles(i);
+            if (moles <= Atmospherics.Epsilon)
+                continue;
+
+            var burnColor = GasPrototypes[i].BurnColor;
+            // Skip gases still using the default color — they shouldn't tint the fire.
+            if (burnColor == defaultColor)
+                continue;
+
+            totalMoles += moles;
+            r += burnColor.R * moles;
+            g += burnColor.G * moles;
+            b += burnColor.B * moles;
+        }
+
+        if (totalMoles <= Atmospherics.Epsilon)
+            return defaultColor;
+
+        return new Color(r / totalMoles, g / totalMoles, b / totalMoles);
     }
 
     /// <summary>

--- a/Content.Shared/Atmos/EntitySystems/SharedAtmosphereSystem.Gases.cs
+++ b/Content.Shared/Atmos/EntitySystems/SharedAtmosphereSystem.Gases.cs
@@ -110,22 +110,20 @@ public abstract partial class SharedAtmosphereSystem
     /// <summary>
     /// Computes the blended fire color for a gas mixture based on the proportional
     /// moles of each reactive gas present (fuels and oxidizers with burn colors).
-    /// Each gas contributes its <see cref="GasPrototype.BurnColor"/> weighted by mole fraction.
+    /// Mixing is performed in Oklab perceptual color space for smooth, natural blends.
     /// </summary>
-    /// <param name="mixture">The <see cref="GasMixture"/> to compute fire color for.</param>
-    /// <returns>A blended <see cref="Color"/> representing the combined burn colors.</returns>
     [PublicAPI]
     public Color GetFuelBurnColor(GasMixture mixture)
     {
         var defaultColor = Color.FromHex("#FFB733");
         var totalMoles = 0f;
-        var r = 0f;
-        var g = 0f;
-        var b = 0f;
+        var labL = 0f;
+        var labA = 0f;
+        var labB = 0f;
+        var alpha = 0f;
 
         for (var i = 0; i < Atmospherics.TotalNumberOfGases; i++)
         {
-            // Include fuels and oxidizers that have a non-default burn color.
             if (GasFuelMask[i] == 0 && GasOxidizerMask[i] == 0)
                 continue;
 
@@ -134,20 +132,89 @@ public abstract partial class SharedAtmosphereSystem
                 continue;
 
             var burnColor = GasPrototypes[i].BurnColor;
-            // Skip gases still using the default color — they shouldn't tint the fire.
             if (burnColor == defaultColor)
                 continue;
 
+            SrgbToOklab(burnColor, out var gL, out var gA, out var gB);
             totalMoles += moles;
-            r += burnColor.R * moles;
-            g += burnColor.G * moles;
-            b += burnColor.B * moles;
+            labL += gL * moles;
+            labA += gA * moles;
+            labB += gB * moles;
+            alpha += burnColor.A * moles;
         }
 
         if (totalMoles <= Atmospherics.Epsilon)
             return defaultColor;
 
-        return new Color(r / totalMoles, g / totalMoles, b / totalMoles);
+        var result = OklabToSrgb(labL / totalMoles, labA / totalMoles, labB / totalMoles);
+        result.A = alpha / totalMoles;
+        return result;
+    }
+
+    /// <summary>
+    /// Converts an sRGB <see cref="Color"/> (0-1 floats) to Oklab (L, a, b).
+    /// </summary>
+    private static void SrgbToOklab(Color c, out float L, out float a, out float b)
+    {
+        // sRGB → linear
+        var lr = SrgbToLinear(c.R);
+        var lg = SrgbToLinear(c.G);
+        var lb = SrgbToLinear(c.B);
+
+        // Linear RGB → LMS
+        var l = 0.4122214708f * lr + 0.5363325363f * lg + 0.0514459929f * lb;
+        var m = 0.2119034982f * lr + 0.6806995451f * lg + 0.1073969566f * lb;
+        var s = 0.0883024619f * lr + 0.2817188376f * lg + 0.6299787005f * lb;
+
+        // Cube root
+        var lc = MathF.Cbrt(l);
+        var mc = MathF.Cbrt(m);
+        var sc = MathF.Cbrt(s);
+
+        // LMS → Oklab
+        L = 0.2104542553f * lc + 0.7936177850f * mc - 0.0040720468f * sc;
+        a = 1.9779984951f * lc - 2.4285922050f * mc + 0.4505937099f * sc;
+        b = 0.0259040371f * lc + 0.7827717662f * mc - 0.8086757660f * sc;
+    }
+
+    /// <summary>
+    /// Converts Oklab (L, a, b) back to an sRGB <see cref="Color"/>.
+    /// </summary>
+    private static Color OklabToSrgb(float L, float a, float b)
+    {
+        // Oklab → LMS (cube-root space)
+        var lc = L + 0.3963377774f * a + 0.2158037573f * b;
+        var mc = L - 0.1055613458f * a - 0.0638541728f * b;
+        var sc = L - 0.0894841775f * a - 1.2914855480f * b;
+
+        // Undo cube root
+        var l = lc * lc * lc;
+        var m = mc * mc * mc;
+        var s = sc * sc * sc;
+
+        // LMS → linear RGB
+        var lr = +4.0767416621f * l - 3.3077115913f * m + 0.2309699292f * s;
+        var lg = -1.2684380046f * l + 2.6097574011f * m - 0.3413193965f * s;
+        var lb = -0.0041960863f * l - 0.7034186147f * m + 1.7076147010f * s;
+
+        // linear → sRGB, clamped
+        return new Color(
+            LinearToSrgb(lr),
+            LinearToSrgb(lg),
+            LinearToSrgb(lb));
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static float SrgbToLinear(float c)
+    {
+        return c <= 0.04045f ? c / 12.92f : MathF.Pow((c + 0.055f) / 1.055f, 2.4f);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static float LinearToSrgb(float c)
+    {
+        c = Math.Clamp(c, 0f, 1f);
+        return c <= 0.0031308f ? c * 12.92f : 1.055f * MathF.Pow(c, 1f / 2.4f) - 0.055f;
     }
 
     /// <summary>

--- a/Content.Shared/Atmos/EntitySystems/SharedGasTileOverlaySystem.cs
+++ b/Content.Shared/Atmos/EntitySystems/SharedGasTileOverlaySystem.cs
@@ -70,7 +70,14 @@ public abstract class SharedGasTileOverlaySystem : EntitySystem
     {
         [ViewVariables] public readonly byte FireState;
         [ViewVariables] public readonly byte[] Opacity;
-        // TODO change fire color based on ByteTemp
+
+        /// <summary>
+        /// Fire color RGB, compressed to 3 bytes for networking.
+        /// Computed from the proportional mix of burning fuel gas colors.
+        /// </summary>
+        [ViewVariables] public readonly byte FireColorR;
+        [ViewVariables] public readonly byte FireColorG;
+        [ViewVariables] public readonly byte FireColorB;
 
         /// <summary>
         /// Network-synced air temperature, compressed to a single byte per tile for bandwidth optimization.
@@ -80,11 +87,14 @@ public abstract class SharedGasTileOverlaySystem : EntitySystem
         public readonly ThermalByte ByteGasTemperature;
 
 
-        public GasOverlayData(byte fireState, byte[] opacity, ThermalByte byteTemp)
+        public GasOverlayData(byte fireState, byte[] opacity, ThermalByte byteTemp, byte fireColorR = 255, byte fireColorG = 183, byte fireColorB = 51)
         {
             FireState = fireState;
             Opacity = opacity;
             ByteGasTemperature = byteTemp;
+            FireColorR = fireColorR;
+            FireColorG = fireColorG;
+            FireColorB = fireColorB;
         }
 
         public bool Equals(GasOverlayData other)
@@ -105,6 +115,9 @@ public abstract class SharedGasTileOverlaySystem : EntitySystem
             }
 
             if (ByteGasTemperature != other.ByteGasTemperature)
+                return false;
+
+            if (FireColorR != other.FireColorR || FireColorG != other.FireColorG || FireColorB != other.FireColorB)
                 return false;
 
             return true;

--- a/Content.Shared/Atmos/EntitySystems/SharedGasTileOverlaySystem.cs
+++ b/Content.Shared/Atmos/EntitySystems/SharedGasTileOverlaySystem.cs
@@ -72,12 +72,14 @@ public abstract class SharedGasTileOverlaySystem : EntitySystem
         [ViewVariables] public readonly byte[] Opacity;
 
         /// <summary>
-        /// Fire color RGB, compressed to 3 bytes for networking.
+        /// Fire color RGBA, compressed to 4 bytes for networking.
         /// Computed from the proportional mix of burning fuel gas colors.
+        /// Alpha controls fire sprite opacity (e.g. hydrogen burns nearly invisible).
         /// </summary>
         [ViewVariables] public readonly byte FireColorR;
         [ViewVariables] public readonly byte FireColorG;
         [ViewVariables] public readonly byte FireColorB;
+        [ViewVariables] public readonly byte FireColorA;
 
         /// <summary>
         /// Network-synced air temperature, compressed to a single byte per tile for bandwidth optimization.
@@ -87,7 +89,7 @@ public abstract class SharedGasTileOverlaySystem : EntitySystem
         public readonly ThermalByte ByteGasTemperature;
 
 
-        public GasOverlayData(byte fireState, byte[] opacity, ThermalByte byteTemp, byte fireColorR = 255, byte fireColorG = 183, byte fireColorB = 51)
+        public GasOverlayData(byte fireState, byte[] opacity, ThermalByte byteTemp, byte fireColorR = 255, byte fireColorG = 183, byte fireColorB = 51, byte fireColorA = 255)
         {
             FireState = fireState;
             Opacity = opacity;
@@ -95,6 +97,7 @@ public abstract class SharedGasTileOverlaySystem : EntitySystem
             FireColorR = fireColorR;
             FireColorG = fireColorG;
             FireColorB = fireColorB;
+            FireColorA = fireColorA;
         }
 
         public bool Equals(GasOverlayData other)
@@ -117,7 +120,7 @@ public abstract class SharedGasTileOverlaySystem : EntitySystem
             if (ByteGasTemperature != other.ByteGasTemperature)
                 return false;
 
-            if (FireColorR != other.FireColorR || FireColorG != other.FireColorG || FireColorB != other.FireColorB)
+            if (FireColorR != other.FireColorR || FireColorG != other.FireColorG || FireColorB != other.FireColorB || FireColorA != other.FireColorA)
                 return false;
 
             return true;

--- a/Content.Shared/Atmos/Hotspot.cs
+++ b/Content.Shared/Atmos/Hotspot.cs
@@ -1,3 +1,5 @@
+using Robust.Shared.Maths;
+
 namespace Content.Shared.Atmos;
 
 /// <summary>
@@ -6,6 +8,8 @@ namespace Content.Shared.Atmos;
 /// </summary>
 public struct Hotspot
 {
+    public Hotspot() { }
+
     /// <summary>
     /// Whether this hotspot is currently representing fire and needs to be processed.
     /// Set when the hotspot "becomes alight". This is never set to false
@@ -61,4 +65,11 @@ public struct Hotspot
     /// </summary>
     [ViewVariables]
     public Gas PrimaryFuel;
+
+    /// <summary>
+    /// The blended fire color computed from the proportional mix of burning fuel gases.
+    /// This is the color used to tint the greyscale fire sprite on the client.
+    /// </summary>
+    [ViewVariables]
+    public Color FireColor = Color.FromHex("#FFB733");
 }

--- a/Content.Shared/Atmos/Prototypes/GasPrototype.cs
+++ b/Content.Shared/Atmos/Prototypes/GasPrototype.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Chemistry.Reagent;
+using Robust.Shared.Maths;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
@@ -99,5 +100,13 @@ namespace Content.Shared.Atmos.Prototypes
         /// </summary>
         [DataField]
         public bool IsOxidizer;
+
+        /// <summary>
+        /// The color of fire produced when this gas burns as a fuel.
+        /// Used to tint the greyscale fire sprite. When multiple fuels burn
+        /// simultaneously, their colors are mixed proportionally by moles burned.
+        /// </summary>
+        [DataField]
+        public Robust.Shared.Maths.Color BurnColor = Robust.Shared.Maths.Color.FromHex("#FFB733");
     }
 }

--- a/Content.Shared/Atmos/TileClF3ExposureEvent.cs
+++ b/Content.Shared/Atmos/TileClF3ExposureEvent.cs
@@ -1,0 +1,10 @@
+namespace Content.Shared.Atmos;
+
+/// <summary>
+/// Event raised on an entity when it is on a tile containing Chlorine Trifluoride gas.
+/// ClF3 is a hypergolic oxidizer that violently corrodes most materials on contact.
+/// </summary>
+/// <param name="Moles">Amount of ClF3 present on the tile.</param>
+/// <param name="Temperature">Current temperature of the gas mixture.</param>
+[ByRefEvent]
+public readonly record struct TileClF3ExposureEvent(float Moles, float Temperature);

--- a/Content.Shared/Singularity/Components/SingularityDistortionComponent.cs
+++ b/Content.Shared/Singularity/Components/SingularityDistortionComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Atmos.EntitySystems;
 using Content.Shared.Singularity.EntitySystems;
 using Robust.Shared.GameStates;
 
@@ -5,7 +6,7 @@ namespace Content.Shared.Singularity.Components
 {
     [RegisterComponent, NetworkedComponent]
     [AutoGenerateComponentState]
-    [Access(typeof(SharedSingularitySystem))]
+    [Access(typeof(SharedSingularitySystem), typeof(SharedAtmosphereSystem))]
     public sealed partial class SingularityDistortionComponent : Component
     {
         [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]

--- a/Resources/Prototypes/Atmospherics/gases.yml
+++ b/Resources/Prototypes/Atmospherics/gases.yml
@@ -41,6 +41,7 @@
   reagent: Plasma
   pricePerMole: 0
   isFuel: true
+  burnColor: "#FF4500"
 
 - type: gas
   id: Tritium
@@ -54,6 +55,7 @@
   reagent: Tritium
   pricePerMole: 0.8
   isFuel: true
+  burnColor: "#33FF88"
 
 - type: gas
   id: WaterVapor
@@ -113,6 +115,8 @@
   color: B4D7FF
   reagent: Hydrogen
   pricePerMole: 0.5
+  isFuel: true
+  burnColor: "#6699FF"
 
 - type: gas
   id: Chlorine
@@ -151,6 +155,8 @@
   color: 8B7D6B
   reagent: Methane
   pricePerMole: 0.4
+  isFuel: true
+  burnColor: "#4488FF"
 
 - type: gas
   id: ChlorineTrifluoride
@@ -164,3 +170,5 @@
   color: FF6B35
   reagent: ChlorineTrifluoride
   pricePerMole: 3
+  isOxidizer: true
+  burnColor: "#CCFF66"

--- a/Resources/Prototypes/Atmospherics/gases.yml
+++ b/Resources/Prototypes/Atmospherics/gases.yml
@@ -116,7 +116,7 @@
   reagent: Hydrogen
   pricePerMole: 0.5
   isFuel: true
-  burnColor: "#6699FF"
+  burnColor: "#A1E6FF"
 
 - type: gas
   id: Chlorine

--- a/Resources/Prototypes/Atmospherics/gases.yml
+++ b/Resources/Prototypes/Atmospherics/gases.yml
@@ -116,7 +116,7 @@
   reagent: Hydrogen
   pricePerMole: 0.5
   isFuel: true
-  burnColor: "#A1E6FF"
+  burnColor: "#D4F1FF18"
 
 - type: gas
   id: Chlorine

--- a/Resources/Prototypes/Atmospherics/reactions.yml
+++ b/Resources/Prototypes/Atmospherics/reactions.yml
@@ -91,8 +91,8 @@
 
 - type: gasReaction
   id: ChlorineTrifluorideFire
-  priority: 10 # Extremely reactive, run before production to avoid instant recombination
-  minimumTemperature: 373.149
+  priority: 10 # Hypergolic oxidizer, runs before other reactions
+  minimumTemperature: 253.15 # -20°C — ClF3 is hypergolic, reacts well below room temp
   minimumRequirements:
     ChlorineTrifluoride: 0.01
   effects:
@@ -101,7 +101,7 @@
 - type: gasReaction
   id: ChlorineFluorideProduction
   priority: 2
-  minimumTemperature: 500 # Needs some heat to initiate
+  minimumTemperature: 523.15 # ~250°C, industrial synthesis temperature
   minimumRequirements:
     Chlorine: 0.01
     Fluorine: 0.01

--- a/Resources/Prototypes/Entities/Effects/radiation.yml
+++ b/Resources/Prototypes/Entities/Effects/radiation.yml
@@ -13,3 +13,25 @@
       collection:
         RadiationPulse
   - type: RadiationPulse
+
+# Gravitational-lensing shimmer + radiation source for ClF3+Tritium reactions.
+# Uses the singularity distortion shader with a visible point light.
+# Distortion intensity is overridden dynamically by code based on tritium amount.
+- type: entity
+  name: radiative flash
+  id: ClF3TritiumFlash
+  categories: [ HideSpawnMenu ]
+  description: The air shimmers with intense ionizing radiation.
+  components:
+  - type: RadiationSource
+    intensity: 3
+    slope: 1.0
+  - type: TimedDespawn
+    lifetime: 6
+  - type: SingularityDistortion
+    intensity: 800
+    falloffPower: 2.4
+  - type: PointLight
+    radius: 10
+    energy: 20
+    color: "#7DF9FF"


### PR DESCRIPTION
This started as a simple fix of my gas reactions for the Wizden upstream merge and it turned into uh, quite a bit more than that.

Adds:

Colorful burn reactions using the burnColor .yml field that mixes based on mol content of the tile (colorful rainbow fires of extreme danger!)

ClF3 (Chlorine Trifluoride) acts more true to life, as an extreme oxidizer and has unique interactions with almost every gas (violent combustion, and in the case of one gas, a unique interaction).

ClF3 formation requires 500c temps to merge. The production reaction is endothermic (takes heat away from the environment).

ClF3 is dangerous when touching anything


No, really, be afraid

<img width="1198" height="705" alt="Screenshot 2026-03-26 163753" src="https://github.com/user-attachments/assets/6c35bf94-ff30-47e1-9558-78cb99dfdc49" />

