### PR TITLE
Artifact Rebalancing

### DIFF
--- a/Resources/Prototypes/XenoArch/effects.yml
+++ b/Resources/Prototypes/XenoArch/effects.yml
@@ -772,7 +772,7 @@
         children:
         - id: SilverOre1
           rolls: !type:RangeNumberSelector
-            range: 2, 6
+            range: 1, 4
 
 - type: entity
   id: XenoArtifactRawMaterialSpawnSilverMore
@@ -790,7 +790,7 @@
         children:
         - id: SilverOre1
           rolls: !type:RangeNumberSelector
-            range: 7, 11
+            range: 5, 11
 
 - type: entity
   id: XenoArtifactRawMaterialSpawnSilverMany
@@ -826,7 +826,7 @@
         children:
         - id: BananiumOre1
           rolls: !type:RangeNumberSelector
-            range: 2, 6
+            range: 1, 4
 
 - type: entity
   id: XenoArtifactRawMaterialSpawnBananiumMore
@@ -844,7 +844,7 @@
         children:
         - id: BananiumOre1
           rolls: !type:RangeNumberSelector
-            range: 7, 11
+            range: 5, 11
 
 - type: entity
   id: XenoArtifactRawMaterialSpawnBananiumMany
@@ -880,7 +880,7 @@
         children:
         - id: PlasmaOre1
           rolls: !type:RangeNumberSelector
-            range: 2, 6
+            range: 1, 4
 
 - type: entity
   id: XenoArtifactRawMaterialSpawnPlasmaMore
@@ -898,7 +898,7 @@
         children:
         - id: PlasmaOre1
           rolls: !type:RangeNumberSelector
-            range: 7, 11
+            range: 5, 11
 
 - type: entity
   id: XenoArtifactRawMaterialSpawnPlasmaMany
@@ -934,7 +934,7 @@
         children:
         - id: GoldOre1
           rolls: !type:RangeNumberSelector
-            range: 2, 6
+            range: 1, 4
 
 - type: entity
   id: XenoArtifactRawMaterialSpawnGoldMore
@@ -952,7 +952,7 @@
         children:
         - id: GoldOre1
           rolls: !type:RangeNumberSelector
-            range: 7, 11
+            range: 5, 11
 
 - type: entity
   id: XenoArtifactRawMaterialSpawnGoldMany
@@ -988,7 +988,7 @@
         children:
         - id: UraniumOre1
           rolls: !type:RangeNumberSelector
-            range: 2, 6
+            range: 1, 4
 
 - type: entity
   id: XenoArtifactRawMaterialSpawnUraniumMore
@@ -1006,7 +1006,7 @@
         children:
         - id: UraniumOre1
           rolls: !type:RangeNumberSelector
-            range: 7, 11
+            range: 5, 11
 
 - type: entity
   id: XenoArtifactRawMaterialSpawnUraniumMany
@@ -1374,7 +1374,7 @@
       spawnDetached: true
       table: !type:GroupSelector
         rolls: !type:RangeNumberSelector
-          range: 2, 4
+          range: 3, 8
         children:
         - id: SheetGlass1
   
@@ -1390,11 +1390,14 @@
     - type: EntityTableSpawner
       deleteSpawnerAfterSpawn: false
       spawnDetached: true
-      table: !type:GroupSelector
-        rolls: !type:RangeNumberSelector
-          range: 1, 3
+      table: !type:AllSelector
         children:
         - id: SheetGlass10
+          rolls: !type:RangeNumberSelector
+            range: 1, 3
+        - id: SheetGlass1
+          rolls: !type:RangeNumberSelector
+            range: 1, 3
 
 - type: entity
   id: XenoArtifactMaterialSpawnGlassStack
@@ -1426,7 +1429,7 @@
       spawnDetached: true
       table: !type:GroupSelector
         rolls: !type:RangeNumberSelector
-          range: 2, 4
+          range: 3, 8
         children:
         - id: SheetSteel1
   
@@ -1442,11 +1445,14 @@
     - type: EntityTableSpawner
       deleteSpawnerAfterSpawn: false
       spawnDetached: true
-      table: !type:GroupSelector
-        rolls: !type:RangeNumberSelector
-          range: 1, 3
+      table: !type:AllSelector
         children:
         - id: SheetSteel10
+          rolls: !type:RangeNumberSelector
+            range: 1, 3
+        - id: SheetSteel1
+          rolls: !type:RangeNumberSelector
+            range: 1, 3
 
 - type: entity
   id: XenoArtifactMaterialSpawnSteelStack
@@ -1467,7 +1473,7 @@
 - type: entity
   id: XenoArtifactMaterialSpawnPlasticFew
   parent: BaseXenoArtifactEffect
-  description: Create a bit of platic
+  description: Create a bit of plastic
   components:
   - type: XAEApplyComponents
     applyIfAlreadyHave: true
@@ -1478,7 +1484,7 @@
       spawnDetached: true
       table: !type:GroupSelector
         rolls: !type:RangeNumberSelector
-          range: 2, 4
+          range: 3, 8
         children:
         - id: SheetPlastic1
   
@@ -1494,11 +1500,14 @@
     - type: EntityTableSpawner
       deleteSpawnerAfterSpawn: false
       spawnDetached: true
-      table: !type:GroupSelector
-        rolls: !type:RangeNumberSelector
-          range: 1, 3
+      table: !type:AllSelector
         children:
         - id: SheetPlastic10
+          rolls: !type:RangeNumberSelector
+            range: 1, 3
+        - id: SheetPlastic1
+          rolls: !type:RangeNumberSelector
+            range: 1, 3
 
 - type: entity
   id: XenoArtifactMaterialSpawnPlasticStack
@@ -1610,7 +1619,7 @@
 - type: entity
   id: XenoArtifactHealAll
   parent: BaseXenoArtifactEffect
-  description: Miraclous healing
+  description: Miraculous healing
   components:
   - type: XAEDamageInArea
     damageChance: 1
@@ -1645,7 +1654,7 @@
       spawnDetached: true
       table: !type:AllSelector
         children:
-        - id: Singularity
+        - id: TeslaEnergyBall
 
 - type: entity
   id: XenoArtifactSingularity
@@ -1661,7 +1670,7 @@
       spawnDetached: true
       table: !type:AllSelector
         children:
-        - id: TeslaEnergyBall
+        - id: Singularity
 
 - type: entity
   id: XenoArtifactExplosionScary


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Corrected a few spelling mistakes and modified some of the numeric values for various anomaly effects namely:
* raw material few nodes now give between 1-4 ore, was 2-6
* raw material more nodes now give between 5-11 ore, was 7-11
* material few nodes now give between 3-8 sheets, was 2-6
* material many nodes now give between 11-33 sheets, was 10-30

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Just some small balance tweaking. Material amount felt a bit off in many cases.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Changed multiple artifact effect node rewards