### PR TITLE
Fix Radar Console Printing

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/cargo.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/cargo.yml
@@ -16,7 +16,6 @@
   - RecyclerMachineCircuitboard
   - CargoBountyComputerCircuitboard
   - SalvageJobBoardComputerCircuitboard
-  - RadarConsoleCircuitboard
 ## Dynamic
 
 - type: latheRecipePack
@@ -34,3 +33,4 @@
   recipes:
   - OreProcessorIndustrialMachineCircuitboard
   - ShuttleGunKineticCircuitboard
+  - RadarConsoleCircuitboard

--- a/Resources/Prototypes/Recipes/Lathes/computer_boards.yml
+++ b/Resources/Prototypes/Recipes/Lathes/computer_boards.yml
@@ -170,6 +170,7 @@
   parent: [ BaseCircuitboardRecipe, BaseSupplyComputerRecipeCategory ]
   id: RadarConsoleCircuitboard
   result: RadarConsoleCircuitboard
+  unlockUses: 4
 
 - type: latheRecipe
   parent: [ BaseGoldCircuitboardRecipe, BaseSupplyComputerRecipeCategory ]


### PR DESCRIPTION
Radar Console Board Recipe was 'researchable' but was in static board pack. This PR fixes it.

