### PR TITLE
Can Unlock from Inside Locker

### DIFF
--- a/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
@@ -91,10 +91,6 @@ public abstract class SharedEntityStorageSystem : EntitySystem
         // Cannot (un)lock open lockers.
         if (target.Open)
             args.Cancelled = true;
-
-        // Cannot (un)lock from the inside. Maybe a bad idea? Security jocks could trap nerds in lockers?
-        if (target.Contents.Contains(args.User))
-            args.Cancelled = true;
     }
 
     private void OnDestruction(EntityUid uid, EntityStorageComponent component, DestructionEventArgs args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Entity Containers can now be unlocked from the inside (provided the contained person has the required access).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Discussed on the discord, I think preventing people from unlocking containers causes more problems than it solves.

## Technical details
<!-- Summary of code changes for easier review. -->
* Removed the restriction preventing contained users from unlocking containers in SharedEntityContainerSystem.cs

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Locked storage containers now have locks on the inside too.

