### PR TITLE
Hunger and Thirst Rate Reductions

### DIFF
--- a/Content.Shared/Nutrition/Components/HungerComponent.cs
+++ b/Content.Shared/Nutrition/Components/HungerComponent.cs
@@ -34,7 +34,7 @@ public sealed partial class HungerComponent : Component
     /// </summary>
     /// <remarks>Any time this is modified, <see cref="HungerSystem.SetAuthoritativeHungerValue"/> should be called.</remarks>
     [DataField("baseDecayRate"), ViewVariables(VVAccess.ReadWrite)]
-    public float BaseDecayRate = 0.01666666666f;
+    public float BaseDecayRate = 0.008333333f;
 
     /// <summary>
     /// The actual amount at which <see cref="LastAuthoritativeHungerValue"/> decays.

--- a/Content.Shared/Nutrition/Components/HungerComponent.cs
+++ b/Content.Shared/Nutrition/Components/HungerComponent.cs
@@ -97,7 +97,7 @@ public sealed partial class HungerComponent : Component
     [AutoNetworkedField]
     public Dictionary<HungerThreshold, float> HungerThresholdDecayModifiers = new()
     {
-        { HungerThreshold.Overfed, 1.2f },
+        { HungerThreshold.Overfed, 1.1f },
         { HungerThreshold.Okay, 1f },
         { HungerThreshold.Peckish, 0.8f },
         { HungerThreshold.Starving, 0.6f },

--- a/Content.Shared/Nutrition/Components/ThirstComponent.cs
+++ b/Content.Shared/Nutrition/Components/ThirstComponent.cs
@@ -14,7 +14,7 @@ public sealed partial class ThirstComponent : Component
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField("baseDecayRate")]
     [AutoNetworkedField]
-    public float BaseDecayRate = 0.1f;
+    public float BaseDecayRate = 0.05f;
 
     [ViewVariables(VVAccess.ReadWrite)]
     [AutoNetworkedField]

--- a/Content.Shared/Nutrition/EntitySystems/HungerSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/HungerSystem.cs
@@ -225,8 +225,8 @@ public sealed class HungerSystem : EntitySystem
         {
             case HungerThreshold.Overfed:
             case HungerThreshold.Okay:
-                return true;
             case HungerThreshold.Peckish:
+                return true;
             case HungerThreshold.Starving:
             case HungerThreshold.Dead:
                 return false;

--- a/Content.Shared/Nutrition/EntitySystems/ThirstSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/ThirstSystem.cs
@@ -193,7 +193,7 @@ public sealed class ThirstSystem : EntitySystem
         {
             case ThirstThreshold.OverHydrated:
                 component.LastThirstThreshold = component.CurrentThirstThreshold;
-                component.ActualDecayRate = component.BaseDecayRate * 1.2f;
+                component.ActualDecayRate = component.BaseDecayRate * 1.1f;
                 return;
 
             case ThirstThreshold.Okay:

--- a/Resources/Prototypes/Body/Species/diona.yml
+++ b/Resources/Prototypes/Body/Species/diona.yml
@@ -79,9 +79,9 @@
       types:
         Asphyxiation: -1.0
   - type: Hunger
-    baseDecayRate: 0.0083
+    baseDecayRate: 0.00415
   - type: Thirst
-    baseDecayRate: 0.0083
+    baseDecayRate: 0.00415
   - type: Damageable
     damageModifierSet: Diona
   - type: DamageVisuals


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- Moved movement speed penalty for hunger from peckish to starving.
- Halved decay speed for both hunger and thirst.
- Reduced decay speed penalty for overeating.
- Further reduced Diona hunger and thirst rates to match relative scale.

## Why / Balance
Current balance of food requirements feels off. As discussed [here on the discord](https://discord.com/channels/1087916308160585740/1500690121005994044), people are having to very regularly reup on their food and water consumption just to be baseline functional, and after having eaten, the food does not last. The changes implemented aim to address this issue while also not trivializing the work service does in making food for people. The most drastic change is the halving of the decay speeds, and it should be monitored to ensure it is accomplishing its goal without abandoning service.

## Technical details
- Within HungerSystem.cs, altered HungerTreshold.Peckish to return true, instead of false
- Within HungerComponent.cs modified BaseDecayRate from .016666666 to .008333333
- Within HungerComponent.cs modified HungerThresholdDecayModifiers value for HungerThreshold.Overfed from 1.2 to 1.1
- Within ThirstSystem.cs, modified UpdateEffects multiplier for ThirstThreshold.OverHydrated from 1.2 to 1.1
- Within ThirstComponent.cs modified BaseDecayRate from 0.1 to 0.05.
- Within Resources/Prototypes/Body/Species/diona.yml, modified hunger and thirst base decay rates from .0083 to .00415.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
- Rats, mice, and rat king decay rates are unchanged, though the changes to thresholds will affect them.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Adjusted hunger and thirst rates and thresholds to prevent the endless gluttony.
