### PR TITLE
change: Anomaly Generator Takes Phoron Alloy

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/anomaly_equipment.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/anomaly_equipment.yml
@@ -269,7 +269,7 @@
       tags:
         - Sheet
     materialWhiteList:
-    - Plasma
+    - Phoron
   - type: OreSiloClient
   - type: Fixtures
     fixtures:


### PR DESCRIPTION
What it says. Anomaly Generator now uses Phoron Alloy instead of Plasma.
