### PR TITLE
Lathe recipes for existing items

### DIFF
--- a/Resources/Locale/en-US/lathe/lathe-categories.ftl
+++ b/Resources/Locale/en-US/lathe/lathe-categories.ftl
@@ -7,6 +7,7 @@ lathe-category-parts = Parts
 lathe-category-tools = Tools
 lathe-category-weapons = Weapons
 lathe-category-bureaucracy = Bureaucracy
+lathe-category-religion = Religion
 
 # Biogen
 lathe-category-food = Food

--- a/Resources/Locale/en-US/lathe/lathe-categories.ftl
+++ b/Resources/Locale/en-US/lathe/lathe-categories.ftl
@@ -6,6 +6,7 @@ lathe-category-machines = Machines
 lathe-category-parts = Parts
 lathe-category-tools = Tools
 lathe-category-weapons = Weapons
+lathe-category-bureaucracy = Bureaucracy
 
 # Biogen
 lathe-category-food = Food

--- a/Resources/Locale/en-US/materials/materials.ftl
+++ b/Resources/Locale/en-US/materials/materials.ftl
@@ -18,6 +18,7 @@ materials-aluminium = aluminum
 materials-copper = copper
 materials-tin = tin
 materials-bronze = bronze
+materials-brass = brass
 
 # Other
 materials-biomass = biomass

--- a/Resources/Prototypes/Entities/Objects/Misc/fluff_lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/fluff_lights.yml
@@ -302,3 +302,13 @@
     materialComposition:
       Glass: 500
       Steel: 200
+
+- type: entity
+  parent: Floodlight
+  id: EmptyFloodlight
+  suffix: Empty
+  components:
+  - type: ItemSlots
+    slots:
+      cell_slot:
+        name: power-cell-slot-component-slot-name-default

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -140,6 +140,7 @@
     - PowerCellsStatic
     - ElectronicsStatic
     - CassetteTape
+    - ReligionStatic
   - type: EmagLatheRecipes
     emagStaticPacks:
     - SecurityAmmoStatic

--- a/Resources/Prototypes/Recipes/Lathes/Packs/buereaucracy.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/buereaucracy.yml
@@ -1,0 +1,17 @@
+## Static
+
+- type: latheRecipePack
+  id: PaperworkStatic
+  recipes:
+  - BoxFolderClipboardEmpty
+  - BoxFolderPlasticClipboardEmpty
+  - BlankPaper
+  - BoxFolderRedEmpty
+  - BoxFolderBlueEmpty
+  - BoxFolderYellowEmpty
+  - BoxFolderGreyEmpty
+  - BoxFolderBlackEmpty
+  - BoxFolderGreenEmpty
+  - DeskBell
+  - BrbSign
+  - BriefcaseBrown

--- a/Resources/Prototypes/Recipes/Lathes/Packs/cargo.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/cargo.yml
@@ -27,6 +27,7 @@
   - MineralScannerEmpty
   - AdvancedMineralScannerEmpty
   - OreBagOfHolding
+  - WeaponGrapplingGun
 
 - type: latheRecipePack
   id: CargoBoards

--- a/Resources/Prototypes/Recipes/Lathes/Packs/clothing.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/clothing.yml
@@ -483,6 +483,7 @@
   - ClothingNeckCloakPirateCap
   - ClothingNeckCloakCe
   - ClothingCloakCmo
+  - ClothingNeckCloakRd
   - ClothingNeckCloakHop
   - ClothingNeckCloakTrans
   - ClothingNeckCloakGoliathCloak
@@ -508,6 +509,7 @@
   - ClothingNeckMantle
   - ClothingNeckMantleQM
   - ClothingNeckMantleRD
+  - ClothingNeckMantleHOS
 
 - type: latheRecipePack
   id: Carpets

--- a/Resources/Prototypes/Recipes/Lathes/Packs/engineering.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/engineering.yml
@@ -29,6 +29,7 @@
   - OreBag
   - PlantBag
   - ClothingShoesSkates
+  - Floodlight
 
 - type: latheRecipePack
   id: AtmosStatic

--- a/Resources/Prototypes/Recipes/Lathes/Packs/service.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/service.yml
@@ -28,6 +28,8 @@
   - WetFloorSign
   - WireBrush
   - BSPAnchorKey
+  - KitchenKnife
+  - RollingPin
 
 - type: latheRecipePack
   id: ServiceBoardsStatic

--- a/Resources/Prototypes/Recipes/Lathes/Packs/service.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/service.yml
@@ -30,6 +30,7 @@
   - BSPAnchorKey
   - KitchenKnife
   - RollingPin
+  - BarberScissors
 
 - type: latheRecipePack
   id: ServiceBoardsStatic

--- a/Resources/Prototypes/Recipes/Lathes/Packs/service.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/service.yml
@@ -48,6 +48,18 @@
   - InvoicePrinterCircuitboard
   - IDComputerCircuitboard
 
+- type: latheRecipePack
+  id: ReligionStatic
+  recipes:
+  - Bible
+  - BibleDruid
+  - BibleCommunistManifesto
+  - BibleNarsie
+  - BibleNanoTrasen
+  - BibleHonk
+  - BibleRatvar
+
+
 ## Dynamic
 
 - type: latheRecipePack

--- a/Resources/Prototypes/Recipes/Lathes/Packs/service.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/service.yml
@@ -31,6 +31,7 @@
   - KitchenKnife
   - RollingPin
   - BarberScissors
+  - CigaretteFilter
 
 - type: latheRecipePack
   id: ServiceBoardsStatic

--- a/Resources/Prototypes/Recipes/Lathes/Packs/shared.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/shared.yml
@@ -47,13 +47,6 @@
   - CableHVCopperStack
 
 - type: latheRecipePack
-  id: PaperworkStatic
-  recipes:
-  - BoxFolderClipboardEmpty
-  - BoxFolderPlasticClipboardEmpty
-  - BlankPaper
-
-- type: latheRecipePack
   id: TowelsStatic # This is used for both the autolathe and the uniform printer, so "unique" towels that only HoP can print shouldn't be included!
   recipes:
   - TowelColorWhite

--- a/Resources/Prototypes/Recipes/Lathes/bureaucracy.yml
+++ b/Resources/Prototypes/Recipes/Lathes/bureaucracy.yml
@@ -1,0 +1,88 @@
+# Base Prototypes
+
+- type: latheRecipe
+  abstract: true
+  id: BaseFolderRecipe
+  categories:
+  - Bureaucracy
+  completetime: 2
+  materials:
+    Steel: 50
+    Plastic: 100
+
+# Recipes
+- type: latheRecipe
+  parent: BaseFolderRecipe
+  id: BoxFolderClipboardEmpty
+  result: BoxFolderClipboardEmpty
+  completetime: 2
+  materials:
+    Wood: 100
+    Steel: 50
+
+- type: latheRecipe
+  parent: BaseFolderRecipe
+  id: BoxFolderPlasticClipboardEmpty
+  result: BoxFolderPlasticClipboardEmpty
+
+- type: latheRecipe
+  parent: BaseFolderRecipe
+  id: BoxFolderRedEmpty
+  result: BoxFolderRedEmpty
+
+- type: latheRecipe
+  parent: BaseFolderRecipe
+  id: BoxFolderBlueEmpty
+  result: BoxFolderBlueEmpty
+
+- type: latheRecipe
+  parent: BaseFolderRecipe
+  id: BoxFolderYellowEmpty
+  result: BoxFolderYellowEmpty
+
+- type: latheRecipe
+  parent: BaseFolderRecipe
+  id: BoxFolderGreyEmpty
+  result: BoxFolderGreyEmpty
+
+- type: latheRecipe
+  parent: BaseFolderRecipe
+  id: BoxFolderBlackEmpty
+  result: BoxFolderBlackEmpty
+
+- type: latheRecipe
+  parent: BaseFolderRecipe
+  id: BoxFolderGreenEmpty
+  result: BoxFolderGreenEmpty
+
+- type: latheRecipe
+  parent: BaseFolderRecipe
+  id: BlankPaper
+  result: Paper
+  completetime: 2
+  materials:
+    Paper: 50
+
+- type: latheRecipe
+  parent: BaseFolderRecipe
+  id: DeskBell
+  result: DeskBell
+  completetime: 2
+  materials:
+    Steel: 100
+
+- type: latheRecipe
+  parent: BaseFolderRecipe
+  id: BrbSign
+  result: BrbSign
+  completetime: 2
+  materials:
+    Plastic: 50
+
+- type: latheRecipe
+  parent: BaseFolderRecipe
+  id: BriefcaseBrown
+  result: BriefcaseBrown
+  completetime: 2
+  materials:
+    Plastic: 500

--- a/Resources/Prototypes/Recipes/Lathes/categories.yml
+++ b/Resources/Prototypes/Recipes/Lathes/categories.yml
@@ -31,6 +31,9 @@
   id: Bureaucracy
   name: lathe-category-bureaucracy
 
+- type: latheCategory
+  id: Religion
+  name: lathe-category-religion
 # Biogen
 - type: latheCategory
   id: Food

--- a/Resources/Prototypes/Recipes/Lathes/categories.yml
+++ b/Resources/Prototypes/Recipes/Lathes/categories.yml
@@ -27,6 +27,10 @@
   id: Weapons
   name: lathe-category-weapons
 
+- type: latheCategory
+  id: Bureaucracy
+  name: lathe-category-bureaucracy
+
 # Biogen
 - type: latheCategory
   id: Food

--- a/Resources/Prototypes/Recipes/Lathes/clothing.yml
+++ b/Resources/Prototypes/Recipes/Lathes/clothing.yml
@@ -1892,6 +1892,11 @@
   id: ClothingNeckCloakHop
   result: ClothingNeckCloakHop
 
+- type: latheRecipe
+  parent: BaseCommandCoatRecipe
+  id: ClothingNeckCloakRd
+  result: ClothingNeckCloakRd
+
 # Mantles
 - type: latheRecipe
   parent: BaseCommandCoatRecipe
@@ -1927,6 +1932,11 @@
   parent: BaseCommandCoatRecipe
   id: ClothingNeckMantleRD
   result: ClothingNeckMantleRD
+
+- type: latheRecipe
+  parent: BaseCommandCoatRecipe
+  id: ClothingNeckMantleHOS
+  result: ClothingNeckMantleHOS
 
 # Military
 - type: latheRecipe

--- a/Resources/Prototypes/Recipes/Lathes/cooking.yml
+++ b/Resources/Prototypes/Recipes/Lathes/cooking.yml
@@ -114,3 +114,11 @@
   completetime: 0.4
   materials:
     Steel: 100
+
+- type: latheRecipe
+  parent: BaseToolRecipe
+  id: RollingPin
+  result: RollingPin
+  materials:
+    Wood: 200
+    Steel: 50

--- a/Resources/Prototypes/Recipes/Lathes/devices.yml
+++ b/Resources/Prototypes/Recipes/Lathes/devices.yml
@@ -231,18 +231,6 @@
     Silver: 100
 
 - type: latheRecipe
-  id: WeaponGrapplingGun
-  result: WeaponGrapplingGun
-  categories:
-  - Tools
-  completetime: 5
-  materials:
-    Steel: 500
-    Glass: 400
-    Gold: 100
-  unlockUses: 4
-
-- type: latheRecipe
   id: CableDetStack1
   result: CableDetStack1
   categories:

--- a/Resources/Prototypes/Recipes/Lathes/misc.yml
+++ b/Resources/Prototypes/Recipes/Lathes/misc.yml
@@ -10,6 +10,15 @@
     Steel: 50
     Glass: 200
 
+- type: latheRecipe
+  abstract: true
+  id: BaseBibleRecipe
+  categories:
+  - Religion
+  completetime: 2
+  materials:
+    Paper: 500
+    Plastic: 100
 # Recipes
 
 ## Lights
@@ -247,3 +256,43 @@
   materials:
     Steel: 500
     Glass: 300
+
+# Bibles
+
+- type: latheRecipe
+  parent: BaseBibleRecipe
+  id: Bible
+  result: Bible
+
+- type: latheRecipe
+  parent: BaseBibleRecipe
+  id: BibleDruid
+  result: BibleDruid
+
+- type: latheRecipe
+  parent: BaseBibleRecipe
+  id: BibleCommunistManifesto
+  result: BibleCommunistManifesto
+
+- type: latheRecipe
+  parent: BaseBibleRecipe
+  id: BibleNarsie
+  result: BibleNarsie
+
+- type: latheRecipe
+  parent: BaseBibleRecipe
+  id: BibleNanoTrasen
+  result: BibleNanoTrasen
+
+- type: latheRecipe
+  parent: BaseBibleRecipe
+  id: BibleHonk
+  result: BibleHonk
+
+- type: latheRecipe
+  parent: BaseBibleRecipe
+  id: BibleRatvar
+  result: BibleRatvar
+  materials:
+    Brass: 550
+

--- a/Resources/Prototypes/Recipes/Lathes/misc.yml
+++ b/Resources/Prototypes/Recipes/Lathes/misc.yml
@@ -257,6 +257,13 @@
     Steel: 500
     Glass: 300
 
+- type: latheRecipe
+  parent: BaseToolRecipe
+  id: BarberScissors
+  result: BarberScissors
+  materials:
+    Steel: 200
+
 # Bibles
 
 - type: latheRecipe

--- a/Resources/Prototypes/Recipes/Lathes/misc.yml
+++ b/Resources/Prototypes/Recipes/Lathes/misc.yml
@@ -261,3 +261,12 @@
   completetime: 2
   materials:
     Cloth: 300
+
+- type: latheRecipe
+  parent: BaseLightRecipe
+  id: Floodlight
+  result: EmptyFloodlight
+  completetime: 2
+  materials:
+    Steel: 500
+    Glass: 300

--- a/Resources/Prototypes/Recipes/Lathes/misc.yml
+++ b/Resources/Prototypes/Recipes/Lathes/misc.yml
@@ -233,29 +233,6 @@
     Aluminium: 30
 
 - type: latheRecipe
-  id: BoxFolderClipboardEmpty
-  result: BoxFolderClipboardEmpty
-  completetime: 2
-  materials:
-    Wood: 100
-    Steel: 50
-
-- type: latheRecipe
-  id: BoxFolderPlasticClipboardEmpty
-  result: BoxFolderPlasticClipboardEmpty
-  completetime: 2
-  materials:
-    Plastic: 100
-    Steel: 50
-
-- type: latheRecipe
-  id: BlankPaper
-  result: Paper
-  completetime: 2
-  materials:
-    Paper: 50
-
-- type: latheRecipe
   id: TowelColorWhite
   result: TowelColorWhite
   completetime: 2

--- a/Resources/Prototypes/Recipes/Lathes/misc.yml
+++ b/Resources/Prototypes/Recipes/Lathes/misc.yml
@@ -264,6 +264,14 @@
   materials:
     Steel: 200
 
+- type: latheRecipe
+  id: CigaretteFilter
+  result: CigaretteFilter
+  completetime: 2
+  materials:
+    Paper: 20
+    Wood: 20
+
 # Bibles
 
 - type: latheRecipe

--- a/Resources/Prototypes/Recipes/Lathes/salvage.yml
+++ b/Resources/Prototypes/Recipes/Lathes/salvage.yml
@@ -110,3 +110,14 @@
     Silver: 500
   unlockUses: 2
 
+- type: latheRecipe
+  id: WeaponGrapplingGun
+  result: WeaponGrapplingGun
+  categories:
+  - Tools
+  completetime: 1
+  materials:
+    Steel: 500
+    Cloth: 500
+    Plastic: 100
+  unlockUses: 2

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -17,6 +17,7 @@
   - ClothingShoesBootsJump
   - ClothingHandsGlovesColorYellow
   - ClothingEyesGlassesMeson
+  - WeaponGrapplingGun
 
 - type: technology
   id: SpaceScanning


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds lathe recipes for floodlights, folders, briefcases, desk bells, brb signs, kitchen knives, rolling pins, 7 different bibles, barber scissors, and cigarette filters
Also adds missing recipes for HoS mantle and RD cloak
Adds grappling gun to the existing salvage research and makes it available at the protolathe. 2 prints per research.

## Why / Balance
These items have a variety of uses in game and ordinarily acquirable through being mapped, or they ARE obtainable but only in bundles like the bureaucracy crate from cargo.
This PR allows these items to made at their respective lathes for easier access.
## Technical details
All YAML. Gives brass a proper locale material name like every other material. Creates two new categories for lathes (religion, bureaucracy)

## Media
<img width="772" height="377" alt="image" src="https://github.com/user-attachments/assets/6abba518-5fab-45b9-a510-a5ccfb80bf99" />
<img width="353" height="291" alt="Screenshot 2026-03-28 164203" src="https://github.com/user-attachments/assets/85671fe2-4f26-4beb-b790-2217a1bda27a" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A