### PR TITLE
Fix Grid Controller Board Prototype

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/computer.yml
@@ -107,7 +107,7 @@
     - type: Sprite
       state: cpu_supply
     - type: ComputerBoard
-      prototype: ComputerStationModification
+      prototype: ComputerGridControl
     - type: StaticPrice
       price: 90
 


### PR DESCRIPTION
Grid Controller board prototype listed: 'ComputerStationModification' instead of; 'ComputerGridControl'

This loong standing issue has been finally fixed.


