### PR TITLE
Updates to fix YAML linter's complaining

### DIFF
--- a/Resources/Locale/en-US/cargo/bounties.ftl
+++ b/Resources/Locale/en-US/cargo/bounties.ftl
@@ -133,6 +133,8 @@ bounty-item-flour = Flour
 bounty-item-cocoapowder = Cocoa Powder
 bounty-item-frostoil = Frost Oil
 bounty-item-opporozidone = Opporozidone
+bounty-item-liquid-desoxyephedrine = Liquid Desoxyephedrine
+bounty-item-liquid-space-mirage = Liquid Space Mirage
 
 bounty-description-artifact = NanoTrasen is in some hot water for stealing artifacts from non-spacefaring planets. Return one and we'll compensate you for it.
 bounty-description-baseball-bat = Baseball fever is going on at CentComm! Be a dear and ship them some baseball bats, so that management can live out their childhood dream.

--- a/Resources/Locale/en-US/guidebook/factions.ftl
+++ b/Resources/Locale/en-US/guidebook/factions.ftl
@@ -1,0 +1,17 @@
+Factions = Factions
+FactionCreation = Faction Creation
+FactionModification = Faction Modification
+TheThreshold = The Threshold
+MakingMoney = Making Money
+ThresholdCargo = Threshold Cargo
+ThresholdMiningHunting = Threshold Mining/Hunting
+ThresholdScience = Threshold Science
+Death = Death
+Achievements = Achievements
+GridControl = Grid Control
+AccessControl = Access Control
+Precursor = Precursor
+Dealer = Dealer
+BountyHunter = Bounty Hunter & Assassin
+PrecursorPurchases = Precursor Purchases
+SectorChaos = Sector Chaos

--- a/Resources/Prototypes/Catalog/Bounties/explorationbounties.yml
+++ b/Resources/Prototypes/Catalog/Bounties/explorationbounties.yml
@@ -1,7 +1,7 @@
-
 - type: cargoBounty
   id: BountyTechDisk
   reward: 2500
+  description: bounty-description-tech-disk
   idPrefix: SS13-
   entries:
   - name: bounty-item-tech-disk

--- a/Resources/Prototypes/Catalog/Bounties/gasbounties.yml
+++ b/Resources/Prototypes/Catalog/Bounties/gasbounties.yml
@@ -1,6 +1,7 @@
 - type: cargoBounty
   id: BountyOxygen
   reward: 0.55 # 9900
+  description: bounty-description-artifact
   gasId: Oxygen
   group: GasBounty
   bountyType: PayPerGas
@@ -11,6 +12,7 @@
 - type: cargoBounty
   id: BountyNitrogen
   reward: 0.5
+  description: bounty-description-artifact
   gasId: Nitrogen
   group: GasBounty
   bountyType: PayPerGas
@@ -21,6 +23,7 @@
 - type: cargoBounty
   id: BountyHydrogen
   reward: 0.75
+  description: bounty-description-artifact
   gasId: Hydrogen
   group: GasBounty
   bountyType: PayPerGas
@@ -31,6 +34,7 @@
 - type: cargoBounty
   id: BountyPlasmaGas
   reward: 0.75
+  description: bounty-description-artifact
   gasId: Plasma
   group: GasBounty
   bountyType: PayPerGas
@@ -41,6 +45,7 @@
 - type: cargoBounty
   id: BountyChlorine
   reward: 2.25
+  description: bounty-description-artifact
   gasId: Chlorine
   group: GasBounty
   bountyType: PayPerGas
@@ -51,6 +56,7 @@
 - type: cargoBounty
   id: BountyFluorine
   reward: 2.5
+  description: bounty-description-artifact
   gasId: Fluorine
   group: GasBounty
   bountyType: PayPerGas

--- a/Resources/Prototypes/Catalog/Bounties/precursor.yml
+++ b/Resources/Prototypes/Catalog/Bounties/precursor.yml
@@ -1,23 +1,25 @@
 - type: cargoBounty
   id: BountyPrecursorSpaceDrugs
   reward: 40
+  description: bounty-description-artifact
   reagentId: SpaceDrugs
   group: PrecursorBounty
   bountyType: PayPerReagent
   successXP: -200
   idPrefix: PREC-
   entries:
-  - name: Liquid Space Mirage
+  - name: bounty-item-liquid-space-mirage
     amount: 250
 
 - type: cargoBounty
   id: BountyPrecursorDesoxyephedrine
   reward: 50
+  description: bounty-description-artifact
   reagentId: Desoxyephedrine
   group: PrecursorBounty
   bountyType: PayPerReagent
   successXP: -200
   idPrefix: PREC-
   entries:
-  - name: Liquid Desoxyephedrine
+  - name: bounty-item-liquid-desoxyephedrine
     amount: 200

--- a/Resources/Prototypes/Catalog/Bounties/servicebounties.yml
+++ b/Resources/Prototypes/Catalog/Bounties/servicebounties.yml
@@ -134,6 +134,7 @@
 - type: cargoBounty
   id: BountyFlower
   reward: 660
+  description: bounty-description-flower
   idPrefix: CC
   entries:
   - name: bounty-item-flower

--- a/Resources/Prototypes/Catalog/Cargo/explorermarket.yml
+++ b/Resources/Prototypes/Catalog/Cargo/explorermarket.yml
@@ -393,7 +393,7 @@
   id: BulkPlantBGoneExTS
   icon:
     sprite: Objects/Specific/Chemistry/jug.rsi
-    state: jug
+    state: icon_empty
   product: CratePlantBGone
   cost: 2500
   category: cargoproduct-category-name-hydroponics

--- a/Resources/Prototypes/Catalog/Cargo/sciencemarket.yml
+++ b/Resources/Prototypes/Catalog/Cargo/sciencemarket.yml
@@ -142,7 +142,7 @@
   id: BulkPlantBGoneSTS
   icon:
     sprite: Objects/Specific/Chemistry/jug.rsi
-    state: jug
+    state: icon_empty
   product: CratePlantBGone
   cost: 2500
   category: cargoproduct-category-name-hydroponics

--- a/Resources/Prototypes/Catalog/Jukebox/Standard.yml
+++ b/Resources/Prototypes/Catalog/Jukebox/Standard.yml
@@ -77,7 +77,7 @@
     path: /Audio/Jukebox/dreaminginspace.ogg
 
 - type: jukebox
-  id: Welcome To The Threshold
+  id: welcometothethreshold
   name: mrjajkes - Welcome To The Threshold
   path:
     path: /Audio/Lobby/Welcome_To_The_Threshold.ogg

--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/human_hair.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/human_hair.yml
@@ -1214,7 +1214,6 @@
 - type: marking
   id: HumanHairCIA2
   bodyPart: Hair
-  markingCategory: Hair
   sprites:
     - sprite: Mobs/Customization/human_hair_persistence.rsi
       state: hair_cia2
@@ -1222,7 +1221,6 @@
 - type: marking
   id: HumanHairCIA3
   bodyPart: Hair
-  markingCategory: Hair
   sprites:
     - sprite: Mobs/Customization/human_hair_persistence.rsi
       state: hair_cia3
@@ -1230,7 +1228,6 @@
 - type: marking
   id: HumanHairCIA5
   bodyPart: Hair
-  markingCategory: Hair
   sprites:
     - sprite: Mobs/Customization/human_hair_persistence.rsi
       state: hair_cia5
@@ -1238,7 +1235,6 @@
 - type: marking
   id: HumanHairIRS
   bodyPart: Hair
-  markingCategory: Hair
   sprites:
     - sprite: Mobs/Customization/human_hair_persistence.rsi
       state: hair_irs
@@ -1246,7 +1242,6 @@
 - type: marking
   id: HumanHairFlatPressed
   bodyPart: Hair
-  markingCategory: Hair
   sprites:
     - sprite: Mobs/Customization/human_hair_persistence.rsi
       state: hair_flatpressed
@@ -1254,7 +1249,6 @@
 - type: marking
   id: HumanHairWaver
   bodyPart: Hair
-  markingCategory: Hair
   sprites:
     - sprite: Mobs/Customization/human_hair_persistence.rsi
       state: hair_waver
@@ -1262,7 +1256,6 @@
 - type: marking
   id: HumanHairElegant
   bodyPart: Hair
-  markingCategory: Hair
   sprites:
     - sprite: Mobs/Customization/human_hair_persistence.rsi
       state: hair_elegantbun
@@ -1270,7 +1263,6 @@
 - type: marking
   id: HumanHairLowBun
   bodyPart: Hair
-  markingCategory: Hair
   sprites:
     - sprite: Mobs/Customization/human_hair_persistence.rsi
       state: hair_low_bun
@@ -1278,7 +1270,6 @@
 - type: marking
   id: HumanHairLowBunAlt
   bodyPart: Hair
-  markingCategory: Hair
   sprites:
     - sprite: Mobs/Customization/human_hair_persistence.rsi
       state: hair_low_bun_alt
@@ -1286,7 +1277,6 @@
 - type: marking
   id: HumanHairLowPonyTail
   bodyPart: Hair
-  markingCategory: Hair
   sprites:
     - sprite: Mobs/Customization/human_hair_persistence.rsi
       state: hair_low_ponytail
@@ -1294,7 +1284,6 @@
 - type: marking
   id: HumanHairLowPonyTailAlt
   bodyPart: Hair
-  markingCategory: Hair
   sprites:
     - sprite: Mobs/Customization/human_hair_persistence.rsi
       state: hair_low_ponytail_alt

--- a/Resources/Prototypes/Guidebook/antagonist.yml
+++ b/Resources/Prototypes/Guidebook/antagonist.yml
@@ -1,59 +1,59 @@
-# - type: guideEntry
-#   id: Antagonists
-#   name: guide-entry-antagonists
-#   text: "/ServerInfo/Guidebook/Antagonist/Antagonists.xml"
-#   children:
-#   - Traitors
-#   - Thieves
-#   - Revolutionaries
-#   - NuclearOperatives
-#   - SpaceNinja
-#   - Wizard
-#   - Zombies
-#   - Xenoborgs
-#   - MinorAntagonists
+- type: guideEntry
+  id: Antagonists
+  name: guide-entry-antagonists
+  text: "/ServerInfo/Guidebook/Antagonist/Antagonists.xml"
+  children:
+  - Traitors
+  - Thieves
+  - Revolutionaries
+  - NuclearOperatives
+  - SpaceNinja
+  - Wizard
+  - Zombies
+  - Xenoborgs
+  - MinorAntagonists
 
-# - type: guideEntry
-#   id: Traitors
-#   name: guide-entry-traitors
-#   text: "/ServerInfo/Guidebook/Antagonist/Traitors.xml"
+- type: guideEntry
+  id: Traitors
+  name: guide-entry-traitors
+  text: "/ServerInfo/Guidebook/Antagonist/Traitors.xml"
 
-# - type: guideEntry
-#   id: NuclearOperatives
-#   name: guide-entry-nuclear-operatives
-#   text: "/ServerInfo/Guidebook/Antagonist/Nuclear Operatives.xml"
+- type: guideEntry
+  id: NuclearOperatives
+  name: guide-entry-nuclear-operatives
+  text: "/ServerInfo/Guidebook/Antagonist/Nuclear Operatives.xml"
 
-# - type: guideEntry
-#   id: Zombies
-#   name: guide-entry-zombies
-#   text: "/ServerInfo/Guidebook/Antagonist/Zombies.xml"
+- type: guideEntry
+  id: Zombies
+  name: guide-entry-zombies
+  text: "/ServerInfo/Guidebook/Antagonist/Zombies.xml"
 
-# - type: guideEntry
-#   id: Revolutionaries
-#   name: guide-entry-revolutionaries
-#   text: "/ServerInfo/Guidebook/Antagonist/Revolutionaries.xml"
+- type: guideEntry
+  id: Revolutionaries
+  name: guide-entry-revolutionaries
+  text: "/ServerInfo/Guidebook/Antagonist/Revolutionaries.xml"
 
-# - type: guideEntry
-#   id: MinorAntagonists
-#   name: guide-entry-minor-antagonists
-#   text: "/ServerInfo/Guidebook/Antagonist/MinorAntagonists.xml"
+- type: guideEntry
+  id: MinorAntagonists
+  name: guide-entry-minor-antagonists
+  text: "/ServerInfo/Guidebook/Antagonist/MinorAntagonists.xml"
 
-# - type: guideEntry
-#   id: SpaceNinja
-#   name: guide-entry-space-ninja
-#   text: "/ServerInfo/Guidebook/Antagonist/SpaceNinja.xml"
+- type: guideEntry
+  id: SpaceNinja
+  name: guide-entry-space-ninja
+  text: "/ServerInfo/Guidebook/Antagonist/SpaceNinja.xml"
 
-# - type: guideEntry
-#   id: Thieves
-#   name: guide-entry-thieves
-#   text: "/ServerInfo/Guidebook/Antagonist/Thieves.xml"
+- type: guideEntry
+  id: Thieves
+  name: guide-entry-thieves
+  text: "/ServerInfo/Guidebook/Antagonist/Thieves.xml"
 
-# - type: guideEntry
-#   id: Wizard
-#   name: guide-entry-wizard
-#   text: "/ServerInfo/Guidebook/Antagonist/Wizard.xml"
+- type: guideEntry
+  id: Wizard
+  name: guide-entry-wizard
+  text: "/ServerInfo/Guidebook/Antagonist/Wizard.xml"
 
-# - type: guideEntry
-#   id: Xenoborgs
-#   name: guide-entry-xenoborgs
-#   text: "/ServerInfo/Guidebook/Antagonist/Xenoborgs.xml"
+- type: guideEntry
+  id: Xenoborgs
+  name: guide-entry-xenoborgs
+  text: "/ServerInfo/Guidebook/Antagonist/Xenoborgs.xml"

--- a/Resources/Prototypes/Guidebook/factions.yml
+++ b/Resources/Prototypes/Guidebook/factions.yml
@@ -8,18 +8,18 @@
 
 - type: guideEntry
   id: FactionCreation
-  name: Faction Creation
+  name: FactionCreation
   text: "/ServerInfo/Guidebook/Persistence/FactionCreation.xml"
 
 - type: guideEntry
   id: FactionModification
-  name: Faction Modification
+  name: FactionModification
   text: "/ServerInfo/Guidebook/Persistence/FactionModification.xml"
 
 
 - type: guideEntry
   id: Threshold
-  name: The Threshold
+  name: TheThreshold
   text: "/ServerInfo/Guidebook/Persistence/Threshold.xml"
   children:
   - MakingMoney
@@ -33,22 +33,22 @@
 
 - type: guideEntry
   id: MakingMoney
-  name: Making Money
+  name: MakingMoney
   text: "/ServerInfo/Guidebook/Persistence/MakingMoney.xml"
 
 - type: guideEntry
   id: ThresholdCargo
-  name: Threshold Cargo
+  name: ThresholdCargo
   text: "/ServerInfo/Guidebook/Persistence/ThresholdCargo.xml"
 
 - type: guideEntry
   id: ThresholdMiningHunting
-  name: Threshold Mining/Hunting
+  name: ThresholdMiningHunting
   text: "/ServerInfo/Guidebook/Persistence/ThresholdMiningHunting.xml"
 
 - type: guideEntry
   id: ThresholdScience
-  name: Threshold Science
+  name: ThresholdScience
   text: "/ServerInfo/Guidebook/Persistence/ThresholdScience.xml"
 
 - type: guideEntry
@@ -63,12 +63,12 @@
 
 - type: guideEntry
   id: GridControl
-  name: Grid Control
+  name: GridControl
   text: "/ServerInfo/Guidebook/Persistence/GridControl.xml"
 
 - type: guideEntry
   id: AccessControl
-  name: Access Control
+  name: AccessControl
   text: "/ServerInfo/Guidebook/Persistence/AccessControl.xml"
 
 - type: guideEntry
@@ -88,15 +88,15 @@
 
 - type: guideEntry
   id: BountyHunter
-  name: Bounty Hunter & Assassin
+  name: BountyHunter
   text: "/ServerInfo/Guidebook/Persistence/Hunter.xml"
 
 - type: guideEntry
   id: Purchases
-  name: Precursor Purchases
+  name: PrecursorPurchases
   text: "/ServerInfo/Guidebook/Persistence/Purchases.xml"
 
 - type: guideEntry
   id: SectorChaos
-  name: Sector Chaos
+  name: SectorChaos
   text: "/ServerInfo/Guidebook/Persistence/SectorChaos.xml"


### PR DESCRIPTION
## About the PR
Modified/added a number of yml/ftl files to reduce YAML linter errors. Linter has no errors on my machine

## Technical details
Added missing bounty name localizations
Added localizations for faction guidebook entries and changed faction guidebook ids to work with the ftl file
Some bounty descriptions were disconnected from existing bounties, they should now be linked
Bounties with no descriptions had placeholders added. I don't think bounty descriptions are currently visible so I don't believe this should cause problems
Updated two image sources as the old sources appear to have been moved or deleted at some point
Removed markingCategory attribute from persistence additions to human_hair.yml. The markingCategory attribute is used in exactly one largely disconnected go file that was last updated 4 years ago and nowhere else, and furthermore nothing else in the human_hair.yml file has it. I don't believe this removal will cause issues
Re added antagonist guidebook entries for the sole purpose of removing linter errors

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.