### PR TITLE
Morgue Labels

### DIFF
--- a/Content.Shared/Morgue/SharedMorgueSystem.cs
+++ b/Content.Shared/Morgue/SharedMorgueSystem.cs
@@ -1,4 +1,8 @@
+using System.Linq;
+using Content.Shared.Access.Systems;
 using Content.Shared.Examine;
+using Content.Shared.Labels.Components;
+using Content.Shared.Labels.EntitySystems;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Morgue.Components;
 using Content.Shared.Storage.Components;
@@ -9,6 +13,8 @@ namespace Content.Shared.Morgue;
 public abstract class SharedMorgueSystem : EntitySystem
 {
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private SharedIdCardSystem _id = default!;
+    [Dependency] private LabelSystem _label = default!;
 
     public override void Initialize()
     {
@@ -65,6 +71,9 @@ public abstract class SharedMorgueSystem : EntitySystem
         }
 
         var hasMob = false;
+        bool hasSoul = false;
+
+        List<string> uniqueNames = new();
 
         foreach (var ent in storage.Contents.ContainedEntities)
         {
@@ -72,12 +81,42 @@ public abstract class SharedMorgueSystem : EntitySystem
                 hasMob = true;
 
             if (HasComp<ActorComponent>(ent))
+                hasSoul = true;
+
+            if (_id.TryGetIdCard(ent, out var idCard)) // If it has an ID Card, use that.
+                uniqueNames.Add(idCard.Comp.NameLocId);
+            else // If it doesn't have an ID Card, get the entities name
             {
-                _appearance.SetData(uid, MorgueVisuals.Contents, MorgueContents.HasSoul, app);
-                return;
+                try
+                {
+                    var name = Name(ent);
+                    uniqueNames.Add(name);
+                }
+                catch (KeyNotFoundException) { } // If the entity doesn't have a name, don't do anything.
             }
         }
 
-        _appearance.SetData(uid, MorgueVisuals.Contents, hasMob ? MorgueContents.HasMob : MorgueContents.HasContents, app);
+        if (TryComp<LabelComponent>(uid, out var labelComp)) // Update the label to match the name of the stored entities.
+            if (uniqueNames.Count > 0)
+                _label.Label(uid, ConstructNameLabel(uniqueNames), label: labelComp);
+            else _label.Label(uid, null, label: labelComp);
+
+        var appearanceState = hasSoul ? MorgueContents.HasSoul : hasMob ? MorgueContents.HasMob : MorgueContents.HasContents;
+        _appearance.SetData(uid, MorgueVisuals.Contents, appearanceState, app);
+    }
+
+    private string ConstructNameLabel(List<string> names)
+    {
+        List<string> converted = new();
+
+        foreach (var name in names)
+        {
+            if (Loc.TryGetString(name, out var loc))
+                converted.Add(loc);
+            else
+                converted.Add(name);
+        }
+
+        return string.Join(", ", converted);
     }
 }

--- a/Resources/Prototypes/Entities/Structures/Storage/morgue.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/morgue.yml
@@ -75,6 +75,7 @@
   - type: Construction
     graph: MorgueGraph
     node: morgue
+  - type: Label
 
 - type: entity
   id: MorgueAssembly


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Two things:
1) Added the ability to put labels on morgues
2) Made Morgues automatically add labels to match the name of any contained entities.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The ability to label morgues is oddly missing and would allow for knowing who is in a morgue before it is opened sounds quite nice as a QoL change.

## Technical details
<!-- Summary of code changes for easier review. -->
* SharedMorgueSystem.cs now scans for the names of the contained entities when checking its contents. Names are applied as a label.
* Label not updates on empty morgues meaning that a morgue can tell you who was last in it.
* Hand labeler can clear the name.
* Added label component to morgue entity proto in morgue.yml

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="481" height="296" alt="image" src="https://github.com/user-attachments/assets/770f59fa-b335-4129-b3c5-fc12a0ed25a6" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Linter is still broken, but I have a made a different PR for that.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Morgues are now labeled with the name of its most recent occupant!
