### PR TITLE
feat: Populated PayPer Bounties and Gas Purchasing Rebalance

### DIFF
--- a/Resources/Maps/Shuttles/trading_outpost_engineering.yml
+++ b/Resources/Maps/Shuttles/trading_outpost_engineering.yml
@@ -1,6 +1,6 @@
 meta:
   format: 7
-  category: Map
+  category: Grid
   engineVersion: 270.0.0
   forkId: pss14
   forkVersion: a42b6c65cecbf5d6276e9bd7fb3019060a22f20b

--- a/Resources/Prototypes/Catalog/Bounties/bounties.yml
+++ b/Resources/Prototypes/Catalog/Bounties/bounties.yml
@@ -1,24 +1,277 @@
 - type: cargoBounty
-  id: BountyOxygen
+  id: BountyOxygenETS
   reward: 0.6
   description: bounty-description-artifact
   gasId: Oxygen
-  group: ScienceBounty
+  group: EngineeringBounty
   bountyType: PayPerGas
   entries:
   - name: Oxygen
     amount: 10000
 
 - type: cargoBounty
-  id: BountyWeldingFuel
+  id: BountyOxygen
+  reward: 0.55
+  description: bounty-description-artifact
+  gasId: Oxygen
+  group: StationBounty
+  bountyType: PayPerGas
+  entries:
+  - name: Oxygen
+    amount: 10000
+
+- type: cargoBounty
+  id: BountyNitrogenETS
+  reward: 0.6
+  description: bounty-description-artifact
+  gasId: Nitrogen
+  group: EngineeringBounty
+  bountyType: PayPerGas
+  entries:
+  - name: Nitrogen
+    amount: 10000
+
+- type: cargoBounty
+  id: BountyNitrogen
+  reward: 0.5
+  description: bounty-description-artifact
+  gasId: Nitrogen
+  group: StationBounty
+  bountyType: PayPerGas
+  entries:
+  - name: Nitrogen
+    amount: 10000
+
+- type: cargoBounty
+  id: BountyHydrogen
+  reward: 0.75
+  description: bounty-description-artifact
+  gasId: Hydrogen
+  group: EngineeringBounty
+  bountyType: PayPerGas
+  entries:
+  - name: Hydrogen
+    amount: 10000
+
+- type: cargoBounty
+  id: BountyPlasmaGas
+  reward: 0.75
+  description: bounty-description-artifact
+  gasId: Plasma
+  group: EngineeringBounty
+  bountyType: PayPerGas
+  entries:
+  - name: Plasma
+    amount: 12500
+
+- type: cargoBounty
+  id: BountyPlasmaGasETS
+  reward: 0.8
+  description: bounty-description-artifact
+  gasId: Plasma
+  group: EngineeringBounty
+  bountyType: PayPerGas
+  entries:
+  - name: Plasma
+    amount: 12500
+
+- type: cargoBounty
+  id: BountyChlorine
+  reward: 2.25
+  description: bounty-description-artifact
+  gasId: Chlorine
+  group: EngineeringBounty
+  bountyType: PayPerGas
+  entries:
+  - name: Chlorine
+    amount: 2500
+
+- type: cargoBounty
+  id: BountyFluorine
+  reward: 2.5
+  description: bounty-description-artifact
+  gasId: Fluorine
+  group: EngineeringBounty
+  bountyType: PayPerGas
+  entries:
+  - name: Fluorine
+    amount: 2500
+
+- type: cargoBounty
+  id: BountyTritium
   reward: 5
   description: bounty-description-artifact
-  reagentId: WeldingFuel
+  gasId: Tritium
+  group: EngineeringBounty
+  bountyType: PayPerGas
+  entries:
+  - name: Tritium
+    amount: 2000
+
+- type: cargoBounty
+  id: BountyFrezon
+  reward: 10
+  description: bounty-description-artifact
+  gasId: Frezon
+  group: EngineeringBounty
+  bountyType: PayPerGas
+  entries:
+  - name: Frezon
+    amount: 1500
+
+- type: cargoBounty
+  id: BountyMethane
+  reward: 2.8
+  description: bounty-description-artifact
+  gasId: Methane
+  group: StationBounty
+  bountyType: PayPerGas
+  entries:
+  - name: Methane
+    amount: 3000
+
+- type: cargoBounty
+  id: BountyMethaneETS
+  reward: 3
+  description: bounty-description-artifact
+  gasId: Methane
+  group: EngineeringBounty
+  bountyType: PayPerGas
+  entries:
+  - name: Methane
+    amount: 3000
+
+- type: cargoBounty
+  id: BountyChlorineTrifluoride
+  reward: 12.5
+  description: bounty-description-artifact
+  gasId: ChlorineTrifluoride
+  group: EngineeringBounty
+  bountyType: PayPerGas
+  entries:
+  - name: ChlorineTrifluoride
+    amount: 1500
+
+- type: cargoBounty
+  id: BountyArtifactGlue
+  reward: 10
+  description: bounty-description-artifact
+  reagentId: ArtifactGlue
   group: ScienceBounty
+  bountyType: PayPerReagent
+  entries:
+  - name: Artifact Glue
+    amount: 1000
+
+- type: cargoBounty
+  id: BountyWeldingFuel
+  reward: 2.5
+  description: bounty-description-artifact
+  reagentId: WeldingFuel
+  group: StationBounty
   bountyType: PayPerReagent
   entries:
   - name: Welding Fuel
     amount: 1000
+
+- type: cargoBounty
+  id: BountyAcetone
+  reward: 4
+  description: bounty-description-artifact
+  reagentId: Acetone
+  group: StationBounty
+  bountyType: PayPerReagent
+  entries:
+  - name: Acetone
+    amount: 1000
+
+- type: cargoBounty
+  id: BountyArithrazine
+  reward: 15
+  description: bounty-description-artifact
+  reagentId: Arithrazine
+  group: StationBounty
+  bountyType: PayPerReagent
+  entries:
+  - name: Arithrazine
+    amount: 100
+
+- type: cargoBounty
+  id: BountyEpinephrine
+  reward: 10
+  description: bounty-description-artifact
+  reagentId: Epinephrine
+  group: StationBounty
+  bountyType: PayPerReagent
+  entries:
+  - name: Epinephrine
+    amount: 200
+
+- type: cargoBounty
+  id: BountyUnstableMutagen
+  reward: 30
+  description: bounty-description-artifact
+  reagentId: UnstableMutagen
+  group: ServiceBounty
+  bountyType: PayPerReagent
+  entries:
+  - name: Unstable Mutagen
+    amount: 250
+
+- type: cargoBounty
+  id: BountyAmmonia
+  reward: 5
+  description: bounty-description-artifact
+  reagentId: Ammonia
+  group: ServiceBounty
+  bountyType: PayPerReagent
+  entries:
+  - name: Ammonia
+    amount: 500
+
+- type: cargoBounty
+  id: BountyFlour
+  reward: 5
+  description: bounty-description-artifact
+  reagentId: Flour
+  group: ServiceBounty
+  bountyType: PayPerReagent
+  entries:
+  - name: Flour
+    amount: 1500
+
+- type: cargoBounty
+  id: BountyCocoaPowder
+  reward: 7.5
+  description: bounty-description-artifact
+  reagentId: CocoaPowder
+  group: ServiceBounty
+  bountyType: PayPerReagent
+  entries:
+  - name: Cocoa Powder
+    amount: 1250
+
+- type: cargoBounty
+  id: BountyFrostOil
+  reward: 10
+  description: bounty-description-artifact
+  reagentId: FrostOil
+  group: ServiceBounty
+  bountyType: PayPerReagent
+  entries:
+  - name: Frost Oil
+    amount: 1000
+
+- type: cargoBounty
+  id: BountyOpporozidone
+  reward: 50
+  description: bounty-description-artifact
+  reagentId: Opporozidone
+  group: StationBounty
+  bountyType: PayPerReagent
+  entries:
+  - name: Opporozidone
+    amount: 250
 
 - type: cargoBounty
   id: BountyArtifactMany

--- a/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
@@ -14,7 +14,7 @@
     sprite: Structures/Storage/canister.rsi
     state: blue
   product: OxygenCanister
-  cost: 2000
+  cost: 2200
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -24,7 +24,7 @@
     sprite: Structures/Storage/canister.rsi
     state: blue
   product: LiquidOxygenCanister
-  cost: 3000
+  cost: 12500
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -34,7 +34,7 @@
     sprite: Structures/Storage/canister.rsi
     state: red
   product: NitrogenCanister
-  cost: 1500
+  cost: 1800
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -44,7 +44,7 @@
     sprite: Structures/Storage/canister.rsi
     state: red
   product: LiquidNitrogenCanister
-  cost: 2500
+  cost: 12500
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -54,7 +54,7 @@
     sprite: Structures/Storage/canister.rsi
     state: black
   product: CarbonDioxideCanister
-  cost: 1000 # even though it's poisonous, it comes locked and only damages you slowly even with high amounts (tested)
+  cost: 600 # even though it's poisonous, it comes locked and only damages you slowly even with high amounts (tested)
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -64,7 +64,17 @@
     sprite: Structures/Storage/canister.rsi
     state: black
   product: LiquidCarbonDioxideCanister
-  cost: 2250 # much less deadly than the plasma can (this has been tested) even though this is cold+poison
+  cost: 7000 # much less deadly than the plasma can (this has been tested) even though this is cold+poison
+  category: cargoproduct-category-name-atmospherics
+  group: market
+
+- type: cargoProduct
+  id: AtmosphericsWaterVapor
+  icon:
+    sprite: Structures/Storage/canister.rsi
+    state: water_vapor
+  product: WaterVaporCanister
+  cost: 400
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -74,19 +84,9 @@
     sprite: Structures/Storage/canister.rsi
     state: yellow
   product: StorageCanister
-  cost: 500 # No gases in it so it's cheaper
+  cost: 500 # No gases in it so it's cheaper# No gases in it so it's cheaper
   category: cargoproduct-category-name-atmospherics
   group: market
-
-#- type: cargoProduct
-#  id: AtmosphericsWaterVapor
-#  icon:
-#    sprite: Structures/Storage/canister.rsi
-#    state: water_vapor
-#  product: WaterVaporCanister
-#  cost: 2600
-#  category: cargoproduct-category-name-atmospherics
-#  group: market
 
 - type: cargoProduct
   id: AtmosphericsPlasma
@@ -128,7 +128,7 @@
   cost: 5000
   category: cargoproduct-category-name-engineering
   group: market
- 
+
 - type: cargoProduct
   id: TinyFanCargo
   icon:

--- a/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_materials.yml
@@ -149,7 +149,7 @@
     sprite: Structures/Storage/tanks.rsi
     state: fueltank
   product: WeldingFuelTankFull
-  cost: 1500
+  cost: 7500
   category: cargoproduct-category-name-materials
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/engineermarket.yml
+++ b/Resources/Prototypes/Catalog/Cargo/engineermarket.yml
@@ -114,7 +114,7 @@
     sprite: Structures/Storage/tanks.rsi
     state: fueltank
   product: WeldingFuelTankFull
-  cost: 1000
+  cost: 7500
   category: cargoproduct-category-name-materials
   group: engineermarket
 
@@ -304,7 +304,7 @@
     sprite: Structures/Storage/canister.rsi
     state: black
   product: CarbonDioxideCanister
-  cost: 500 # even though it's poisonous, it comes locked and only damages you slowly even with high amounts (tested)
+  cost: 600 # even though it's poisonous, it comes locked and only damages you slowly even with high amounts (tested)
   category: cargoproduct-category-name-atmospherics
   group: engineermarket
 
@@ -314,7 +314,7 @@
     sprite: Structures/Storage/canister.rsi
     state: black
   product: LiquidCarbonDioxideCanister
-  cost: 1125 # much less deadly than the plasma can (this has been tested) even though this is cold+poison
+  cost: 7000 # much less deadly than the plasma can (this has been tested) even though this is cold+poison
   category: cargoproduct-category-name-atmospherics
   group: engineermarket
 
@@ -328,15 +328,15 @@
   category: cargoproduct-category-name-atmospherics
   group: engineermarket
 
-#- type: cargoProduct
-#  id: AtmosphericsWaterVaporETS
-#  icon:
-#    sprite: Structures/Storage/canister.rsi
-#    state: water_vapor
-#  product: WaterVaporCanister
-#  cost: 1300
-#  category: cargoproduct-category-name-atmospherics
-#  group: engineermarket
+- type: cargoProduct
+  id: AtmosphericsWaterVaporETS
+  icon:
+    sprite: Structures/Storage/canister.rsi
+    state: water_vapor
+  product: WaterVaporCanister
+  cost: 400
+  category: cargoproduct-category-name-atmospherics
+  group: engineermarket
 
 - type: cargoProduct
   id: AtmosphericsPlasmaETS

--- a/Resources/Prototypes/Catalog/Cargo/explorermarket.yml
+++ b/Resources/Prototypes/Catalog/Cargo/explorermarket.yml
@@ -55,7 +55,7 @@
     sprite: Structures/Storage/canister.rsi
     state: grey
   product: AirCanister
-  cost: 1750
+  cost: 2500
   category: cargoproduct-category-name-atmospherics
   group: explorermarket
 
@@ -65,7 +65,7 @@
     sprite: Structures/Storage/canister.rsi
     state: blue
   product: OxygenCanister
-  cost: 1500
+  cost: 2200
   category: cargoproduct-category-name-atmospherics
   group: explorermarket
 
@@ -75,7 +75,7 @@
     sprite: Structures/Storage/canister.rsi
     state: blue
   product: LiquidOxygenCanister
-  cost: 2000
+  cost: 12500
   category: cargoproduct-category-name-atmospherics
   group: explorermarket
 
@@ -85,7 +85,7 @@
     sprite: Structures/Storage/canister.rsi
     state: red
   product: NitrogenCanister
-  cost: 1000
+  cost: 1800
   category: cargoproduct-category-name-atmospherics
   group: explorermarket
 
@@ -95,7 +95,7 @@
     sprite: Structures/Storage/canister.rsi
     state: red
   product: LiquidNitrogenCanister
-  cost: 1500
+  cost: 12500
   category: cargoproduct-category-name-atmospherics
   group: explorermarket
 
@@ -115,7 +115,17 @@
     sprite: Structures/Storage/canister.rsi
     state: black
   product: LiquidCarbonDioxideCanister
-  cost: 780 # much less deadly than the plasma can (this has been tested) even though this is cold+poison
+  cost: 7000 # much less deadly than the plasma can (this has been tested) even though this is cold+poison
+  category: cargoproduct-category-name-atmospherics
+  group: explorermarket
+
+- type: cargoProduct
+  id: AtmosphericsWaterVaporExTS
+  icon:
+    sprite: Structures/Storage/canister.rsi
+    state: water_vapor
+  product: WaterVaporCanister
+  cost: 400
   category: cargoproduct-category-name-atmospherics
   group: explorermarket
 
@@ -128,16 +138,6 @@
   cost: 350 # No gases in it so it's cheaper
   category: cargoproduct-category-name-atmospherics
   group: explorermarket
-
-#- type: cargoProduct
-#  id: AtmosphericsWaterVaporExTS
-#  icon:
-#    sprite: Structures/Storage/canister.rsi
-#    state: water_vapor
-#  product: WaterVaporCanister
-#  cost: 1300
-#  category: cargoproduct-category-name-atmospherics
-#  group: explorermarket
 
 - type: cargoProduct
   id: AtmosphericsPlasmaExTS


### PR DESCRIPTION
Populated a few bounties for the first look at our PayPer bounty system.

Adds:
All gasses have bounties
Some notable reagents have bounties
<img width="561" height="130" alt="image" src="https://github.com/user-attachments/assets/3d16d9d0-ecc5-47e4-ad91-0ee49ec43d2d" />

Changes:
Purchasing gas is much more expensive due to mols of gas being used for bounties and otherwise able to be exploited (liquid cans are much more expensive, normal cans, not so much)

Fixes:
Engineer trade station spawn prototype listed as map, now listed as grid, now able to be spawned


STILL NEEDED:
More reagent bounties of various types (science reagents and dangerous chems, didnt get to these due to a deadline)