### PR TITLE
Science Research Rebalance

### DIFF
--- a/Content.Shared/Xenoarchaeology/Artifact/Components/XenoArtifactNodeComponent.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/Components/XenoArtifactNodeComponent.cs
@@ -57,7 +57,7 @@ public sealed partial class XenoArtifactNodeComponent : Component
     /// The maximum factor by which using the durability of an artifact will scale it's Research Value.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float DurabilityResearchMultiplier = 2f;
+    public float DurabilityResearchMultiplier = 4f;
 
     /// <summary>
     /// The variance from MaxDurability present when a node is created.
@@ -113,7 +113,7 @@ public sealed partial class XenoArtifactNodeComponent : Component
     /// The amount of points a node is worth with no scaling
     /// </summary>
     [DataField, AutoNetworkedField]
-    public float BasePointValue = 4000;
+    public float BasePointValue = 2000;
 
     /// <summary>
     /// Amount of points available currently for extracting.

--- a/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Node.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Node.cs
@@ -395,9 +395,9 @@ public abstract partial class SharedXenoArtifactSystem
         var durabilityEffect = MathF.Pow((float)nodeComponent.Durability / maxDurability, 2);
         var durabilityMultiplier = nodeComponent.DurabilityResearchMultiplier - (nodeComponent.DurabilityResearchMultiplier - 1) * durabilityEffect;
 
-        var predecessorNodes = GetPredecessorNodes((artifact, artifact), node);
-        var predecessorMultiplier = Math.Pow(1.25, Math.Pow(predecessorNodes.Count, 1.5f));
-        nodeComponent.ResearchValue = (int)(nodeComponent.BasePointValue * predecessorMultiplier * durabilityMultiplier);
+        var nodeDepth = node.Comp.Depth;
+        var depthMultipler = Math.Pow(1.5f, Math.Pow(nodeDepth, 1.5f));
+        nodeComponent.ResearchValue = (int)(nodeComponent.BasePointValue * depthMultipler * durabilityMultiplier);
     }
 
     public void Shatter(Entity<XenoArtifactNodeComponent?> node)

--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -144,7 +144,7 @@
     state: icon
   discipline: Arsenal
   tier: 2
-  cost: 10000
+  cost: 50000
   recipeUnlocks:
   - WeaponLaserCannon
 
@@ -156,7 +156,7 @@
     state: icon
   discipline: Arsenal
   tier: 2
-  cost: 10000
+  cost: 50000
   recipeUnlocks:
   - WeaponXrayCannon
 
@@ -168,7 +168,7 @@
     state: display
   discipline: Arsenal
   tier: 2
-  cost: 7500
+  cost: 37500
   recipeUnlocks:
   - PKAUpgradeDamage
   - PKAUpgradeRange
@@ -182,7 +182,7 @@
     state: full
   discipline: Arsenal
   tier: 2
-  cost: 10500
+  cost: 52500
   recipeUnlocks:
   - PowerCageRechargerCircuitboard
   - PowerCageSmall
@@ -204,7 +204,7 @@
     state: icon
   discipline: Arsenal
   tier: 2
-  cost: 10000
+  cost: 50000
   recipeUnlocks:
   - ClothingBackpackHarmpack
 
@@ -216,7 +216,7 @@
     state: icon
   discipline: Arsenal
   tier: 2
-  cost: 15000
+  cost: 75000
   recipeUnlocks:
   - Securityhardsuit
   - Brigmedichardsuit
@@ -236,7 +236,7 @@
     state: icon
   discipline: Arsenal
   tier: 3
-  cost: 15000
+  cost: 150000
   recipeUnlocks:
   - WeaponAdvancedLaser
   - PortableRecharger
@@ -249,7 +249,7 @@
     state: icon
   discipline: Arsenal
   tier: 3
-  cost: 15000
+  cost: 150000
   recipeUnlocks:
   - WeaponTemperatureGun
 
@@ -261,7 +261,7 @@
     state: icon
   discipline: Arsenal
   tier: 3
-  cost: 15000
+  cost: 150000
   recipeUnlocks:
   - GrenadeEMP
   - PowerCageHigh

--- a/Resources/Prototypes/Research/civilianservices.yml
+++ b/Resources/Prototypes/Research/civilianservices.yml
@@ -122,7 +122,7 @@
     state: astroice
   discipline: CivilianServices
   tier: 2
-  cost: 5000
+  cost: 25000
   recipeUnlocks:
   - FauxTileAstroGrass
   - FauxTileMowedAstroGrass
@@ -144,7 +144,7 @@
     state: icon
   discipline: CivilianServices
   tier: 2
-  cost: 7500
+  cost: 37500
   recipeUnlocks:
   - StasisBedMachineCircuitboard
   - CryoPodMachineCircuitboard
@@ -159,7 +159,7 @@
     state: medical
   discipline: CivilianServices
   tier: 2
-  cost: 5000
+  cost: 25000
   recipeUnlocks:
   - BorgModuleAdvancedTopical
   - AdvancedJetInjector
@@ -172,7 +172,7 @@
     state: advmop
   discipline: CivilianServices
   tier: 2
-  cost: 10000
+  cost: 50000
   recipeUnlocks:
   - AdvMopItem
   - MegaSprayBottle
@@ -186,7 +186,7 @@
     state: honker
   discipline: CivilianServices
   tier: 2
-  cost: 7500
+  cost: 32500
   recipeUnlocks:
   - HonkerHarness
   - HonkerLArm
@@ -206,7 +206,7 @@
     state: icon
   discipline: CivilianServices
   tier: 2
-  cost: 10000
+  cost: 50000
   recipeUnlocks:
   - WeaponSprayNozzle
   - ClothingBackpackWaterTank
@@ -219,7 +219,7 @@
     state: icon
   discipline: CivilianServices
   tier: 2
-  cost: 4000
+  cost: 20000
   recipeUnlocks:
   - PushHorn
   - BorgModuleAdvancedClowning
@@ -234,7 +234,7 @@
     state: icon
   discipline: CivilianServices
   tier: 3
-  cost: 10000
+  cost: 100000
   recipeUnlocks:
   - ClothingShoesBootsSpeed
 
@@ -246,7 +246,7 @@
     state: beakerbluespace
   discipline: CivilianServices
   tier: 3
-  cost: 10000
+  cost: 100000
   recipeUnlocks:
   - BluespaceBeaker
   - SyringeBluespace
@@ -259,7 +259,7 @@
     state: syringe_gun
   discipline: CivilianServices
   tier: 3
-  cost: 15000
+  cost: 150000
   recipeUnlocks:
   - LauncherSyringe
   - MiniSyringe
@@ -272,6 +272,6 @@
     state: telecom-nopower
   discipline: CivilianServices
   tier: 3
-  cost: 10000
+  cost: 100000
   recipeUnlocks:
   - TelecomServer1kCircuitboard

--- a/Resources/Prototypes/Research/experimental.yml
+++ b/Resources/Prototypes/Research/experimental.yml
@@ -92,7 +92,7 @@
     state: icon
   discipline: Experimental
   tier: 2
-  cost: 5000
+  cost: 25000
   recipeUnlocks:
   - ArtifactCrusherMachineCircuitboard
 
@@ -104,7 +104,7 @@
     state: base
   discipline: Experimental
   tier: 2
-  cost: 10000
+  cost: 50000
   recipeUnlocks:
   - WeaponPistolCHIMP
   - AnomalySynchronizerCircuitboard
@@ -120,7 +120,7 @@
     state: base
   discipline: Experimental
   tier: 2
-  cost: 7500
+  cost: 32500
   recipeUnlocks:
   - WeaponParticleDecelerator
   - HoloprojectorField
@@ -133,7 +133,7 @@
     state: base
   discipline: Experimental
   tier: 2
-  cost: 10000
+  cost: 50000
   recipeUnlocks:
     - WeaponForceGun
     - WeaponTetherGun
@@ -148,7 +148,7 @@
     state: icon
   discipline: Experimental
   tier: 3
-  cost: 10000
+  cost: 100000
   recipeUnlocks:
   - DeviceQuantumSpinInverter
 
@@ -160,6 +160,6 @@
     state: icon
   discipline: Experimental
   tier: 3
-  cost: 10000
+  cost: 100000
   recipeUnlocks:
   - DeviceDesynchronizer

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -162,7 +162,7 @@
     state: base
   discipline: Industrial
   tier: 2
-  cost: 10000
+  cost: 50000
   recipeUnlocks:
   - ShuttleConsoleCircuitboard
   - ThrusterMachineCircuitboard
@@ -178,7 +178,7 @@
     state: icon
   discipline: Industrial
   tier: 2
-  cost: 7500
+  cost: 32500
   recipeUnlocks:
   - HellfireFreezerMachineCircuitBoard
   - PortableScrubberMachineCircuitBoard
@@ -194,7 +194,7 @@
     state: icon
   discipline: Industrial
   tier: 2
-  cost: 10000
+  cost: 50000
   recipeUnlocks:
     - WelderExperimental
     - PowerDrill
@@ -211,7 +211,7 @@
     state: handdrill
   discipline: Industrial
   tier: 2
-  cost: 12500
+  cost: 62500
   recipeUnlocks:
     - OreBagOfHolding
     - MiningDrillDiamond
@@ -226,7 +226,7 @@
     state: icon
   discipline: Industrial
   tier: 2
-  cost: 12500
+  cost: 62500
   recipeUnlocks:
   - Engineeringsuit
   - Atmossuit
@@ -244,7 +244,7 @@
     state: holding
   discipline: Industrial
   tier: 3
-  cost: 15000
+  cost: 150000
   recipeUnlocks:
   - ClothingBackpackHolding
   - ClothingBackpackSatchelHolding
@@ -258,7 +258,7 @@
     state: microreactor
   discipline: Industrial
   tier: 3
-  cost: 10000
+  cost: 100000
   recipeUnlocks:
   - PowerCellMicroreactor
   - PowerCellHyper
@@ -273,7 +273,7 @@
     state: icon
   discipline: Industrial
   tier: 3
-  cost: 20000
+  cost: 200000
   recipeUnlocks:
   - Luxuryminingsuit
   - Researchdirectorsuit


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
* Base research values of nodes reduced from 4k to 2k.
* Durability multiplier for research values increased from 2x to 4x
* All T2 technology costs increased by 5x
* All T3 technology costs increased by 10x
* Research value curve now based on node depth, was predecessors count.
* Steepness of research value curve increased.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
As it currently stands, anyone who does any amount of research starts swimming in research points. In particular, Zenith currently has around 1.5 million points, where the *most* expensive research is currently 20,000 points. This dramatically reduces the value of high end technologies such as bags of holding, QSIs, microreactor cells, etc. In a persistent environment, these problems are exaggerated.

These changes seek to dramatically slow down research, while still allowing small teams to dive in and contribute to research. Small tier techs are still fairly easily available. High end techs may now cost around 100k all the way to 200k for the most expensive techs.

## Technical details
<!-- Summary of code changes for easier review. -->
* Curve was modified to be steeper. New curve is nodeDepthMultiplier = 1.5 ^ depth ^ 1.5, was 1.25 ^ depth ^ 1.5
* Curve now uses node.Comp.Depth instead of GetPredecesors

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Arti research values now depends on depth
- tweak: Artis give less research when at full durability
- tweak: Research is much more expensive for T2 and T3 techs
