### PR TITLE
Purchased Artifacts Always Large

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/artifacts.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/artifacts.yml
@@ -6,6 +6,12 @@
       weight: 2
     - id: ComplexXenoArtifactItem
 
+- type: entityTable
+  id: RandomArtifactTableLarge
+  table: !type:GroupSelector
+    children:
+    - id: ComplexXenoArtifact
+
 - type: entity
   parent: MarkerBase
   id: RandomArtifactSpawner
@@ -18,7 +24,7 @@
       state: ano01
   - type: EntityTableSpawner
     table: !type:NestedSelector
-      tableId: RandomArtifactTable
+      tableId: RandomArtifactTableLarge
 
 - type: entity
   id: RandomArtifactSpawner20


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Makes artifacts purchased from a trade station always come out as large artifacts.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
With recent changes to artifacts, there is now a substantive difference between large and small artifacts. Small ones can be continually made from fragments, while large ones must be purchased from a trade station (with a discount for the STS).
Having a 1/3 chance to just get a small one when I shill out big bucks hurts my soul.


## Technical details
<!-- Summary of code changes for easier review. -->
* Created new artifact spawning table RandomArtifactTableLarge which only contains the ComplexXenoArtifact and not the handheld varient
* Modified spawner to use the large table

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Purchased artifacts are always large
