### PR TITLE
Titanium Walls to Girder

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
@@ -425,7 +425,7 @@
     - node: titaniumWall
       entity: WallTitanium
       edges:
-        - to: reinforcedGirder
+        - to: girder
           completed:
             - !type:SpawnPrototype
               prototype: SheetTitanium1


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed bug where titanium wall would deconstruct to a reinforced girder but construct from a standard girder by making the wall deconstruct into a standard girder.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Before this was a way to get infinite plasteel. Can't have that now.

## Technical details
<!-- Summary of code changes for easier review. -->
* modified to node of girder construction graph titaniumWall node from reinforcedGirder to girder

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Titanium walls no longer deconstruct to reinforced girders