### PR TITLE
Girder to Miner Wall Graph fix

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/girder.yml
@@ -72,7 +72,7 @@
             - tool: Welding
               doAfter: 10
 
-        - to: miningWall
+        - to: miningWallTemp
           completed:
             - !type:SnapToGrid
               southRotation: true
@@ -81,12 +81,6 @@
           steps:
             - tool: Screwing 
               doAfter: 2
-            - material: Steel
-              amount: 4
-              doAfter: 1
-            - material: Plastic
-              amount: 2
-              doAfter: 1
 
         - to: silverWall
           completed:
@@ -220,6 +214,25 @@
               doAfter: 10
             - tool: Prying
               doAfter: 10
+    
+    - node: miningWallTemp
+      entity: Girder
+      edges:
+        - to: girder
+          steps:
+          - tool: Screwing
+            doAfter: 2
+        
+        - to: miningWall
+          steps:
+          - material: Steel
+            amount: 4
+            doAfter: 1
+          - material: Plastic
+            amount: 2
+            doAfter: 1
+          - tool: Welding
+            doAfter: 8
 
     - node: miningWall
       entity: WallMining


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added additional intermediate step in the Mining Wall construction graph allowing accidental screwing of an anchored girder to be undone.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
So many of us have tried to deconstruct a girder only to accidentally get it stuck having to build up a whole mining wall just to then deconstruct the mining wall...

## Technical details
<!-- Summary of code changes for easier review. -->
* Simple modifications of girder.yml, see diff for more info.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
No known breaking changes

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Can now fix mistake of using screwdriver on anchored girder without building a whole mining wall.