### PR TITLE
Bugfix: Persistent Artifact Sprites

### DIFF
--- a/Content.Client/Xenoarchaeology/XenoArtifacts/RandomArtifactSpriteSystem.cs
+++ b/Content.Client/Xenoarchaeology/XenoArtifacts/RandomArtifactSpriteSystem.cs
@@ -11,6 +11,9 @@ public sealed class RandomArtifactSpriteSystem : VisualizerSystem<RandomArtifact
             return;
 
         if (!AppearanceSystem.TryGetData<int>(uid, SharedArtifactsVisuals.SpriteIndex, out var spriteIndex, args.Component))
+            spriteIndex = component.SelectedSprite;
+
+        if (spriteIndex < 0)
             return;
 
         if (!AppearanceSystem.TryGetData<bool>(uid, SharedArtifactsVisuals.IsUnlocking, out var isUnlocking, args.Component))

--- a/Content.Server/Xenoarchaeology/Artifact/RandomArtifactSpriteSystem.cs
+++ b/Content.Server/Xenoarchaeology/Artifact/RandomArtifactSpriteSystem.cs
@@ -46,6 +46,8 @@ public sealed class RandomArtifactSpriteSystem : EntitySystem
     private void OnMapInit(EntityUid uid, RandomArtifactSpriteComponent component, MapInitEvent args)
     {
         var randomSprite = _random.Next(component.MinSprite, component.MaxSprite + 1);
+        component.SelectedSprite = randomSprite;
+        Dirty(uid, component);
         _appearance.SetData(uid, SharedArtifactsVisuals.SpriteIndex, randomSprite);
         _item.SetHeldPrefix(uid, "ano" + randomSprite.ToString("D2")); //set item artifact inhands
     }

--- a/Content.Shared/Xenoarchaeology/XenoArtifacts/RandomArtifactSpriteComponent.cs
+++ b/Content.Shared/Xenoarchaeology/XenoArtifacts/RandomArtifactSpriteComponent.cs
@@ -1,8 +1,13 @@
+using Robust.Shared.GameStates;
+
 namespace Content.Shared.Xenoarchaeology.XenoArtifacts;
 
-[RegisterComponent]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class RandomArtifactSpriteComponent : Component
 {
+    [DataField, AutoNetworkedField]
+    public int SelectedSprite = -1;
+
     [DataField("minSprite")]
     public int MinSprite = 1;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed bug where artifact sprites would reset on save load.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It was very sad seeing artifacts all be the same boring sprite at the start of every shift.

## Technical details
<!-- Summary of code changes for easier review. -->
* Added new DataField to RandomArtifactSpriteComponent.cs called SelectedSprite which is stored when the sprite is selected.
* If possible, OnChangeAppearance uses this variable to set the appearance of the sprite. 

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="396" height="313" alt="image" src="https://github.com/user-attachments/assets/d00a7bdb-74ac-4e40-a112-88c85b70b492" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Unfortunately this will only work for newly made artifacts. Existing ones will still all be the same....

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed artifact sprites not saving properly and reverting to standard.
