### PR TITLE
reduce tiny fan's deltapressure

### DIFF
--- a/Resources/Prototypes/Atmospherics/Thresholds/deltapressure.yml
+++ b/Resources/Prototypes/Atmospherics/Thresholds/deltapressure.yml
@@ -42,7 +42,7 @@
     minPressure: 3750
     minPressureDelta: 2500
 
-## -- PLASMA -- 
+## -- PLASMA --
 ## For plasma windows
 - type: entity
   abstract: true
@@ -129,3 +129,12 @@
     minPressureDelta: 50000
     scalingType: Linear
 
+# For tiny fans
+- type: entity
+  abstract: true
+  id: BaseDeltaPressureFans
+  components:
+  - type: DeltaPressure
+    minPressure: 200
+    minPressureDelta: 150
+    scalingType: Linear

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/special.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/special.yml
@@ -1,6 +1,7 @@
 # Devices which are not portable but don't link up to anything
 - type: entity
   id: AtmosDeviceFanTiny
+  parent: BaseDeltaPressureFans
   name: tiny fan
   description: A tiny fan, releasing a thin gust of air.
   placement:
@@ -43,9 +44,29 @@
   - type: Tag
     tags:
       - SpreaderIgnore
+  - type: Damageable
+    damageContainer: StructuralInorganic
+    damageModifierSet: StructuralMetallic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 1
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+          spawn:
+            TinyFanFlatpack:
+              min: 1
+              max: 1
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalSlam
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
 
 - type: entity
   id: AtmosDeviceFanDirectional
+  parent: BaseDeltaPressureFans
   name: directional fan
   description: A thin fan, stopping the movement of gases across it.
   placement:
@@ -91,3 +112,22 @@
   - type: Tag
     tags:
       - SpreaderIgnore
+  - type: Damageable
+    damageContainer: StructuralInorganic
+    damageModifierSet: StructuralMetallic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 1
+      behaviors:
+      - !type:SpawnEntitiesBehavior
+          spawn:
+            DirectionalFanFlatpack:
+              min: 1
+              max: 1
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalSlam
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This PR make tiny fans break into flatboxes when deltapressure is above 200kPa
This is a re-upload because the last one fails checks

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
Added a code block for deltapressure specifically for tiny fans.
Added new components for tiny and directional fans to make them break down

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
