### PR TITLE
Server error reduction

### DIFF
--- a/Content.Server/Chemistry/EntitySystems/ReagentDispenserSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ReagentDispenserSystem.cs
@@ -49,7 +49,6 @@ namespace Content.Server.Chemistry.EntitySystems
             SubscribeLocalEvent<ReagentDispenserComponent, ReagentDispenserEjectContainerMessage>(OnEjectReagentMessage);
             SubscribeLocalEvent<ReagentDispenserComponent, ReagentDispenserClearContainerSolutionMessage>(OnClearContainerSolutionMessage);
 
-            SubscribeLocalEvent<ReagentDispenserComponent, MapInitEvent>(OnMapInit, before: new[] { typeof(ItemSlotsSystem) });
             SubscribeLocalEvent<ReagentDispenserComponent, ComponentInit>(OnCompInit, before: new[] { typeof(ItemSlotsSystem) });
         }
 
@@ -190,11 +189,6 @@ namespace Content.Server.Chemistry.EntitySystems
         /// <summary>
         /// Initializes the beaker slot
         /// </summary>
-        private void OnMapInit(Entity<ReagentDispenserComponent> ent, ref MapInitEvent args)
-        {
-            _itemSlotsSystem.AddItemSlot(ent.Owner, SharedReagentDispenser.OutputSlotName, ent.Comp.BeakerSlot);
-        }
-
         private void OnCompInit(Entity<ReagentDispenserComponent> ent, ref ComponentInit args)
         {
             _itemSlotsSystem.AddItemSlot(ent.Owner, SharedReagentDispenser.OutputSlotName, ent.Comp.BeakerSlot);

--- a/Resources/Maps/Ruins/jokers_ruins.yml
+++ b/Resources/Maps/Ruins/jokers_ruins.yml
@@ -1,17 +1,6 @@
 meta:
-  format: 7
-  category: Grid
-  engineVersion: 270.0.0
-  forkId: ""
-  forkVersion: ""
-  time: 12/29/2025 20:38:43
-  entityCount: 451
-maps:
-- 1
-grids:
-- 2
-orphans: []
-nullspace: []
+  format: 6
+  postmapinit: false
 tilemap:
   2: Space
   6: FloorAstroGrass
@@ -25,26 +14,13 @@ tilemap:
 entities:
 - proto: ""
   entities:
-  - uid: 1
-    components:
-    - type: MetaData
-      name: Map Entity
-    - type: Transform
-    - type: Map
-      mapPaused: True
-    - type: GridTree
-    - type: SolarLocation
-      sunAngularVelocity: 0.0018475114686694076 rad
-      towardsSun: 0.14296611731940287 rad
-    - type: Broadphase
-    - type: OccluderTree
   - uid: 2
     components:
     - type: MetaData
       name: grid
     - type: Transform
       pos: -5.2112017,-0.008535743
-      parent: 1
+      parent: invalid
     - type: MapGrid
       chunks:
         0,0:

--- a/Resources/Maps/Ruins/rigged_outpost.yml
+++ b/Resources/Maps/Ruins/rigged_outpost.yml
@@ -1,17 +1,6 @@
 meta:
-  format: 7
-  category: Grid
-  engineVersion: 268.0.0
-  forkId: ""
-  forkVersion: ""
-  time: 12/26/2025 05:18:50
-  entityCount: 382
-maps:
-- 374
-grids:
-- 2
-orphans: []
-nullspace: []
+  format: 6
+  postmapinit: false
 tilemap:
   0: Space
   18: FloorBlueCircuit
@@ -36,7 +25,7 @@ entities:
       name: grid
     - type: Transform
       pos: 6.7773275,4.1394477
-      parent: 374
+      parent: invalid
     - type: MapGrid
       chunks:
         0,0:
@@ -636,19 +625,6 @@ entities:
     - type: RadiationGridResistance
     - type: ImplicitRoof
     - type: ExplosionAirtightGrid
-  - uid: 374
-    components:
-    - type: MetaData
-      name: Map Entity
-    - type: Transform
-    - type: Map
-      mapPaused: True
-    - type: GridTree
-    - type: SolarLocation
-      sunAngularVelocity: 0.0013506018881502325 rad
-      towardsSun: 2.107508378859541 rad
-    - type: Broadphase
-    - type: OccluderTree
 - proto: AirlockAssemblyCargo
   entities:
   - uid: 331

--- a/Resources/Maps/Shuttles/trading_outpost.yml
+++ b/Resources/Maps/Shuttles/trading_outpost.yml
@@ -1,17 +1,6 @@
 meta:
-  format: 7
-  category: Grid
-  engineVersion: 268.0.0
-  forkId: ""
-  forkVersion: ""
-  time: 12/17/2025 02:07:06
-  entityCount: 1371
-maps:
-- 33
-grids:
-- 2
-orphans: []
-nullspace: []
+  format: 6
+  postmapinit: false
 tilemap:
   0: Space
   31: FloorDark
@@ -41,7 +30,7 @@ entities:
       name: Automated Trade Station
     - type: Transform
       pos: -2.9375,-1.625
-      parent: 33
+      parent: invalid
     - type: MapGrid
       chunks:
         0,0:
@@ -618,19 +607,6 @@ entities:
     - type: GasTileOverlay
     - type: RadiationGridResistance
     - type: ImplicitRoof
-  - uid: 33
-    components:
-    - type: MetaData
-      name: Map Entity
-    - type: Transform
-    - type: Map
-      mapPaused: True
-    - type: GridTree
-    - type: SolarLocation
-      sunAngularVelocity: 0.0014256716901055683 rad
-      towardsSun: 2.7040584237289575 rad
-    - type: Broadphase
-    - type: OccluderTree
 - proto: AirAlarm
   entities:
   - uid: 424

--- a/Resources/Maps/Shuttles/trading_outpost_blank.yml
+++ b/Resources/Maps/Shuttles/trading_outpost_blank.yml
@@ -1,11 +1,6 @@
 meta:
-  format: 7
-  category: Grid
-  engineVersion: 268.0.0
-  forkId: pss14
-  forkVersion: b788360f67dd0852241b407cf4ed0c2f8d5be04f
-  time: 12/21/2025 04:09:17
-  entityCount: 1305
+  format: 6
+  postmapinit: false
 maps:
 - 33
 grids:
@@ -41,7 +36,7 @@ entities:
       name: Hunter Trade Station
     - type: Transform
       pos: -2.9375,-1.625
-      parent: 33
+      parent: invalid
     - type: MapGrid
       chunks:
         0,0:
@@ -382,19 +377,6 @@ entities:
     - type: GasTileOverlay
     - type: RadiationGridResistance
     - type: ImplicitRoof
-  - uid: 33
-    components:
-    - type: MetaData
-      name: Map Entity
-    - type: Transform
-    - type: Map
-      mapPaused: True
-    - type: GridTree
-    - type: SolarLocation
-      sunAngularVelocity: 0.001765702559050777 rad
-      towardsSun: 0.47842178568226373 rad
-    - type: Broadphase
-    - type: OccluderTree
 - proto: AirAlarm
   entities:
   - uid: 424

--- a/Resources/Maps/Shuttles/trading_outpost_engineering.yml
+++ b/Resources/Maps/Shuttles/trading_outpost_engineering.yml
@@ -7710,16 +7710,6 @@ entities:
       parent: 2
 - proto: ClothingBeltUtilityEngineering
   entities:
-  - uid: 434
-    components:
-    - type: Transform
-      pos: 6.2896113,-14.183771
-      parent: 2
-    - type: UserInterface
-      actors:
-        enum.StorageUiKey.Key:
-        - invalid
-    - type: ActiveUserInterface
   - uid: 435
     components:
     - type: Transform

--- a/Resources/Maps/Shuttles/trading_outpost_engineering.yml
+++ b/Resources/Maps/Shuttles/trading_outpost_engineering.yml
@@ -1,17 +1,6 @@
 meta:
-  format: 7
-  category: Grid
-  engineVersion: 270.0.0
-  forkId: pss14
-  forkVersion: a42b6c65cecbf5d6276e9bd7fb3019060a22f20b
-  time: 12/30/2025 03:46:33
-  entityCount: 1341
-maps:
-- 33
-grids:
-- 2
-orphans: []
-nullspace: []
+  format: 6
+  postmapinit: false
 tilemap:
   0: Space
   31: FloorDark
@@ -43,7 +32,7 @@ entities:
       name: Engineering Trade Station
     - type: Transform
       pos: -2.9375,-1.625
-      parent: 33
+      parent: invalid
     - type: MapGrid
       chunks:
         0,0:
@@ -559,19 +548,6 @@ entities:
     - type: RadiationGridResistance
     - type: ImplicitRoof
     - type: ExplosionAirtightGrid
-  - uid: 33
-    components:
-    - type: MetaData
-      name: Map Entity
-    - type: Transform
-    - type: Map
-      mapPaused: True
-    - type: GridTree
-    - type: SolarLocation
-      sunAngularVelocity: 0.0013282153080185492 rad
-      towardsSun: 4.182544209635864 rad
-    - type: Broadphase
-    - type: OccluderTree
 - proto: AirAlarm
   entities:
   - uid: 424

--- a/Resources/Maps/Shuttles/trading_outpost_explore.yml
+++ b/Resources/Maps/Shuttles/trading_outpost_explore.yml
@@ -1,17 +1,6 @@
 meta:
-  format: 7
-  category: Grid
-  engineVersion: 268.0.0
-  forkId: pss14
-  forkVersion: 3f642a4a74df463d6cc17ad566feb90d0b06f697
-  time: 12/24/2025 02:32:31
-  entityCount: 1347
-maps:
-- 33
-grids:
-- 2
-orphans: []
-nullspace: []
+  format: 6
+  postmapinit: false
 tilemap:
   0: Space
   11: FloorBar
@@ -49,7 +38,7 @@ entities:
       name: Explorer Trade Station
     - type: Transform
       pos: -2.9375,-1.625
-      parent: 33
+      parent: invalid
     - type: MapGrid
       chunks:
         0,0:
@@ -391,19 +380,6 @@ entities:
     - type: RadiationGridResistance
     - type: ImplicitRoof
     - type: ExplosionAirtightGrid
-  - uid: 33
-    components:
-    - type: MetaData
-      name: Map Entity
-    - type: Transform
-    - type: Map
-      mapPaused: True
-    - type: GridTree
-    - type: SolarLocation
-      sunAngularVelocity: 0.0019621272284944453 rad
-      towardsSun: 5.330442700909319 rad
-    - type: Broadphase
-    - type: OccluderTree
 - proto: AirAlarm
   entities:
   - uid: 424

--- a/Resources/Maps/Shuttles/trading_outpost_hunter.yml
+++ b/Resources/Maps/Shuttles/trading_outpost_hunter.yml
@@ -1,17 +1,6 @@
 meta:
-  format: 7
-  category: Grid
-  engineVersion: 268.0.0
-  forkId: pss14
-  forkVersion: b788360f67dd0852241b407cf4ed0c2f8d5be04f
-  time: 12/21/2025 04:58:21
-  entityCount: 1342
-maps:
-- 33
-grids:
-- 2
-orphans: []
-nullspace: []
+  format: 6
+  postmapinit: false
 tilemap:
   0: Space
   31: FloorDark
@@ -45,7 +34,7 @@ entities:
       name: Hunter Trade Station
     - type: Transform
       pos: -2.9375,-1.625
-      parent: 33
+      parent: invalid
     - type: MapGrid
       chunks:
         0,0:
@@ -386,19 +375,6 @@ entities:
     - type: GasTileOverlay
     - type: RadiationGridResistance
     - type: ImplicitRoof
-  - uid: 33
-    components:
-    - type: MetaData
-      name: Map Entity
-    - type: Transform
-    - type: Map
-      mapPaused: True
-    - type: GridTree
-    - type: SolarLocation
-      sunAngularVelocity: 0.001765702559050777 rad
-      towardsSun: 0.47842178568226373 rad
-    - type: Broadphase
-    - type: OccluderTree
 - proto: AirAlarm
   entities:
   - uid: 424

--- a/Resources/Maps/Shuttles/trading_outpost_science.yml
+++ b/Resources/Maps/Shuttles/trading_outpost_science.yml
@@ -32,7 +32,6 @@ entities:
       name: Science Trade Station
     - type: Transform
       pos: -2.9375,-1.625
-      parent: 1
     - type: MapGrid
       chunks:
         0,0:
@@ -1876,23 +1875,25 @@ entities:
     - type: Transform
       pos: 12.541403,3.5539834
       parent: 2
-    - type: Storage
-      storedItems:
-        1444:
-          position: 0,0
-          _rotation: South
-    - type: ContainerContainer
-      containers:
-        storagebase: !type:Container
-          showEnts: False
-          occludes: True
-          ents:
-          - 1444
   - uid: 1445
     components:
     - type: Transform
       pos: 12.541403,3.5539834
       parent: 2
+- proto: NetworkConfigurator
+  entities:
+  - uid: 1444
+    components:
+    - type: Transform
+      pos: 12.541403,3.5539834
+      parent: 2
+    - type: NetworkConfigurator
+      devices:
+        SCR-2820-523E: 161
+        VNT-58BA-3674: 1037
+      linkModeActive: False
+    - type: Physics
+      canCollide: False
 - proto: BoxSyringe
   entities:
   - uid: 1446
@@ -13961,19 +13962,6 @@ entities:
         Blunt: 0
         Slash: 0
         Piercing: 0
-- proto: NetworkConfigurator
-  entities:
-  - uid: 1444
-    components:
-    - type: Transform
-      parent: 1443
-    - type: NetworkConfigurator
-      devices:
-        SCR-2820-523E: 161
-        VNT-58BA-3674: 1037
-      linkModeActive: False
-    - type: Physics
-      canCollide: False
 - proto: PaperBin10
   entities:
   - uid: 823

--- a/Resources/Maps/Shuttles/trading_outpost_science.yml
+++ b/Resources/Maps/Shuttles/trading_outpost_science.yml
@@ -1,17 +1,6 @@
 meta:
-  format: 7
-  category: Grid
-  engineVersion: 268.0.0
-  forkId: ""
-  forkVersion: ""
-  time: 12/25/2025 20:43:48
-  entityCount: 1497
-maps:
-- 1
-grids:
-- 2
-orphans: []
-nullspace: []
+  format: 6
+  postmapinit: false
 tilemap:
   0: Space
   31: FloorDark
@@ -37,19 +26,6 @@ tilemap:
 entities:
 - proto: ""
   entities:
-  - uid: 1
-    components:
-    - type: MetaData
-      name: Map Entity
-    - type: Transform
-    - type: Map
-      mapPaused: True
-    - type: GridTree
-    - type: SolarLocation
-      sunAngularVelocity: 0.0013670176714303945 rad
-      towardsSun: 5.708141463451581 rad
-    - type: Broadphase
-    - type: OccluderTree
   - uid: 2
     components:
     - type: MetaData

--- a/Resources/Prototypes/Entities/Objects/Fun/dice.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/dice.yml
@@ -39,9 +39,6 @@
     currentValue: 20
   - type: Sprite
     state: d20_20
-  - type: Tag
-    tags:
-    - DiceD20
 
 - type: entity
   parent: BaseDice

--- a/Resources/Prototypes/Entities/Structures/Walls/asteroid.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/asteroid.yml
@@ -447,7 +447,7 @@
       map: [ "enum.MiningScannerVisualLayers.Overlay" ]
 
 - type: entity
-  id: AsteroidRockTinOre
+  id: AsteroidRockTin
   parent: AsteroidRock
   description: An ore vein rich with tin.
   suffix: Tin
@@ -1486,7 +1486,7 @@
   components:
   - type: EntityRemap
     mask:
-      AsteroidRock: AsteroidRockTinOre
+      AsteroidRock: AsteroidRockTin
       WallRockBasalt: WallRockBasaltTin
       WallRockChromite: WallRockChromiteTin
       WallRockSand: WallRockSandTin


### PR DESCRIPTION
## About the PR
General error message reduction for the server console.

## Technical details
Modified 8 yml grid files to use format 6 instead of format 7, avoiding robust toolbox error messages that appeared whenever one spawned.
Eliminated ReagentDispenserSystem function called on map initialization that added item slots for a handful of reagent dispenser items. Two functions were serving the same purpose and causing duplicate item slot errors, the map initialization function was chosen to be removed over the component initialization function as other checked component systems appeared to prefer component initialization over map initialization.
Removed UserInterface uid from trading_outpost_engineering.yml as the entity deserializer didn't know what to do with it.
Changed tin ore asteroid id to match standard asteroid format and to allow two ruins spawners to work that previously were failing to do so.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.