### PR TITLE
Removed antagonists from guidebook

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -189,7 +189,6 @@
   - type: GuideHelp
     guides:
     - Security
-    - Antagonists
   - type: IdentityBlocker
     coverage: EYES
 

--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -665,7 +665,6 @@
   - type: GuideHelp
     guides:
     - Security
-    - Antagonists
 
 - type: entity #Admeme
   parent: ClothingHandsKnuckleDusters

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -541,7 +541,6 @@
     guides:
     - Cyborgs
     - Robotics
-    - Xenoborgs
   - type: Access
     tags:
     - Xenoborg

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -119,9 +119,6 @@
     - NamesRegalratKingdom
     - NamesRegalratTitle
     nameFormat: name-format-regal-rat
-  - type: GuideHelp
-    guides:
-    - MinorAntagonists
   - type: Grammar
     attributes:
       gender: male
@@ -160,9 +157,6 @@
     speedModifierThresholds:
       200: 0.7
       250: 0.5
-  - type: GuideHelp
-    guides:
-    - MinorAntagonists
 
 - type: entity
   name: rat servant
@@ -298,9 +292,6 @@
     isBoss: false
   - type: Speech
     speechVerb: SmallMob
-  - type: GuideHelp
-    guides:
-    - MinorAntagonists
   - type: FireVisuals
     sprite: Mobs/Effects/onfire.rsi
     normalState: Mouse_burning

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -181,9 +181,6 @@
   - type: ActionGun
     action: ActionDragonsBreath
     gunProto: DragonsBreathGun
-  - type: GuideHelp
-    guides:
-    - MinorAntagonists
 
 - type: entity
   categories: [ HideSpawnMenu ]

--- a/Resources/Prototypes/Entities/Mobs/Player/mothershipcore.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/mothershipcore.yml
@@ -162,7 +162,6 @@
   - type: GuideHelp
     guides:
     - Robotics
-    - Xenoborgs
   - type: Inventory
     templateId: borg
   - type: NpcFactionMember

--- a/Resources/Prototypes/Entities/Objects/Misc/books.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/books.yml
@@ -274,7 +274,6 @@
   - type: GuideHelp
     guides:
     - Security
-    - Antagonists
 
 - type: entity
   id: BookHowToKeepStationClean

--- a/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
@@ -26,7 +26,6 @@
   - type: GuideHelp
     guides:
     - Security
-    - Antagonists
   - type: UseDelay
     delay: 3
 

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/morgue.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/morgue.yml
@@ -152,6 +152,3 @@
               Quantity: 25
             - ReagentId: Arcryox
               Quantity: 25
-    - type: GuideHelp
-      guides:
-      - MinorAntagonists

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -561,7 +561,6 @@
   - type: GuideHelp
     guides:
     - Security
-    - Antagonists
   - type: PacifismAllowedGun
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -54,7 +54,6 @@
   - type: GuideHelp
     guides:
     - Security
-    - Antagonists
   - type: Tag
     tags:
     - HandGrenade

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -90,7 +90,6 @@
   - type: GuideHelp
     guides:
     - Security
-    - Antagonists
 
 - type: entity
   name: truncheon
@@ -127,7 +126,6 @@
   - type: GuideHelp
     guides:
     - Security
-    - Antagonists
 
 - type: entity
   name: flash
@@ -174,7 +172,6 @@
     - type: GuideHelp
       guides:
       - Security
-      - Antagonists
 
 - type: entity
   name: flash
@@ -230,4 +227,3 @@
     - type: GuideHelp
       guides:
       - Security
-      - Antagonists

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -1035,7 +1035,6 @@
   - type: GuideHelp
     guides:
     - Security
-    - Antagonists
 
 - type: entity
   parent: VendingMachine

--- a/Resources/Prototypes/Guidebook/antagonist.yml
+++ b/Resources/Prototypes/Guidebook/antagonist.yml
@@ -1,59 +1,59 @@
-- type: guideEntry
-  id: Antagonists
-  name: guide-entry-antagonists
-  text: "/ServerInfo/Guidebook/Antagonist/Antagonists.xml"
-  children:
-  - Traitors
-  - Thieves
-  - Revolutionaries
-  - NuclearOperatives
-  - SpaceNinja
-  - Wizard
-  - Zombies
-  - Xenoborgs
-  - MinorAntagonists
-
-- type: guideEntry
-  id: Traitors
-  name: guide-entry-traitors
-  text: "/ServerInfo/Guidebook/Antagonist/Traitors.xml"
-
-- type: guideEntry
-  id: NuclearOperatives
-  name: guide-entry-nuclear-operatives
-  text: "/ServerInfo/Guidebook/Antagonist/Nuclear Operatives.xml"
-
-- type: guideEntry
-  id: Zombies
-  name: guide-entry-zombies
-  text: "/ServerInfo/Guidebook/Antagonist/Zombies.xml"
-
-- type: guideEntry
-  id: Revolutionaries
-  name: guide-entry-revolutionaries
-  text: "/ServerInfo/Guidebook/Antagonist/Revolutionaries.xml"
-
-- type: guideEntry
-  id: MinorAntagonists
-  name: guide-entry-minor-antagonists
-  text: "/ServerInfo/Guidebook/Antagonist/MinorAntagonists.xml"
-
-- type: guideEntry
-  id: SpaceNinja
-  name: guide-entry-space-ninja
-  text: "/ServerInfo/Guidebook/Antagonist/SpaceNinja.xml"
-
-- type: guideEntry
-  id: Thieves
-  name: guide-entry-thieves
-  text: "/ServerInfo/Guidebook/Antagonist/Thieves.xml"
-
-- type: guideEntry
-  id: Wizard
-  name: guide-entry-wizard
-  text: "/ServerInfo/Guidebook/Antagonist/Wizard.xml"
-
-- type: guideEntry
-  id: Xenoborgs
-  name: guide-entry-xenoborgs
-  text: "/ServerInfo/Guidebook/Antagonist/Xenoborgs.xml"
+#- type: guideEntry
+#  id: Antagonists
+#  name: guide-entry-antagonists
+#  text: "/ServerInfo/Guidebook/Antagonist/Antagonists.xml"
+#  children:
+#  - Traitors
+#  - Thieves
+#  - Revolutionaries
+#  - NuclearOperatives
+#  - SpaceNinja
+#  - Wizard
+#  - Zombies
+#  - Xenoborgs
+#  - MinorAntagonists
+#
+#- type: guideEntry
+#  id: Traitors
+#  name: guide-entry-traitors
+#  text: "/ServerInfo/Guidebook/Antagonist/Traitors.xml"
+#
+#- type: guideEntry
+#  id: NuclearOperatives
+#  name: guide-entry-nuclear-operatives
+#  text: "/ServerInfo/Guidebook/Antagonist/Nuclear Operatives.xml"
+#
+#- type: guideEntry
+#  id: Zombies
+#  name: guide-entry-zombies
+#  text: "/ServerInfo/Guidebook/Antagonist/Zombies.xml"
+#
+#- type: guideEntry
+#  id: Revolutionaries
+#  name: guide-entry-revolutionaries
+#  text: "/ServerInfo/Guidebook/Antagonist/Revolutionaries.xml"
+#
+#- type: guideEntry
+#  id: MinorAntagonists
+#  name: guide-entry-minor-antagonists
+#  text: "/ServerInfo/Guidebook/Antagonist/MinorAntagonists.xml"
+#
+#- type: guideEntry
+#  id: SpaceNinja
+#  name: guide-entry-space-ninja
+#  text: "/ServerInfo/Guidebook/Antagonist/SpaceNinja.xml"
+#
+#- type: guideEntry
+#  id: Thieves
+#  name: guide-entry-thieves
+#  text: "/ServerInfo/Guidebook/Antagonist/Thieves.xml"
+#
+#- type: guideEntry
+#  id: Wizard
+#  name: guide-entry-wizard
+#  text: "/ServerInfo/Guidebook/Antagonist/Wizard.xml"
+#
+#- type: guideEntry
+#  id: Xenoborgs
+#  name: guide-entry-xenoborgs
+#  text: "/ServerInfo/Guidebook/Antagonist/Xenoborgs.xml"

--- a/Resources/Prototypes/Roles/Antags/ninja.yml
+++ b/Resources/Prototypes/Roles/Antags/ninja.yml
@@ -4,7 +4,6 @@
   antagonist: true
   setPreference: false
   objective: roles-antag-space-ninja-objective
-  guides: [ SpaceNinja ]
 
 #Ninja Gear
 - type: startingGear

--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -7,7 +7,6 @@
   requirements:
   - !type:OverallPlaytimeRequirement
     time: 5h
-  guides: [ NuclearOperatives ]
 
 - type: antag
   id: NukeopsMedic
@@ -21,7 +20,6 @@
   - !type:RoleTimeRequirement
     role: JobChemist
     time: 3h
-  guides: [ NuclearOperatives ]
 
 - type: antag
   id: NukeopsCommander
@@ -36,7 +34,6 @@
     department: Security
     time: 5h
   # should be changed to nukie playtime when thats tracked (wyci)
-  guides: [ NuclearOperatives ]
 
 - type: startingGear
   id: SyndicateOperativeGearFullNoUplink

--- a/Resources/Prototypes/Roles/Antags/revolutionary.yml
+++ b/Resources/Prototypes/Roles/Antags/revolutionary.yml
@@ -4,7 +4,6 @@
   antagonist: true
   setPreference: true
   objective: roles-antag-rev-head-objective
-  guides: [ Revolutionaries ]
   requirements:
   - !type:OverallPlaytimeRequirement
     time: 1h
@@ -15,7 +14,6 @@
   antagonist: true
   setPreference: false
   objective: roles-antag-rev-objective
-  guides: [ Revolutionaries ]
 
 - type: startingGear
   id: HeadRevGear

--- a/Resources/Prototypes/Roles/Antags/thief.yml
+++ b/Resources/Prototypes/Roles/Antags/thief.yml
@@ -4,7 +4,6 @@
   antagonist: true
   setPreference: true
   objective: roles-antag-thief-objective
-  guides: [ Thieves ]
   requirements:
   - !type:OverallPlaytimeRequirement
     time: 1h

--- a/Resources/Prototypes/Roles/Antags/traitor.yml
+++ b/Resources/Prototypes/Roles/Antags/traitor.yml
@@ -4,7 +4,6 @@
   antagonist: true
   setPreference: true
   objective: roles-antag-syndicate-agent-objective
-  guides: [ Traitors ]
   requirements:
   - !type:OverallPlaytimeRequirement
     time: 1h
@@ -15,7 +14,6 @@
   antagonist: true
   setPreference: true
   objective: roles-antag-syndicate-agent-sleeper-objective
-  guides: [ Traitors ]
   requirements:
   - !type:OverallPlaytimeRequirement
     time: 1h

--- a/Resources/Prototypes/Roles/Antags/wizard.yml
+++ b/Resources/Prototypes/Roles/Antags/wizard.yml
@@ -3,7 +3,6 @@
   name: roles-antag-survivor-name
   antagonist: true
   objective: roles-antag-survivor-objective
-  # guides: [  ]
 
 - type: antag
   id: Wizard
@@ -14,6 +13,5 @@
   requirements: # I hate time locked roles but this should be enough time for someone to be acclimated
   - !type:OverallPlaytimeRequirement
     time: 5h
-  guides: [ Wizard ]
 
 # See wizard_startinggear for wiz start gear options

--- a/Resources/Prototypes/Roles/Antags/xenoborgs.yml
+++ b/Resources/Prototypes/Roles/Antags/xenoborgs.yml
@@ -8,7 +8,6 @@
   - !type:RoleTimeRequirement
     role: JobBorg
     time: 18000  # 5 hrs
-  guides: [ Xenoborgs ]
 
 - type: antag
   id: Xenoborg
@@ -20,4 +19,3 @@
   - !type:RoleTimeRequirement
     role: JobBorg
     time: 18000  # 5 hrs
-  guides: [ Xenoborgs ]

--- a/Resources/Prototypes/Roles/Antags/zombie.yml
+++ b/Resources/Prototypes/Roles/Antags/zombie.yml
@@ -4,7 +4,6 @@
   antagonist: true
   setPreference: true
   objective: roles-antag-initial-infected-objective
-  guides: [ Zombies ]
   requirements:
   - !type:OverallPlaytimeRequirement
     time: 1h
@@ -15,4 +14,3 @@
   antagonist: true
   setPreference: false
   objective: roles-antag-zombie-objective
-  guides: [ Zombies ]

--- a/Resources/ServerInfo/Guidebook/NewPlayer/CharacterCreation.xml
+++ b/Resources/ServerInfo/Guidebook/NewPlayer/CharacterCreation.xml
@@ -31,15 +31,6 @@ This may have various effects on gameplay, as some clothing items have [color=#a
 You may also choose what bag you spawn in with.
 [color=#a4885c]Backpacks[/color] are medium sized but can carry large items easier. [color=#a4885c]Satchels[/color] have more total space than backpacks but have trouble carrying large items. [color=#a4885c]Duffel bags[/color] are large but incur a movement penalty.
 
-## Antags
-Turning on an [color=#a4885c]antagonist[/color] toggle will put you on the list of potentional antags at the start of the round. They do not guarantee your antagonist role, don't use this as an excuse to self-antag!
-Instead, like job priorities, a handful of players are chosen randomly from eligible players. If you are a command member or security officer, you cannot be chosen for an antag role.
-
-[textlink="For more information about antagonists, click here." link="Antagonists"]
-
-Joining multiple games or ghosting/disconnecting/commiting suicide upon not being chosen for an antag role is referred to as "antag-rolling" and it is against the rules.
-Plenty of people patiently wait for their turn to be antagonists, so [color=#a4885c]we kindly ask you to refrain from opting-in to an antagonist role if you aren't ready[/color].
-
 ## Traits
 Speech traits alter your speech, sometimes to an extreme degree.
 

--- a/Resources/ServerInfo/Guidebook/Security/Security.xml
+++ b/Resources/ServerInfo/Guidebook/Security/Security.xml
@@ -2,7 +2,7 @@
 # Security
 Ensuring the safety of both station and crew is number one for [color=#cb0000]Security[/color]. They are ready for any situation, and [color=#cb0000]Security[/color] are on hand to maintain order and control crowds.
 
-They face [textlink="Syndicate Agents" link="Traitors"], [textlink="Nuclear Operatives" link="NuclearOperatives"], [textlink="Zombies" link="Zombies"] and unruly staff.
+They face Syndicate Agents, Nuclear Operatives, Zombies and unruly staff.
 
 ## Personnel
 [color=#cb0000]Security[/color]'s staff is made up of Security Cadets, Security Officers, and the Detective. [color=#cb0000]Security[/color] is run by the Warden and Head of Security.


### PR DESCRIPTION
## About the PR
Removed guidebook entries relating to antagonists

## Technical details
Removed antagonist guide tags from yml files that had them. If no relevant guides remained the GuideHelp tag was removed entirely
Commented out the entirety of Resources/Prototypes/Guidebook/antagonists.yml, though I don't believe anything checks it anymore
Removed section on antagonists from character creation guidebook entry, being as the guidebook entries themselves aren't available
Removed a few links in the guidebook that lead to antagonist guidebook entries, again being as they are unavailable
The xml files containing the antagonist guidebook entries remain where they were just in case

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.