### PR TITLE
Bugfix: 0 durability node initial activation

### DIFF
--- a/Content.Shared/Xenoarchaeology/Artifact/Components/XenoArtifactNodeComponent.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/Components/XenoArtifactNodeComponent.cs
@@ -39,7 +39,7 @@ public sealed partial class XenoArtifactNodeComponent : Component
     /// <summary>
     /// Marker, is durability of node degraded or not.
     /// </summary>
-    public bool Degraded => Durability <= 0;
+    public bool Degraded => Durability <= 0 && ActivatedOnce;
 
     /// <summary>
     /// The amount of generic activations a node has left before becoming fully degraded and useless.
@@ -47,6 +47,12 @@ public sealed partial class XenoArtifactNodeComponent : Component
     [DataField, AutoNetworkedField]
     public int Durability;
 
+    /// <summary>
+    /// Marks whether the artifact has ever been activated. Used for the initial activation of 0 durability nodes.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool ActivatedOnce = false;
+    
     /// <summary>
     /// The maximum amount of times a node can be generically activated before becoming useless
     /// </summary>

--- a/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.XAE.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.XAE.cs
@@ -145,6 +145,7 @@ public abstract partial class SharedXenoArtifactSystem
         }
         var ev = new XenoArtifactNodeActivatedEvent(artifact, node, user, target, coordinates);
         RaiseLocalEvent(node, ref ev);
+        node.Comp.ActivatedOnce = true;
         return true;
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes a bug where the XAEApplyComponents effect would not actually apply the needed components because the node had 0 durability which meant it was disabled. Added a new bool to track the first activation. A node is only degraded if it has 0 durability AND has been activated at least once.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This was a bug caused by making single use nodes 0 durability. This fix preserves that functionality while allowing the nodes to still initially activate as necessary.

## Technical details
<!-- Summary of code changes for easier review. -->
* Added new field to XenoArtifactNodeComponent called ActivatedOnce
* Modified Degraded to ensure the artifact node has been activated once before degrading
* Modified XenoArtifactSystem.XAE to set ActivatedOnce to true when activated.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Existing single use nodes will need to be activated once in game to get their effects but should work just fine afterwards.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Artifact nodes that apply components now properly apply those components.
