### PR TITLE
Sci Bounty Rebalance

### DIFF
--- a/Resources/Prototypes/Catalog/Bounties/sciencebounties.yml
+++ b/Resources/Prototypes/Catalog/Bounties/sciencebounties.yml
@@ -1,21 +1,21 @@
 - type: cargoBounty
   id: BountyArtifactGlue
-  reward: 10
+  reward: 25
   description: bounty-description-artifact
   reagentId: ArtifactGlue
   group: ScienceBounty
   bountyType: PayPerReagent
   entries:
   - name: bounty-item-artifactglue
-    amount: 1000
+    amount: 400
 
 - type: cargoBounty
   id: BountyArtifactMany
-  reward: 500
+  reward: 2000
   description: bounty-description-artifact
   entries:
   - name: bounty-item-artifact
-    amount: 20
+    amount: 5
     whitelist:
       components:
       - XenoArtifact
@@ -116,11 +116,11 @@
 
 - type: cargoBounty
   id: BountyBorgModule
-  reward: 2000
+  reward: 500
   description: bounty-description-borg-module
   entries:
   - name: bounty-item-borg-module
-    amount: 2
+    amount: 8
     whitelist:
       components:
       - BorgModule


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
* Changed artifact bounty from 20 to 5 (adjusting price from 500 to 2000). This pricing lines up with just barely less than buying an artifact would cost. Previously there was literally no point in completing this bounty.
* Changed artifact glue bounty from 1000 to 400 and reward from 10 to 25. Accounts for how much more difficult it is to make artifact glue now.
* Increased borg module bounty count from 2 to 8, decreased reward from 2000 to 500. Makes this one less lucrative but more at once.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
A number of the science bounties felt off in their reward to work ratios, especially considering recent changes made to how artifacts work, how artifact glue is made, etc.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Changed numerous values relating to science bounties
