### PR TITLE
fix: Phoron Alloy added Sheet tag for Anom Generator

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Materials/materials.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/materials.yml
@@ -452,6 +452,7 @@
       Phoron: 100
   - type: Tag
     tags:
+    - Sheet
     - RawMaterial
     - Phoron
 

--- a/Resources/Prototypes/Entities/Structures/Machines/anomaly_equipment.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/anomaly_equipment.yml
@@ -260,6 +260,7 @@
   - type: Physics
     bodyType: Static
   - type: AnomalyGenerator
+    requiredMaterial: Phoron
     generatingSound:
       path: /Audio/Machines/anomaly_generate.ogg
     generatingFinishedSound:


### PR DESCRIPTION
Fixed phoron not being used by the anomaly generator. Simple change, adds sheet tag and forces the anomaly generator to use phoron alone.
