### PR TITLE
Fireproof Containers

### DIFF
--- a/Content.Server/Atmos/Components/FireproofComponent.cs
+++ b/Content.Server/Atmos/Components/FireproofComponent.cs
@@ -1,0 +1,11 @@
+namespace Content.Server.Atmos;
+
+[RegisterComponent]
+public sealed partial class FireproofComponent : Component
+{
+    /// <summary>
+    /// Determines if a container protects its contents from fire.
+    /// </summary>
+    [DataField]
+    public bool ProtectContents = true;
+}

--- a/Content.Server/Atmos/Components/FireproofComponent.cs
+++ b/Content.Server/Atmos/Components/FireproofComponent.cs
@@ -10,7 +10,8 @@ public sealed partial class FireproofComponent : Component
     public bool ProtectContents = true;
 
     /// <summary>
-    /// Maximum tempurature a fireproof item can reach
+    /// Maximum temperature a fireproof item can reach
     /// </summar>
-    public float MaxTempurature = 370; // Just below the ignition tempurature for paper. Creatures will still take damage if in a fireproof container.
+    [DataField]
+    public float MaxTemperature = 370; // Just below the ignition tempurature for paper. Creatures will still take damage if in a fireproof container.
 }

--- a/Content.Server/Atmos/Components/FireproofComponent.cs
+++ b/Content.Server/Atmos/Components/FireproofComponent.cs
@@ -8,4 +8,9 @@ public sealed partial class FireproofComponent : Component
     /// </summary>
     [DataField]
     public bool ProtectContents = true;
+
+    /// <summary>
+    /// Maximum tempurature a fireproof item can reach
+    /// </summar>
+    public float MaxTempurature = 370; // Just below the ignition tempurature for paper. Creatures will still take damage if in a fireproof container.
 }

--- a/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
@@ -32,6 +32,7 @@ using Robust.Shared.Physics.Events;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
+using Robust.Server.Containers;
 
 namespace Content.Server.Atmos.EntitySystems
 {
@@ -53,6 +54,7 @@ namespace Content.Server.Atmos.EntitySystems
         [Dependency] private readonly AudioSystem _audio = default!;
         [Dependency] private readonly IRobustRandom _random = default!;
         [Dependency] private readonly IGameTiming _timing = default!;
+        [Dependency] private readonly ContainerSystem _container = default!;
 
         private EntityQuery<InventoryComponent> _inventoryQuery;
         private EntityQuery<PhysicsComponent> _physicsQuery;
@@ -471,9 +473,13 @@ namespace Content.Server.Atmos.EntitySystems
                     continue;
                 }
 
-                _alertsSystem.ShowAlert(uid, flammable.FireAlert);
+                bool fireproof = false;
+                if (HasComp<FireproofComponent>(uid) || InFireproofContainer(uid))
+                    fireproof = true;
 
-                if (flammable.FireStacks > 0)
+                if (!fireproof) _alertsSystem.ShowAlert(uid, flammable.FireAlert);
+
+                if (flammable.FireStacks > 0 && !fireproof)
                 {
                     var air = _atmosphereSystem.GetContainingMixture(uid);
 
@@ -506,6 +512,23 @@ namespace Content.Server.Atmos.EntitySystems
                     Extinguish(uid, flammable);
                 }
             }
+        }
+
+        public bool InFireproofContainer(EntityUid uid)
+        {
+            var id = uid;
+            int iterationCount = 0;
+            while (iterationCount < 30) // Protects against turtles all the way down
+            {
+                if (!_container.TryGetContainingContainer(id, out var container))
+                    return false;
+
+                id = container.Owner;
+                if (TryComp<FireproofComponent>(id, out var fireproof) && fireproof.ProtectContents)
+                    return true;
+            }
+
+            return false;
         }
     }
 }

--- a/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
@@ -510,7 +510,7 @@ namespace Content.Server.Atmos.EntitySystems
                 {
                     if (fireproof && fireproofComponent != null && TryComp<TemperatureComponent>(uid, out var temp))
                     {
-                        var safetemp = fireproofComponent.MaxTempurature;
+                        var safetemp = fireproofComponent.MaxTemperature;
                         if (temp.CurrentTemperature > safetemp)
                             _temperatureSystem.ForceChangeTemperature(uid, safetemp, temp);
                     }

--- a/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
@@ -248,6 +248,8 @@ namespace Content.Server.Atmos.EntitySystems
 
         private void OnTileFire(Entity<FlammableComponent> ent, ref TileFireEvent args)
         {
+            if (IsFireproof(ent)) return;
+
             var tempDelta = args.Temperature - ent.Comp.MinIgnitionTemperature;
 
             _fireEvents.TryGetValue(ent, out var maxTemp);
@@ -265,7 +267,7 @@ namespace Content.Server.Atmos.EntitySystems
         {
             // Only oxidize materials that would realistically react — organic, flammable items.
             // Metal structures, glass, etc. are not AlwaysCombustible and are spared.
-            if (!ent.Comp.AlwaysCombustible)
+            if (!ent.Comp.AlwaysCombustible || IsFireproof(ent))
                 return;
 
             // Damage scales with ClF3 concentration: more moles = faster destruction.
@@ -473,9 +475,7 @@ namespace Content.Server.Atmos.EntitySystems
                     continue;
                 }
 
-                bool fireproof = false;
-                if (HasComp<FireproofComponent>(uid) || InFireproofContainer(uid))
-                    fireproof = true;
+                bool fireproof = IsFireproof(uid);
 
                 if (!fireproof) _alertsSystem.ShowAlert(uid, flammable.FireAlert);
 
@@ -514,12 +514,15 @@ namespace Content.Server.Atmos.EntitySystems
             }
         }
 
-        public bool InFireproofContainer(EntityUid uid)
+        public bool IsFireproof(EntityUid uid)
         {
             var id = uid;
+            if (HasComp<FireproofComponent>(uid)) return true;
+
             int iterationCount = 0;
             while (iterationCount < 30) // Protects against turtles all the way down
             {
+                iterationCount++;
                 if (!_container.TryGetContainingContainer(id, out var container))
                     return false;
 

--- a/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
@@ -31,6 +31,7 @@ using Robust.Shared.Physics.Systems;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 using Robust.Server.Containers;
+using Robust.Shared.Toolshed.Commands.Values;
 
 namespace Content.Server.Atmos.EntitySystems
 {
@@ -473,7 +474,7 @@ namespace Content.Server.Atmos.EntitySystems
                     continue;
                 }
 
-                bool fireproof = IsFireproof(uid);
+                bool fireproof = IsFireproof(uid, out var fireproofComponent);
 
                 if (!fireproof) _alertsSystem.ShowAlert(uid, flammable.FireAlert);
 
@@ -507,14 +508,21 @@ namespace Content.Server.Atmos.EntitySystems
                 }
                 else
                 {
+                    if (fireproof && fireproofComponent != null && TryComp<TemperatureComponent>(uid, out var temp))
+                    {
+                        var safetemp = fireproofComponent.MaxTempurature;
+                        if (temp.CurrentTemperature > safetemp)
+                            _temperatureSystem.ForceChangeTemperature(uid, safetemp, temp);
+                    }
                     Extinguish(uid, flammable);
                 }
             }
         }
 
-        public bool IsFireproof(EntityUid uid)
+        public bool IsFireproof(EntityUid uid, out FireproofComponent? comp)
         {
             var id = uid;
+            comp = null;
             if (HasComp<FireproofComponent>(uid)) return true;
 
             int iterationCount = 0;
@@ -526,10 +534,14 @@ namespace Content.Server.Atmos.EntitySystems
 
                 id = container.Owner;
                 if (TryComp<FireproofComponent>(id, out var fireproof) && fireproof.ProtectContents)
+                {
+                    comp = fireproof;
                     return true;
+                }
             }
 
             return false;
         }
+        public bool IsFireproof(EntityUid uid) => IsFireproof(uid, out _);
     }
 }

--- a/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
@@ -24,8 +24,6 @@ using Content.Shared.Throwing;
 using Content.Shared.Timing;
 using Content.Shared.Toggleable;
 using Content.Shared.Weapons.Melee.Events;
-using Content.Shared.FixedPoint;
-using Content.Shared.Temperature.Components;
 using Robust.Server.Audio;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Events;

--- a/Resources/Prototypes/Entities/Objects/Misc/folders.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/folders.yml
@@ -486,7 +486,7 @@
   id: BoxFolderTitaniumBaseEmpty
   abstract: true
   name: reinforced folder
-  description: A folder created out of a solid sheet of titanium. Features a sealing mechanism which holds it's contents safely inside. Durable, robust, and explosion resistant. Not fireproof however.
+  description: A folder created out of a solid sheet of titanium. Features a sealing mechanism which holds it's contents safely inside. Durable, robust, and explosion resistant.
   components:
   - type: ItemMapper
     mapLayers:
@@ -501,6 +501,7 @@
     price: 50 
   - type: ExplosionResistance
     damageCoefficient: 0.0
+  - type: Fireproof
 
 - type: entity
   parent: BoxFolderTitaniumBaseEmpty

--- a/Resources/Prototypes/_NF/Entities/Clothing/Wallet/base_wallet.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Wallet/base_wallet.yml
@@ -77,3 +77,4 @@
         closed-coin:
           Open: { state: open-coin }
           Closed: { state: closed-coin }
+  - type: Fireproof


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Title says it all. Adds a component for allowing containers to be fireproof, meaning items inside are unable to light on fire. This is mainly to allow reinforced folders and wallets to safely protect papers within from ashing in a fire (as has happened more than once in engineering). Fireproof containers cap the maximum temperature contained items can reach.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
As stated above, the main goal is to allow for reinforced folders and wallets to safely hold papers/permits/etc without fear of them ashing should the worst happen. Engineering should be able to hold their paperwork in peace.

This is a stepping stone to further permit changes, and the ability to safely hold important permits in wallets or reinforced folders.

## Technical details
<!-- Summary of code changes for easier review. -->
* Added the FireproofComponent with a field ProtectContents, true by default.
* The FlammableSystem now checks for the FireproofComponent when trying to light things on fire or do fire updates.
* The Flammable System also checks to see if the item is in a container with the FireproofComponent with ProtectContents=true
* Added FireproofComponent to wallets and titanium folder prototypes.
* Updated description of the titatium folder prototype to remove the "Does not protect from fire" line.
* Added field to FireproofComponent, MaxTempurature. Caps the temperature a fireproof item can reach to prevent automatic ignition after exiting a fireproof container.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://www.youtube.com/watch?v=94eHZRWyOLk

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
There shouldn't be any breaking changes, I tested around and didn't find any...

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Wallets are now fireproof, protecting contents within from fire.
- tweak: Reinforced Folders are now fireproof, protecting contents within from fire.
