### PR TITLE
Bugfix: HARMPACK hand duplication

### DIFF
--- a/Content.Shared/Hands/EntitySystems/ExtraHandsEquipmentSystem.cs
+++ b/Content.Shared/Hands/EntitySystems/ExtraHandsEquipmentSystem.cs
@@ -22,8 +22,7 @@ public sealed class ExtraHandsEquipmentSystem : EntitySystem
 
         foreach (var (handName, hand) in ent.Comp.Hands)
         {
-            // add the NetEntity id to the container name to prevent multiple items with this component from conflicting
-            var handId = $"{GetNetEntity(ent.Owner).Id}-{handName}";
+            var handId = $"{handName}";
             _hands.AddHand((args.Equipee, handsComp), handId, hand.Location);
         }
     }
@@ -35,8 +34,7 @@ public sealed class ExtraHandsEquipmentSystem : EntitySystem
 
         foreach (var handName in ent.Comp.Hands.Keys)
         {
-            // add the NetEntity id to the container name to prevent multiple items with this component from conflicting
-            var handId = $"{GetNetEntity(ent.Owner).Id}-{handName}";
+            var handId = $"{handName}";
             _hands.RemoveHand((args.Equipee, handsComp), handId);
         }
     }

--- a/Resources/Prototypes/Entities/Clothing/Back/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/specific.yml
@@ -118,9 +118,9 @@
     hands:
       # middle hands to prevent overlapping inhand sprites
       # This can be changed once we have per-hand displacement maps
-      extra_hand_1:
+      harmpack_hand_1:
         location: Middle
-      extra_hand_2:
+      harmpack_hand_2:
         location: Middle
 
 - type: entity


### PR DESCRIPTION
Removed NetEnt reference from ExtraHandsEquipmentSystem handID assignment. Modified specific.yml to use a unique hand id set for the harmpack hands.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed bug where removing harmpacks after save failed to remove hands.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfixes. Is this section really necessary?

## Technical details
<!-- Summary of code changes for easier review. -->
* Old harmpack implementation used NetEnt ids in the name assignment of hand slots. These IDs do not persist.
* Modified ExtraHandsEquipmentSystem to use static IDs instead of Network IDs.
* Modified relevant YAML to use better naming for hands.


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
* Anyone currently weaking a HARMPACK in game will still keep their duplicate hands. 
* Anyone with extra hands will keep their extra hands.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: HARMPACKs no longer create duplicate hands when removed after loading a save
