### PR TITLE
Fulton Beacon Link Bugfix

### DIFF
--- a/Content.Server/Salvage/FultonSystem.cs
+++ b/Content.Server/Salvage/FultonSystem.cs
@@ -52,9 +52,9 @@ public sealed class FultonSystem : SharedFultonSystem
 
     private void Fulton(EntityUid uid, FultonedComponent component)
     {
-        if (!Deleted(component.Beacon) &&
-            TryComp(component.Beacon, out TransformComponent? beaconXform) &&
-            !Container.IsEntityOrParentInContainer(component.Beacon.Value, xform: beaconXform) &&
+        if (TryGetBeacon(component.BeaconKey, out var beaconUid) &&
+            TryComp(beaconUid, out TransformComponent? beaconXform) &&
+            !Container.IsEntityOrParentInContainer(beaconUid.Value, xform: beaconXform) &&
             CanFulton(uid))
         {
             var xform = Transform(uid);

--- a/Content.Shared/Salvage/Fulton/FultonBeaconComponent.cs
+++ b/Content.Shared/Salvage/Fulton/FultonBeaconComponent.cs
@@ -11,4 +11,7 @@ public sealed partial class FultonBeaconComponent : Component
 {
     [ViewVariables(VVAccess.ReadWrite), DataField("soundLink"), AutoNetworkedField]
     public SoundSpecifier? LinkSound = new SoundPathSpecifier("/Audio/Items/beep.ogg");
+
+    [DataField("key"), ViewVariables(VVAccess.ReadOnly), AutoNetworkedField]
+    public string? Key = null;
 }

--- a/Content.Shared/Salvage/Fulton/FultonComponent.cs
+++ b/Content.Shared/Salvage/Fulton/FultonComponent.cs
@@ -19,8 +19,8 @@ public sealed partial class FultonComponent : Component
     /// <summary>
     /// Linked fulton beacon.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField("beacon"), AutoNetworkedField]
-    public EntityUid? Beacon;
+    [ViewVariables(VVAccess.ReadWrite), DataField("beaconKey"), AutoNetworkedField]
+    public string? BeaconKey = null;
 
     /// <summary>
     /// Applies Removeable to the <see cref="FultonedComponent"/>.

--- a/Content.Shared/Salvage/Fulton/FultonedComponent.cs
+++ b/Content.Shared/Salvage/Fulton/FultonedComponent.cs
@@ -16,8 +16,8 @@ public sealed partial class FultonedComponent : Component
     [ViewVariables, DataField("effect"), AutoNetworkedField]
     public EntityUid Effect { get; set; }
 
-    [ViewVariables(VVAccess.ReadWrite), DataField("beacon")]
-    public EntityUid? Beacon;
+    [ViewVariables(VVAccess.ReadWrite), DataField("beaconKey"), AutoNetworkedField]
+    public string? BeaconKey = null;
 
     [ViewVariables(VVAccess.ReadWrite), DataField("fultonDuration"), AutoNetworkedField]
     public TimeSpan FultonDuration = TimeSpan.FromSeconds(45);

--- a/Content.Shared/Salvage/Fulton/SharedFultonSystem.cs
+++ b/Content.Shared/Salvage/Fulton/SharedFultonSystem.cs
@@ -12,6 +12,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
+using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 
 namespace Content.Shared.Salvage.Fulton;
@@ -97,7 +98,7 @@ public abstract partial class SharedFultonSystem : EntitySystem
         }
 
         var fultoned = AddComp<FultonedComponent>(args.Target.Value);
-        fultoned.Beacon = fulton.Beacon;
+        fultoned.BeaconKey = fulton.BeaconKey;
         fultoned.NextFulton = Timing.CurTime + fulton.FultonDuration;
         fultoned.FultonDuration = fulton.FultonDuration;
         fultoned.Removeable = fulton.Removeable;
@@ -111,35 +112,41 @@ public abstract partial class SharedFultonSystem : EntitySystem
         if (args.Target == null || args.Handled || !args.CanReach)
             return;
 
+        // Interact with Beacon
         if (TryComp<FultonBeaconComponent>(args.Target, out var beacon))
         {
+            EnsureBeaconKey(beacon); // Make sure the beacon has a key before linking.
             if (!_foldable.IsFolded(args.Target.Value))
             {
-                component.Beacon = args.Target.Value;
+                component.BeaconKey = beacon.Key;
                 Audio.PlayPredicted(beacon.LinkSound, uid, args.User);
                 _popup.PopupClient(Loc.GetString("fulton-linked"), uid, args.User);
             }
             else
             {
-                component.Beacon = EntityUid.Invalid;
+                component.BeaconKey = null;
                 _popup.PopupClient(Loc.GetString("fulton-folded"), uid, args.User);
             }
 
             return;
         }
 
-        if (Deleted(component.Beacon))
+        // If the beacon doesn't exist anymore, 
+        if (!TryGetBeacon(component.BeaconKey, out var beaconUid))
         {
             _popup.PopupClient(Loc.GetString("fulton-not-found"), uid, args.User);
+            component.BeaconKey = null; // Unlink the beacon since it no longer exists.
             return;
         }
 
+        // Invalid fulton target
         if (!CanApplyFulton(args.Target.Value, component))
         {
             _popup.PopupClient(Loc.GetString("fulton-invalid"), uid, uid);
             return;
         }
 
+        // Already fultoned
         if (HasComp<FultonedComponent>(args.Target))
         {
             _popup.PopupClient(Loc.GetString("fulton-fultoned"), uid, uid);
@@ -162,7 +169,7 @@ public abstract partial class SharedFultonSystem : EntitySystem
     private void OnFultonSplit(EntityUid uid, FultonComponent component, ref StackSplitEvent args)
     {
         var newFulton = EnsureComp<FultonComponent>(args.NewId);
-        newFulton.Beacon = component.Beacon;
+        newFulton.BeaconKey = component.BeaconKey;
         Dirty(args.NewId, newFulton);
     }
 
@@ -210,5 +217,34 @@ public abstract partial class SharedFultonSystem : EntitySystem
     {
         public NetEntity Entity;
         public NetCoordinates Coordinates;
+    }
+
+    protected virtual bool TryGetBeacon(string? key, [NotNullWhen(true)] out EntityUid? beacon)
+    {
+        beacon = null;
+
+        if (key == null)
+            return false;
+
+        var query = EntityQueryEnumerator<FultonBeaconComponent>();
+
+        while (query.MoveNext(out var uid, out var beaconComp))
+        {
+            if (beaconComp.Key == key)
+            {
+                beacon = uid;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected virtual void EnsureBeaconKey(FultonBeaconComponent beacon)
+    {
+        if (beacon.Key != null)
+            return;
+
+        beacon.Key = Guid.NewGuid().ToString();
     }
 }

--- a/Content.Shared/Salvage/Fulton/SharedFultonSystem.cs
+++ b/Content.Shared/Salvage/Fulton/SharedFultonSystem.cs
@@ -49,6 +49,7 @@ public abstract partial class SharedFultonSystem : EntitySystem
         SubscribeLocalEvent<FultonComponent, AfterInteractEvent>(OnFultonInteract);
 
         SubscribeLocalEvent<FultonComponent, StackSplitEvent>(OnFultonSplit);
+        SubscribeLocalEvent<FultonBeaconComponent, FoldedEvent>(OnBeaconFolded);
     }
 
     private void OnFultonContainerInserted(EntityUid uid, FultonedComponent component, EntGotInsertedIntoContainerMessage args)
@@ -164,6 +165,13 @@ public abstract partial class SharedFultonSystem : EntitySystem
                 Broadcast = true,
                 NeedHand = true,
             });
+    }
+
+    private void OnBeaconFolded(EntityUid uid, FultonBeaconComponent component, FoldedEvent args)
+    {
+        if (args.User == null) // Only reset if a player folded the beacon. Prevents roundstart from resetting beacon link.
+            return;
+        component.Key = null;
     }
 
     private void OnFultonSplit(EntityUid uid, FultonComponent component, ref StackSplitEvent args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fulton beacons and fultons now correctly remain linked between saves.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It was brought to my attention that fultons were meant to stay linked between saves. This is a bugfix to make that happen.

## Technical details
<!-- Summary of code changes for easier review. -->
* Fulton beacons now have a GUID key
* When interacted with a fulton, the fulton copies the key for reference later
* Fultons teleport to the beacon with the matching key
* Fulton beacons reset their key when folded (to prevent transport of linked beacond)

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/bd2ac0fe-2f6a-427f-b477-0df4d43e7e2d" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
No known breaking changes

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fultons and fulton beacons now properly remain connected between saves
