### PR TITLE
Bugfix: QSI breaking on reload

### DIFF
--- a/Content.Shared/Teleportation/Components/SwapTeleporterComponent.cs
+++ b/Content.Shared/Teleportation/Components/SwapTeleporterComponent.cs
@@ -16,12 +16,6 @@ namespace Content.Shared.Teleportation.Components;
 public sealed partial class SwapTeleporterComponent : Component
 {
     /// <summary>
-    /// The other SwapTeleporterComponent that this one is linked to
-    /// </summary>
-    [DataField, AutoNetworkedField]
-    public EntityUid? LinkedEnt;
-
-    /// <summary>
     /// the time at which <see cref="TeleportDelay"/> ends and the teleportation occurs
     /// </summary>
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
@@ -57,6 +51,10 @@ public sealed partial class SwapTeleporterComponent : Component
     /// </summary>
     [DataField]
     public EntityWhitelist TeleporterWhitelist = new();
+
+    [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadOnly)]
+    public string? Key = null;
+    public bool HasKey => Key != null;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Teleportation/Systems/SwapTeleporterSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SwapTeleporterSystem.cs
@@ -40,8 +40,14 @@ public sealed class SwapTeleporterSystem : EntitySystem
         SubscribeLocalEvent<SwapTeleporterComponent, ExaminedEvent>(OnExamined);
 
         SubscribeLocalEvent<SwapTeleporterComponent, ComponentShutdown>(OnShutdown);
+        SubscribeLocalEvent<SwapTeleporterComponent, ComponentInit>(OnComponentInit);
 
         _xformQuery = GetEntityQuery<TransformComponent>();
+    }
+
+    private void OnComponentInit(EntityUid uid, SwapTeleporterComponent comp, ref ComponentInit args)
+    {
+        UpdateAppearance(uid, comp);
     }
 
     private void OnInteract(Entity<SwapTeleporterComponent> ent, ref AfterInteractEvent args)
@@ -61,25 +67,32 @@ public sealed class SwapTeleporterSystem : EntitySystem
             return;
         }
 
-        if (comp.LinkedEnt != null)
+        if (comp.Key != null)
         {
             _popup.PopupClient(Loc.GetString("swap-teleporter-popup-link-fail-already"), uid, args.User);
             return;
         }
 
-        if (targetComp.LinkedEnt != null)
+        if (targetComp.Key != null)
         {
             _popup.PopupClient(Loc.GetString("swap-teleporter-popup-link-fail-already-other"), uid, args.User);
             return;
         }
 
-        comp.LinkedEnt = target;
-        targetComp.LinkedEnt = uid;
+        comp.Key = GetUniqueBeaconKey();
+        targetComp.Key = comp.Key;
+
         Dirty(uid, comp);
         Dirty(target, targetComp);
-        _appearance.SetData(uid, SwapTeleporterVisuals.Linked, true);
-        _appearance.SetData(target, SwapTeleporterVisuals.Linked, true);
+
+        UpdateAppearance(uid, comp);
+        UpdateAppearance(target, targetComp);
         _popup.PopupClient(Loc.GetString("swap-teleporter-popup-link-create"), uid, args.User);
+    }
+
+    private void UpdateAppearance(EntityUid uid, SwapTeleporterComponent comp)
+    {
+        _appearance.SetData(uid, SwapTeleporterVisuals.Linked, comp.HasKey);
     }
 
     private void OnGetAltVerb(Entity<SwapTeleporterComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
@@ -87,8 +100,9 @@ public sealed class SwapTeleporterSystem : EntitySystem
         var (uid, comp) = ent;
         if (!args.CanAccess || !args.CanInteract || args.Hands == null || comp.TeleportTime != null)
             return;
-
-        if (!TryComp<SwapTeleporterComponent>(comp.LinkedEnt, out var otherComp) || otherComp.TeleportTime != null)
+        if (!TryGetPaired(ent, comp.Key, out var linkedEnt))
+            return;
+        if (!TryComp<SwapTeleporterComponent>(linkedEnt, out var otherComp) || otherComp.TeleportTime != null)
             return;
 
         var user = args.User;
@@ -113,14 +127,14 @@ public sealed class SwapTeleporterSystem : EntitySystem
         if (comp.TeleportTime != null)
             return;
 
-        if (comp.LinkedEnt == null)
+        if (!TryGetPaired(ent, comp.Key, out var linkedEnt))
         {
             _popup.PopupClient(Loc.GetString("swap-teleporter-popup-teleport-cancel-link"), ent, user);
             return;
         }
 
         // don't allow teleporting to happen if the linked one is already teleporting
-        if (!TryComp<SwapTeleporterComponent>(comp.LinkedEnt, out var otherComp)
+        if (!TryComp<SwapTeleporterComponent>(linkedEnt, out var otherComp)
             || otherComp.TeleportTime != null)
         {
             return;
@@ -133,7 +147,7 @@ public sealed class SwapTeleporterSystem : EntitySystem
         }
 
         _audio.PlayPredicted(comp.TeleportSound, uid, user);
-        _audio.PlayPredicted(otherComp.TeleportSound, comp.LinkedEnt.Value, user);
+        _audio.PlayPredicted(otherComp.TeleportSound, linkedEnt, user);
         comp.NextTeleportUse = _timing.CurTime + comp.Cooldown;
         comp.TeleportTime = _timing.CurTime + comp.TeleportDelay;
         Dirty(uid, comp);
@@ -148,7 +162,7 @@ public sealed class SwapTeleporterSystem : EntitySystem
 
         Dirty(uid, comp);
         // We can't run the teleport logic on the client due to PVS range issues.
-        if (_net.IsClient || comp.LinkedEnt is not { } linkedEnt)
+        if (_net.IsClient || !TryGetPaired(ent, comp.Key, out var linkedEnt))
             return;
 
         var teleEnt = GetTeleportingEntity((uid, xform));
@@ -201,9 +215,11 @@ public sealed class SwapTeleporterSystem : EntitySystem
     {
         if (!Resolve(ent, ref ent.Comp, false))
             return;
-        var linkedNullable = ent.Comp.LinkedEnt;
+        if (!ent.Comp.HasKey)
+            return;
 
-        ent.Comp.LinkedEnt = null;
+        string? oldKey = ent.Comp.Key;
+        ent.Comp.Key = null;
         ent.Comp.TeleportTime = null;
         _appearance.SetData(ent, SwapTeleporterVisuals.Linked, false);
         Dirty(ent, ent.Comp);
@@ -212,9 +228,8 @@ public sealed class SwapTeleporterSystem : EntitySystem
             _popup.PopupClient(Loc.GetString("swap-teleporter-popup-link-destroyed"), ent, user.Value);
         else
             _popup.PopupEntity(Loc.GetString("swap-teleporter-popup-link-destroyed"), ent);
-
-        if (linkedNullable is { } linked)
-            DestroyLink(linked, user); // the linked one is shown globally
+        if (TryGetPaired(ent, oldKey, out var linkedNullable))
+            DestroyLink(linkedNullable, user); // the linked one is shown globally
     }
 
     private EntityUid GetTeleportingEntity(Entity<TransformComponent> ent)
@@ -238,7 +253,7 @@ public sealed class SwapTeleporterSystem : EntitySystem
         var (_, comp) = ent;
         using (args.PushGroup(nameof(SwapTeleporterComponent)))
         {
-            var locale = comp.LinkedEnt == null
+            var locale = !TryGetPaired(ent, comp.Key, out _)
                 ? "swap-teleporter-examine-link-absent"
                 : "swap-teleporter-examine-link-present";
             args.PushMarkup(Loc.GetString(locale));
@@ -271,5 +286,27 @@ public sealed class SwapTeleporterSystem : EntitySystem
 
             DoTeleport((uid, comp, xform));
         }
+    }
+
+    private string GetUniqueBeaconKey() => Guid.NewGuid().ToString("N");
+
+    private bool TryGetPaired(EntityUid self, string? key, out EntityUid uid)
+    {
+        uid = default!;
+
+        if (key == null) return false;
+
+        var query = EntityQueryEnumerator<SwapTeleporterComponent>();
+
+        while (query.MoveNext(out var id, out var comp))
+        {
+            if (id == self) continue;
+            if (comp.Key != key) continue;
+
+            uid = id;
+            return true;
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Quantum Spin Inverters now pair via a key which saves better than the old Entity reference link.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
QSIs shouldn't break on save/load.

## Technical details
<!-- Summary of code changes for easier review. -->
* SwapTeleporterSystem now uses the new Key field on the SwapTeleporterComponent
* When activated, QSIs scan for their key pair and teleport to that as the target entity.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Did not remove refs to TargetEnt from comments and XML summaries, only hardcoded areas.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Quantum Spin Inverters now maintain connection properly on load
