### PR TITLE
Tape recorders can be controlled with signals

### DIFF
--- a/Content.Shared/DeltaV/TapeRecorder/Components/TapeRecorderComponent.cs
+++ b/Content.Shared/DeltaV/TapeRecorder/Components/TapeRecorderComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.DeltaV.TapeRecorder.Systems;
+using Content.Shared.DeviceLinking;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
@@ -80,4 +81,20 @@ public sealed partial class TapeRecorderComponent : Component
     {
         Params = AudioParams.Default.WithVolume(-2f).WithMaxDistance(3f)
     };
+
+    /// <summary>
+    /// Ports for signal control
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public ProtoId<SinkPortPrototype> PausePort = "Pause";
+
+    [DataField, AutoNetworkedField]
+    public ProtoId<SinkPortPrototype> RecordPort = "Record";
+
+    [DataField, AutoNetworkedField]
+    public ProtoId<SinkPortPrototype> PlaybackPort = "Playback";
+
+    [DataField, AutoNetworkedField]
+    public ProtoId<SinkPortPrototype> RewindPort = "Rewind";
+
 }

--- a/Content.Shared/DeltaV/TapeRecorder/Systems/SharedTapeRecorderSystem.cs
+++ b/Content.Shared/DeltaV/TapeRecorder/Systems/SharedTapeRecorderSystem.cs
@@ -11,6 +11,8 @@ using Content.Shared.Tag;
 using Content.Shared.Toggleable;
 using Content.Shared.UserInterface;
 using Content.Shared.Whitelist;
+using Content.Shared.DeviceLinking;
+using Content.Shared.DeviceLinking.Events;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Random;
@@ -45,6 +47,7 @@ public abstract class SharedTapeRecorderSystem : EntitySystem
         SubscribeLocalEvent<TapeRecorderComponent, ExaminedEvent>(OnRecorderExamined);
         SubscribeLocalEvent<TapeRecorderComponent, ChangeModeTapeRecorderMessage>(OnChangeModeMessage);
         SubscribeLocalEvent<TapeRecorderComponent, AfterActivatableUIOpenEvent>(OnUIOpened);
+        SubscribeLocalEvent<TapeRecorderComponent, SignalReceivedEvent>(OnSignalReceived);
 
         SubscribeLocalEvent<TapeCassetteComponent, ExaminedEvent>(OnTapeExamined);
         SubscribeLocalEvent<TapeCassetteComponent, DamageChangedEvent>(OnDamagedChanged);
@@ -414,6 +417,26 @@ public abstract class SharedTapeRecorderSystem : EntitySystem
             cooldown);
 
         _ui.SetUiState(uid, TapeRecorderUIKey.Key, state);
+    }
+
+    private void OnSignalReceived(Entity<TapeRecorderComponent> ent, ref SignalReceivedEvent args)
+    {
+        if (args.Port == ent.Comp.PausePort)
+        {
+            SetMode(ent, TapeRecorderMode.Stopped);
+        }
+        else if (args.Port == ent.Comp.RecordPort)
+        {
+            SetMode(ent, TapeRecorderMode.Recording);
+        }
+        else if (args.Port == ent.Comp.PlaybackPort)
+        {
+            SetMode(ent, TapeRecorderMode.Playing);
+        }
+        else if (args.Port == ent.Comp.RewindPort)
+        {
+            SetMode(ent, TapeRecorderMode.Rewinding);
+        }
     }
 }
 

--- a/Resources/Locale/en-US/deltav/linkports/link-ports.ftl
+++ b/Resources/Locale/en-US/deltav/linkports/link-ports.ftl
@@ -1,0 +1,4 @@
+signal-port-description-playback = Start audio playback.
+signal-port-description-record = Start recording audio.
+signal-port-description-rewind = Rewind audio.
+signal-port-description-pause = Stop playing, recording, or rewinding.

--- a/Resources/Prototypes/DeltaV/DeviceLinking/sink_ports.yml
+++ b/Resources/Prototypes/DeltaV/DeviceLinking/sink_ports.yml
@@ -1,0 +1,19 @@
+- type: sinkPort
+  id: Pause
+  name: tape-recorder-menu-stopped-button
+  description: signal-port-description-pause
+
+- type: sinkPort
+  id: Record
+  name: tape-recorder-menu-recording-button
+  description: signal-port-description-record
+
+- type: sinkPort
+  id: Playback
+  name: tape-recorder-menu-playing-button
+  description: signal-port-description-playback
+
+- type: sinkPort
+  id: Rewind
+  name: tape-recorder-menu-rewinding-button
+  description: signal-port-description-rewind

--- a/Resources/Prototypes/DeltaV/Entities/Objects/Devices/tape_recorder.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Devices/tape_recorder.yml
@@ -50,6 +50,17 @@
     interfaces:
       enum.TapeRecorderUIKey.Key:
         type: TapeRecorderBoundUserInterface
+  - type: DeviceNetwork
+    deviceNetId: Wireless
+    receiveFrequencyId: BasicDevice
+  - type: WirelessNetworkConnection
+    range: 200
+  - type: DeviceLinkSink
+    ports:
+    - Pause
+    - Record
+    - Playback
+    - Rewind
 
 - type: entity
   parent: TapeRecorder


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Ported the ability to control tape recorders with signals from deltaV

## Why / Balance
Original tape recorder port said it ported it, but didn't



## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
:cl:
- add: You can control tape recorders with signals.

