### PR TITLE
Borgs can enter cryo

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -252,6 +252,7 @@
     requiredMobState:
     - Critical
     - Dead
+  - type: CanEnterCryostorage
 
 - type: entity
   abstract: true


### PR DESCRIPTION
Requested by Koollan,

### Technical:
Added "CanEnterCryostorage" component to BorgChasssNotIonStormable

### Why:
Now borg players can at the very least enter cryo storage to save, albeit they still must change their characters name to reload.