### PR TITLE
Persistent Identification

### DIFF
--- a/Content.Server/DeviceLinking/Systems/DeviceLinkSystem.cs
+++ b/Content.Server/DeviceLinking/Systems/DeviceLinkSystem.cs
@@ -27,7 +27,8 @@ public sealed class DeviceLinkSystem : SharedDeviceLinkSystem
 
         foreach (var sinkUid in sinks)
         {
-            if (!sourceComponent.LinkedPorts.TryGetValue(sinkUid, out var links))
+            var id = Pid.EnsureId(sinkUid);
+            if (!sourceComponent.LinkedPorts.TryGetValue(id, out var links))
                 continue;
 
             if (!TryComp<DeviceLinkSinkComponent>(sinkUid, out var sinkComponent))

--- a/Content.Shared/DeviceLinking/DeviceLinkSourceComponent.cs
+++ b/Content.Shared/DeviceLinking/DeviceLinkSourceComponent.cs
@@ -32,7 +32,7 @@ public sealed partial class DeviceLinkSourceComponent : Component
     /// The list of source to sink ports for each linked sink entity for easier managing of links
     /// </summary>
     [DataField]
-    public Dictionary<EntityUid, HashSet<(ProtoId<SourcePortPrototype> Source, ProtoId<SinkPortPrototype> Sink)>> LinkedPorts = new();
+    public Dictionary<string, HashSet<(ProtoId<SourcePortPrototype> Source, ProtoId<SinkPortPrototype> Sink)>> LinkedPorts = new();
 
     /// <summary>
     ///     Limits the range devices can be linked across.

--- a/Content.Shared/DeviceLinking/SharedDeviceLinkSystem.cs
+++ b/Content.Shared/DeviceLinking/SharedDeviceLinkSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._Persistence14.PersistentIdentifier;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
 using Content.Shared.DeviceLinking.Events;
@@ -17,6 +18,7 @@ public abstract class SharedDeviceLinkSystem : EntitySystem
     [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly IGameTiming _gameTiming = default!;
+    [Dependency] protected readonly PersistentIdentifierSystem Pid = default!;
 
     public const string InvokedPort = "link_port";
 
@@ -35,13 +37,16 @@ public abstract class SharedDeviceLinkSystem : EntitySystem
     /// </summary>
     private void OnSourceStartup(Entity<DeviceLinkSourceComponent> source, ref ComponentStartup args)
     {
-        List<EntityUid> invalidSinks = new();
+        List<string> invalidSinks = new();
         List<(string, string)> invalidLinks = new();
-        foreach (var (sink, links) in source.Comp.LinkedPorts)
+        foreach (var (sinkId, links) in source.Comp.LinkedPorts)
         {
+            if (!Pid.TryResolveId(source, sinkId, out var sink))
+                continue;
+
             if (!TryComp(sink, out DeviceLinkSinkComponent? sinkComponent))
             {
-                invalidSinks.Add(sink);
+                invalidSinks.Add(sinkId);
                 continue;
             }
 
@@ -61,7 +66,7 @@ public abstract class SharedDeviceLinkSystem : EntitySystem
 
             if (links.Count == 0)
             {
-                invalidSinks.Add(sink);
+                invalidSinks.Add(sinkId);
                 continue;
             }
 
@@ -72,7 +77,7 @@ public abstract class SharedDeviceLinkSystem : EntitySystem
         foreach (var sink in invalidSinks)
         {
             source.Comp.LinkedPorts.Remove(sink);
-            Log.Warning($"Device source {ToPrettyString(source)} contains invalid sink: {ToPrettyString(sink)}");
+            Log.Warning($"Device source {ToPrettyString(source)} contains invalid sink id: {sink}");
         }
     }
     #endregion
@@ -83,12 +88,14 @@ public abstract class SharedDeviceLinkSystem : EntitySystem
     private void OnSourceRemoved(Entity<DeviceLinkSourceComponent> source, ref ComponentRemove args)
     {
         var query = GetEntityQuery<DeviceLinkSinkComponent>();
-        foreach (var sinkUid in source.Comp.LinkedPorts.Keys)
+        foreach (var sinkId in source.Comp.LinkedPorts.Keys)
         {
-            if (query.TryGetComponent(sinkUid, out var sink))
-                RemoveSinkFromSourceInternal(source, sinkUid, source, sink);
+            if (!Pid.TryResolveId(source, sinkId, out var sinkEnt))
+                continue;
+            if (query.TryGetComponent(sinkEnt, out var sink))
+                RemoveSinkFromSourceInternal(source, sinkEnt, source, sink);
             else
-                Log.Error($"Device source {ToPrettyString(source)} links to invalid entity: {ToPrettyString(sinkUid)}");
+                Log.Error($"Device source {ToPrettyString(source)} links to invalid entity: {ToPrettyString(sinkEnt.Owner)}");
         }
     }
 
@@ -208,8 +215,13 @@ public abstract class SharedDeviceLinkSystem : EntitySystem
     /// <returns>A list of sink and source port ids that are linked together</returns>
     public HashSet<(ProtoId<SourcePortPrototype> source, ProtoId<SinkPortPrototype> sink)> GetLinks(EntityUid sourceUid, EntityUid sinkUid, DeviceLinkSourceComponent? sourceComponent = null)
     {
-        if (!Resolve(sourceUid, ref sourceComponent) || !sourceComponent.LinkedPorts.TryGetValue(sinkUid, out var links))
+        var id = Pid.EnsureId(sinkUid);
+        if (
+            !Resolve(sourceUid, ref sourceComponent) ||
+            !sourceComponent.LinkedPorts.TryGetValue(id, out var links))
+        {
             return new HashSet<(ProtoId<SourcePortPrototype>, ProtoId<SinkPortPrototype>)>();
+        }
 
         return links;
     }
@@ -321,7 +333,8 @@ public abstract class SharedDeviceLinkSystem : EntitySystem
                 continue;
 
             sourceComponent.Outputs.GetOrNew(source).Add(sinkUid);
-            sourceComponent.LinkedPorts.GetOrNew(sinkUid).Add((source, sink));
+            var id = Pid.EnsureId(sinkUid);
+            sourceComponent.LinkedPorts.GetOrNew(id).Add((source, sink));
 
             SendNewLinkEvent(userId, sourceUid, source, sinkUid, sink);
         }
@@ -373,7 +386,7 @@ public abstract class SharedDeviceLinkSystem : EntitySystem
         else
         {
             Log.Error($"Attempted to remove link between {ToPrettyString(sourceUid)} and {ToPrettyString(sinkUid)}, but the sink component was missing.");
-            sourceComponent.LinkedPorts.Remove(sinkUid);
+            sourceComponent.LinkedPorts.Remove(Pid.EnsureId(sinkUid));
         }
     }
 
@@ -384,8 +397,13 @@ public abstract class SharedDeviceLinkSystem : EntitySystem
         DeviceLinkSinkComponent sinkComponent)
     {
         // This function gets called on component removal. Beware that TryComp & Resolve may return false.
+        if (!TryComp<PersistentIdentifierComponent>(sinkUid, out var idComp) || !Pid.TryGetId((sinkUid, idComp), out var id))
+            return;
 
-        if (sourceComponent.LinkedPorts.TryGetValue(sinkUid, out var ports))
+        if (EntityManager.Deleted(sourceUid) || EntityManager.Deleted(sinkUid))
+            return;
+
+        if (sourceComponent.LinkedPorts.TryGetValue(id, out var ports))
         {
             foreach (var (sourcePort, sinkPort) in ports)
             {
@@ -395,7 +413,7 @@ public abstract class SharedDeviceLinkSystem : EntitySystem
         }
 
         sinkComponent.LinkedSources.Remove(sourceUid);
-        sourceComponent.LinkedPorts.Remove(sinkUid);
+        sourceComponent.LinkedPorts.Remove(id);
         foreach (var outputList in sourceComponent.Outputs.Values)
         {
             outputList.Remove(sinkUid);
@@ -419,7 +437,8 @@ public abstract class SharedDeviceLinkSystem : EntitySystem
             return false;
 
         var outputs = sourceComponent.Outputs.GetOrNew(source);
-        var linkedPorts = sourceComponent.LinkedPorts.GetOrNew(sinkUid);
+        var id = Pid.EnsureId(sinkUid);
+        var linkedPorts = sourceComponent.LinkedPorts.GetOrNew(id);
 
         if (linkedPorts.Contains((source, sink)))
         {
@@ -437,7 +456,7 @@ public abstract class SharedDeviceLinkSystem : EntitySystem
             if (linkedPorts.Count != 0)
                 return true;
 
-            sourceComponent.LinkedPorts.Remove(sinkUid);
+            sourceComponent.LinkedPorts.Remove(id);
             sinkComponent.LinkedSources.Remove(sourceUid);
             CreateLinkPopup(userId, sourceUid, source, sinkUid, sink, true);
         }

--- a/Content.Shared/Salvage/Fulton/FultonBeaconComponent.cs
+++ b/Content.Shared/Salvage/Fulton/FultonBeaconComponent.cs
@@ -11,7 +11,4 @@ public sealed partial class FultonBeaconComponent : Component
 {
     [ViewVariables(VVAccess.ReadWrite), DataField("soundLink"), AutoNetworkedField]
     public SoundSpecifier? LinkSound = new SoundPathSpecifier("/Audio/Items/beep.ogg");
-
-    [DataField("key"), ViewVariables(VVAccess.ReadOnly), AutoNetworkedField]
-    public string? Key = null;
 }

--- a/Content.Shared/Salvage/Fulton/SharedFultonSystem.cs
+++ b/Content.Shared/Salvage/Fulton/SharedFultonSystem.cs
@@ -14,6 +14,7 @@ using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
+using Content.Shared._Persistence14.PersistentIdentifier;
 
 namespace Content.Shared.Salvage.Fulton;
 
@@ -32,6 +33,7 @@ public abstract partial class SharedFultonSystem : EntitySystem
     [Dependency] private readonly SharedStackSystem _stack = default!;
     [Dependency] protected readonly SharedTransformSystem TransformSystem = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
+    [Dependency] private PersistentIdentifierSystem _pid = default!;
 
     public static readonly EntProtoId EffectProto = "FultonEffect";
     protected static readonly Vector2 EffectOffset = Vector2.Zero;
@@ -116,10 +118,9 @@ public abstract partial class SharedFultonSystem : EntitySystem
         // Interact with Beacon
         if (TryComp<FultonBeaconComponent>(args.Target, out var beacon))
         {
-            EnsureBeaconKey(beacon); // Make sure the beacon has a key before linking.
             if (!_foldable.IsFolded(args.Target.Value))
             {
-                component.BeaconKey = beacon.Key;
+                component.BeaconKey = _pid.EnsureId(args.Target.Value);
                 Audio.PlayPredicted(beacon.LinkSound, uid, args.User);
                 _popup.PopupClient(Loc.GetString("fulton-linked"), uid, args.User);
             }
@@ -171,7 +172,8 @@ public abstract partial class SharedFultonSystem : EntitySystem
     {
         if (args.User == null) // Only reset if a player folded the beacon. Prevents roundstart from resetting beacon link.
             return;
-        component.Key = null;
+        EnsureComp<PersistentIdentifierComponent>(uid, out var idComp);
+        _pid.ResetId((uid, idComp), PersistentIdChangeBehaviour.Sever);
     }
 
     private void OnFultonSplit(EntityUid uid, FultonComponent component, ref StackSplitEvent args)
@@ -238,7 +240,7 @@ public abstract partial class SharedFultonSystem : EntitySystem
 
         while (query.MoveNext(out var uid, out var beaconComp))
         {
-            if (beaconComp.Key == key)
+            if (_pid.EnsureId(uid) == key)
             {
                 beacon = uid;
                 return true;
@@ -246,13 +248,5 @@ public abstract partial class SharedFultonSystem : EntitySystem
         }
 
         return false;
-    }
-
-    protected virtual void EnsureBeaconKey(FultonBeaconComponent beacon)
-    {
-        if (beacon.Key != null)
-            return;
-
-        beacon.Key = Guid.NewGuid().ToString();
     }
 }

--- a/Content.Shared/Teleportation/Components/SwapTeleporterComponent.cs
+++ b/Content.Shared/Teleportation/Components/SwapTeleporterComponent.cs
@@ -53,8 +53,8 @@ public sealed partial class SwapTeleporterComponent : Component
     public EntityWhitelist TeleporterWhitelist = new();
 
     [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadOnly)]
-    public string? Key = null;
-    public bool HasKey => Key != null;
+    public string Key = Guid.Empty.ToString();
+    public bool HasKey => Key != Guid.Empty.ToString();
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Teleportation/Systems/SwapTeleporterSystem.cs
+++ b/Content.Shared/Teleportation/Systems/SwapTeleporterSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._Persistence14.PersistentIdentifier;
 using Content.Shared.Examine;
 using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
@@ -28,6 +29,10 @@ public sealed class SwapTeleporterSystem : EntitySystem
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
+    [Dependency] private readonly PersistentIdentifierSystem _pid = default!;
+    [Dependency] private readonly ILogManager _log = default!;
+
+    public const string Sawmill = "Swap Teleport";
 
     private EntityQuery<TransformComponent> _xformQuery;
 
@@ -39,7 +44,6 @@ public sealed class SwapTeleporterSystem : EntitySystem
         SubscribeLocalEvent<SwapTeleporterComponent, ActivateInWorldEvent>(OnActivateInWorld);
         SubscribeLocalEvent<SwapTeleporterComponent, ExaminedEvent>(OnExamined);
 
-        SubscribeLocalEvent<SwapTeleporterComponent, ComponentShutdown>(OnShutdown);
         SubscribeLocalEvent<SwapTeleporterComponent, ComponentInit>(OnComponentInit);
 
         _xformQuery = GetEntityQuery<TransformComponent>();
@@ -48,6 +52,9 @@ public sealed class SwapTeleporterSystem : EntitySystem
     private void OnComponentInit(EntityUid uid, SwapTeleporterComponent comp, ref ComponentInit args)
     {
         UpdateAppearance(uid, comp);
+
+        if (!HasComp<PersistentIdentifierComponent>(uid))
+            MigrateKeys((uid, comp));
     }
 
     private void OnInteract(Entity<SwapTeleporterComponent> ent, ref AfterInteractEvent args)
@@ -67,20 +74,20 @@ public sealed class SwapTeleporterSystem : EntitySystem
             return;
         }
 
-        if (comp.Key != null)
+        if (comp.HasKey)
         {
             _popup.PopupClient(Loc.GetString("swap-teleporter-popup-link-fail-already"), uid, args.User);
             return;
         }
 
-        if (targetComp.Key != null)
+        if (targetComp.HasKey)
         {
             _popup.PopupClient(Loc.GetString("swap-teleporter-popup-link-fail-already-other"), uid, args.User);
             return;
         }
 
-        comp.Key = GetUniqueBeaconKey();
-        targetComp.Key = comp.Key;
+        comp.Key = _pid.EnsureId(target);
+        targetComp.Key = _pid.EnsureId(uid);
 
         Dirty(uid, comp);
         Dirty(target, targetComp);
@@ -217,7 +224,7 @@ public sealed class SwapTeleporterSystem : EntitySystem
             return;
 
         var hasPaired = TryGetPaired(ent, ent.Comp, out var paired);
-        ent.Comp.Key = null;
+        ent.Comp.Key = Guid.Empty.ToString();
         ent.Comp.TeleportTime = null;
         _appearance.SetData(ent, SwapTeleporterVisuals.Linked, false);
         Dirty(ent, ent.Comp);
@@ -265,11 +272,6 @@ public sealed class SwapTeleporterSystem : EntitySystem
         }
     }
 
-    private void OnShutdown(Entity<SwapTeleporterComponent> ent, ref ComponentShutdown args)
-    {
-        //DestroyLink((ent, ent), null); // Not a thing we want in persistence I don't think...
-    }
-
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
@@ -287,30 +289,47 @@ public sealed class SwapTeleporterSystem : EntitySystem
         }
     }
 
-    private string GetUniqueBeaconKey() => Guid.NewGuid().ToString("N");
-
     private bool TryGetPaired(EntityUid self, SwapTeleporterComponent component, out EntityUid paired, bool nullifyUnpaired = false)
     {
         paired = default!;
 
-        if (component.Key == null) return false;
+        if (component.Key == Guid.Empty.ToString()) return false;
 
-        var query = EntityQueryEnumerator<SwapTeleporterComponent>();
-
-        while (query.MoveNext(out var id, out var comp))
+        if (_pid.TryResolveId(self, component.Key, out var target))
         {
-            if (id == self) continue;
-            if (comp.Key != component.Key) continue;
-
-            paired = id;
+            paired = target;
             return true;
         }
 
         if (nullifyUnpaired)
         {
-            component.Key = null; // Removes the key if a pair isn't found
+            component.Key = Guid.Empty.ToString(); // Removes the key if a pair isn't found
             Dirty(self, component);
         }
         return false;
+    }
+
+    private void MigrateKeys(Entity<SwapTeleporterComponent> ent)
+    {
+        var enumerator = EntityQueryEnumerator<SwapTeleporterComponent>();
+        var entId = _pid.EnsureId(ent);
+        while (enumerator.MoveNext(out var uid, out var tp))
+        {
+            if (tp.Key != ent.Comp.Key || ent.Owner == uid) continue;
+            if (HasComp<PersistentIdentifierComponent>(uid))
+            {
+                ent.Comp.Key = Guid.Empty.ToString();
+                Dirty(ent);
+                return;
+            }
+
+            EnsureComp<PersistentIdentifierComponent>(uid, out var pairedIdComp);
+
+            _pid.ResetId((uid, pairedIdComp), out ent.Comp.Key);
+            tp.Key = entId;
+            Dirty(uid, tp);
+            Dirty(ent);
+            return;
+        }
     }
 }

--- a/Content.Shared/_Persistence14/PersistentIdentifier/PersistentIdRegisteryComponent.cs
+++ b/Content.Shared/_Persistence14/PersistentIdentifier/PersistentIdRegisteryComponent.cs
@@ -1,0 +1,96 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Content.Shared._Persistence14.PersistentIdentifier;
+
+[RegisterComponent]
+public sealed partial class PersistentIdRegisterComponent : Component
+{
+    /// <summary>
+    /// A runtime register of registered entities allowing for faster lookup.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadOnly)]
+    private Dictionary<Guid, Entity<PersistentIdentifierComponent>> _registeredEntities = new();
+
+    /// <summary>
+    /// Verifies the existance of a valid entity within the register matching a provided key.
+    /// </summary>
+    public bool Contains(Guid id, IEntityManager entMan) => TryGet(id, out _, entMan);
+
+    /// <summary>
+    /// Attempts to retrieve a valid entity matching a provided key from the register.<br/>
+    /// Culls any stale references that either do not exist or do not contain the required components/state.
+    /// </summary>
+    public bool TryGet(Guid id, out Entity<PersistentIdentifierComponent> ent, IEntityManager entMan)
+    {
+        ent = default!;
+
+        if (!_registeredEntities.TryGetValue(id, out ent))
+            return false;
+
+        if (!entMan.EntityExists(ent) || !entMan.TryGetComponent<PersistentIdentifierComponent>(ent, out var idComp) || idComp.Id != id)
+        {
+            _registeredEntities.Remove(id);
+            ent = default!;
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Culls any stale references that either do not exist or do not contain the required components/state.
+    /// </summary>
+    public bool CullStaleEntities(IEntityManager entMan)
+    {
+        var ids = _registeredEntities.Keys;
+        bool cullAny = false;
+
+        List<Guid> staleIds = new();
+
+        foreach (var id in ids)
+        {
+            var ent = _registeredEntities[id];
+            if (!entMan.EntityExists(ent) || !entMan.TryGetComponent<PersistentIdentifierComponent>(ent, out var idComp) || idComp.Id != id)
+            {
+                staleIds.Add(id);
+                cullAny = true;
+            }
+        }
+
+        foreach (var id in staleIds)
+            _registeredEntities.Remove(id);
+
+        return cullAny;
+    }
+
+    /// <summary>
+    /// Attempts to register an entity to the register.<br/><br/>
+    /// Return false if a matching entity already exists in the register, otherwise true.
+    /// </summary>
+    public bool TryRegister(Entity<PersistentIdentifierComponent> ent, IEntityManager entMan)
+    {
+        if (Contains(ent.Comp.Id, entMan) || ent.Comp.Id == Guid.Empty) return false;
+
+        _registeredEntities[ent.Comp.Id] = ent;
+        return true;
+    }
+
+    /// <summary>
+    /// Attempts to remove an ID from the register.
+    /// Returns true if the ID was successfully removed, otherwise false.
+    /// </summary>
+    public bool TryUnregister(Guid id) => _registeredEntities.Remove(id);
+
+    /// <summary>
+    /// Attempts to remove a <see cref="PersistentIdentifierComponent"/> from the register. 
+    /// Returns true if the ID was successfully removed, otherwise false.
+    /// </summary>
+    /// <param name="ent"></param>
+    /// <returns></returns>
+    public bool TryUnregister(Entity<PersistentIdentifierComponent> ent) => TryUnregister(ent.Comp.Id);
+
+    /// <summary>
+    /// Removes all entities from the registry.
+    /// </summary>
+    public void Clear() => _registeredEntities.Clear();
+}

--- a/Content.Shared/_Persistence14/PersistentIdentifier/PersistentIdRegisteryComponent.cs
+++ b/Content.Shared/_Persistence14/PersistentIdentifier/PersistentIdRegisteryComponent.cs
@@ -9,18 +9,18 @@ public sealed partial class PersistentIdRegisterComponent : Component
     /// A runtime register of registered entities allowing for faster lookup.
     /// </summary>
     [ViewVariables(VVAccess.ReadOnly)]
-    private Dictionary<Guid, Entity<PersistentIdentifierComponent>> _registeredEntities = new();
+    private Dictionary<string, Entity<PersistentIdentifierComponent>> _registeredEntities = new();
 
     /// <summary>
     /// Verifies the existance of a valid entity within the register matching a provided key.
     /// </summary>
-    public bool Contains(Guid id, IEntityManager entMan) => TryGet(id, out _, entMan);
+    public bool Contains(string id, IEntityManager entMan) => TryGet(id, out _, entMan);
 
     /// <summary>
     /// Attempts to retrieve a valid entity matching a provided key from the register.<br/>
     /// Culls any stale references that either do not exist or do not contain the required components/state.
     /// </summary>
-    public bool TryGet(Guid id, out Entity<PersistentIdentifierComponent> ent, IEntityManager entMan)
+    public bool TryGet(string id, out Entity<PersistentIdentifierComponent> ent, IEntityManager entMan)
     {
         ent = default!;
 
@@ -45,7 +45,7 @@ public sealed partial class PersistentIdRegisterComponent : Component
         var ids = _registeredEntities.Keys;
         bool cullAny = false;
 
-        List<Guid> staleIds = new();
+        List<string> staleIds = new();
 
         foreach (var id in ids)
         {
@@ -69,7 +69,7 @@ public sealed partial class PersistentIdRegisterComponent : Component
     /// </summary>
     public bool TryRegister(Entity<PersistentIdentifierComponent> ent, IEntityManager entMan)
     {
-        if (Contains(ent.Comp.Id, entMan) || ent.Comp.Id == Guid.Empty) return false;
+        if (Contains(ent.Comp.Id, entMan) || !ent.Comp.IdInit) return false;
 
         _registeredEntities[ent.Comp.Id] = ent;
         return true;
@@ -79,7 +79,7 @@ public sealed partial class PersistentIdRegisterComponent : Component
     /// Attempts to remove an ID from the register.
     /// Returns true if the ID was successfully removed, otherwise false.
     /// </summary>
-    public bool TryUnregister(Guid id) => _registeredEntities.Remove(id);
+    public bool TryUnregister(string id) => _registeredEntities.Remove(id);
 
     /// <summary>
     /// Attempts to remove a <see cref="PersistentIdentifierComponent"/> from the register. 

--- a/Content.Shared/_Persistence14/PersistentIdentifier/PersistentIdentifierComponent.cs
+++ b/Content.Shared/_Persistence14/PersistentIdentifier/PersistentIdentifierComponent.cs
@@ -12,7 +12,7 @@ public sealed partial class PersistentIdentifierComponent : Component
     /// A serialized identifier used to reference the entity this component is attached to between runtimes.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadOnly), AutoNetworkedField]
-    public Guid Id = Guid.Empty;
+    public string Id = Guid.Empty.ToString();
 
     /// <summary>
     /// Shows the current initialization state of the ID and allows for basic manipulation of that ID.<br/><br/>
@@ -20,5 +20,5 @@ public sealed partial class PersistentIdentifierComponent : Component
     /// Returns false when the ID is null.
     /// </summary>
     [ViewVariables(VVAccess.ReadOnly)]
-    public bool IdInit => Id != Guid.Empty;
+    public bool IdInit => Id != Guid.Empty.ToString();
 }

--- a/Content.Shared/_Persistence14/PersistentIdentifier/PersistentIdentifierComponent.cs
+++ b/Content.Shared/_Persistence14/PersistentIdentifier/PersistentIdentifierComponent.cs
@@ -1,0 +1,24 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Persistence14.PersistentIdentifier;
+
+/// <summary>
+/// A component allowing reference to the entity this is attached to between runtimes through a serialized GUID.
+/// </summary>
+[RegisterComponent, Access(typeof(PersistentIdentifierSystem)), NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class PersistentIdentifierComponent : Component
+{
+    /// <summary>
+    /// A serialized identifier used to reference the entity this component is attached to between runtimes.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadOnly), AutoNetworkedField]
+    public Guid Id = Guid.Empty;
+
+    /// <summary>
+    /// Shows the current initialization state of the ID and allows for basic manipulation of that ID.<br/><br/>
+    /// Returns true when the ID has been initialized and is not null.<br/>
+    /// Returns false when the ID is null.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadOnly)]
+    public bool IdInit => Id != Guid.Empty;
+}

--- a/Content.Shared/_Persistence14/PersistentIdentifier/PersistentIdentifierSystem.cs
+++ b/Content.Shared/_Persistence14/PersistentIdentifier/PersistentIdentifierSystem.cs
@@ -19,7 +19,7 @@ public sealed partial class PersistentIdentifierSystem : EntitySystem
     /// <summary>
     /// Gets the ID from a <see cref="PersistentIdentifierComponent"/>. Generates a new ID if one is not present.
     /// </summary>
-    public Guid EnsureId(Entity<PersistentIdentifierComponent> ent)
+    public string EnsureId(Entity<PersistentIdentifierComponent> ent)
     {
         if (ent.Comp.IdInit) return ent.Comp.Id;
 
@@ -27,11 +27,17 @@ public sealed partial class PersistentIdentifierSystem : EntitySystem
         return id;
     }
 
+    public string EnsureId(EntityUid uid)
+    {
+        EnsureComp<PersistentIdentifierComponent>(uid, out var idComp);
+        return EnsureId((uid, idComp));
+    }
+
     /// <summary>
     /// Attempts to retrieve the ID from a <see cref="PersistentIdentifierComponent"/>.<br/><br/>
     /// Return true if the component has an ID, otherwise false.
     /// </summary>
-    public bool TryGetId(Entity<PersistentIdentifierComponent> ent, out Guid id)
+    public bool TryGetId(Entity<PersistentIdentifierComponent> ent, out string id)
     {
         if (ent.Comp.IdInit)
         {
@@ -39,17 +45,17 @@ public sealed partial class PersistentIdentifierSystem : EntitySystem
             return true;
         }
 
-        id = Guid.Empty;
+        id = Guid.Empty.ToString();
         return false;
     }
 
     /// <summary>
     /// Resets the ID of a <see cref="PersistentIdentifierComponent"/> to a new valid GUID.
     /// </summary>
-    public void ResetId(Entity<PersistentIdentifierComponent> ent, out Guid id, PersistentIdChangeBehaviour behaviour = PersistentIdChangeBehaviour.Sever)
+    public void ResetId(Entity<PersistentIdentifierComponent> ent, out string id, PersistentIdChangeBehaviour behaviour = PersistentIdChangeBehaviour.Sever)
     {
         var oldId = ent.Comp.Id;
-        ent.Comp.Id = Guid.NewGuid();
+        ent.Comp.Id = Guid.NewGuid().ToString();
         id = ent.Comp.Id;
         Dirty(ent);
 
@@ -57,26 +63,29 @@ public sealed partial class PersistentIdentifierSystem : EntitySystem
         RaiseLocalEvent(ref ev);
     }
 
+    public void ResetId(Entity<PersistentIdentifierComponent> ent, PersistentIdChangeBehaviour behaviour = PersistentIdChangeBehaviour.Sever)
+        => ResetId(ent, out _, behaviour);
+
     /// <summary>
     /// Empties the ID of a <see cref="PersistentIdentifierComponent"/>.
     /// </summary>
     public void ClearId(Entity<PersistentIdentifierComponent> ent, PersistentIdChangeBehaviour behaviour = PersistentIdChangeBehaviour.Sever)
     {
-        if (ent.Comp.Id == Guid.Empty) return;
+        if (!ent.Comp.IdInit) return;
 
         var oldId = ent.Comp.Id;
-        ent.Comp.Id = Guid.Empty;
+        ent.Comp.Id = Guid.Empty.ToString();
         Dirty(ent);
 
         var ev = new PersistentIdChangedEvent(ent, oldId, ent.Comp.Id, behaviour);
         RaiseLocalEvent(ref ev);
     }
 
-    public bool OverrideId(Entity<PersistentIdentifierComponent> ent, Guid id, PersistentIdChangeBehaviour behaviour = PersistentIdChangeBehaviour.Sever)
+    public bool OverrideId(Entity<PersistentIdentifierComponent> ent, string id, PersistentIdChangeBehaviour behaviour = PersistentIdChangeBehaviour.Sever)
     {
         if (id == ent.Comp.Id) return false;
 
-        if (id == Guid.Empty)
+        if (id == Guid.Empty.ToString())
         {
             _log.GetSawmill(Sawmill).Warning("Unable to override ID to empty. Use ClearId instead.");
             return false;
@@ -103,7 +112,7 @@ public sealed partial class PersistentIdentifierSystem : EntitySystem
     /// <returns>True if able to successfully resolve the id, otherwise false.</returns>
     public bool TryResolveId(
         EntityUid sourceUid,
-        Guid id,
+        string id,
         out Entity<PersistentIdentifierComponent> ent,
         Func<Entity<PersistentIdentifierComponent>, bool>? conditional = null,
         bool useFetchIfFalse = true, bool ensureRegistry = true)
@@ -140,7 +149,7 @@ public sealed partial class PersistentIdentifierSystem : EntitySystem
     /// <param name="registry">An optional registry to register valid ids to when found. Improves speed of future searches.</param>
     /// <returns></returns>
     public bool TryFetchId(
-        Guid id,
+        string id,
         out Entity<PersistentIdentifierComponent> ent,
         Func<Entity<PersistentIdentifierComponent>, bool>? conditional = null,
         PersistentIdRegisterComponent? registry = null)
@@ -158,9 +167,12 @@ public sealed partial class PersistentIdentifierSystem : EntitySystem
             {
                 ent = (uid, idComp);
                 if (registry is not null) registry.TryRegister(ent, _entMan);
+                _log.GetSawmill(Sawmill).Info($"Entity found: {uid}");
                 return true;
             }
         }
+
+        _log.GetSawmill(Sawmill).Warning($"Unable to find entity with matching pid.");
         return false;
     }
 
@@ -169,7 +181,7 @@ public sealed partial class PersistentIdentifierSystem : EntitySystem
         // Culling will remove the existing reference as the new ID will not match that stored in the key.
         register.CullStaleEntities(_entMan);
 
-        if (args.NewId == Guid.Empty || args.NewId == args.OldId || args.Behaviour == PersistentIdChangeBehaviour.Sever)
+        if (args.NewId == Guid.Empty.ToString() || args.NewId == args.OldId || args.Behaviour == PersistentIdChangeBehaviour.Sever)
             return; // Nothing more to do.
 
         if (!TryComp<PersistentIdentifierComponent>(args.Uid, out var idComp))

--- a/Content.Shared/_Persistence14/PersistentIdentifier/PersistentIdentifierSystem.cs
+++ b/Content.Shared/_Persistence14/PersistentIdentifier/PersistentIdentifierSystem.cs
@@ -1,0 +1,180 @@
+namespace Content.Shared._Persistence14.PersistentIdentifier;
+
+public sealed partial class PersistentIdentifierSystem : EntitySystem
+{
+    [Dependency] private IEntityManager _entMan = default!;
+    [Dependency] private ILogManager _log = default!;
+
+    /// <summary>
+    /// The Sawmill key for all ID related log messages.
+    /// </summary>
+    public const string Sawmill = "Persistent ID";
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<PersistentIdRegisterComponent, PersistentIdChangedEvent>(OnRegisterIdChange);
+    }
+
+    /// <summary>
+    /// Gets the ID from a <see cref="PersistentIdentifierComponent"/>. Generates a new ID if one is not present.
+    /// </summary>
+    public Guid EnsureId(Entity<PersistentIdentifierComponent> ent)
+    {
+        if (ent.Comp.IdInit) return ent.Comp.Id;
+
+        ResetId(ent, out var id, PersistentIdChangeBehaviour.Sever);
+        return id;
+    }
+
+    /// <summary>
+    /// Attempts to retrieve the ID from a <see cref="PersistentIdentifierComponent"/>.<br/><br/>
+    /// Return true if the component has an ID, otherwise false.
+    /// </summary>
+    public bool TryGetId(Entity<PersistentIdentifierComponent> ent, out Guid id)
+    {
+        if (ent.Comp.IdInit)
+        {
+            id = ent.Comp.Id;
+            return true;
+        }
+
+        id = Guid.Empty;
+        return false;
+    }
+
+    /// <summary>
+    /// Resets the ID of a <see cref="PersistentIdentifierComponent"/> to a new valid GUID.
+    /// </summary>
+    public void ResetId(Entity<PersistentIdentifierComponent> ent, out Guid id, PersistentIdChangeBehaviour behaviour = PersistentIdChangeBehaviour.Sever)
+    {
+        var oldId = ent.Comp.Id;
+        ent.Comp.Id = Guid.NewGuid();
+        id = ent.Comp.Id;
+        Dirty(ent);
+
+        var ev = new PersistentIdChangedEvent(ent, oldId, ent.Comp.Id, behaviour);
+        RaiseLocalEvent(ref ev);
+    }
+
+    /// <summary>
+    /// Empties the ID of a <see cref="PersistentIdentifierComponent"/>.
+    /// </summary>
+    public void ClearId(Entity<PersistentIdentifierComponent> ent, PersistentIdChangeBehaviour behaviour = PersistentIdChangeBehaviour.Sever)
+    {
+        if (ent.Comp.Id == Guid.Empty) return;
+
+        var oldId = ent.Comp.Id;
+        ent.Comp.Id = Guid.Empty;
+        Dirty(ent);
+
+        var ev = new PersistentIdChangedEvent(ent, oldId, ent.Comp.Id, behaviour);
+        RaiseLocalEvent(ref ev);
+    }
+
+    public bool OverrideId(Entity<PersistentIdentifierComponent> ent, Guid id, PersistentIdChangeBehaviour behaviour = PersistentIdChangeBehaviour.Sever)
+    {
+        if (id == ent.Comp.Id) return false;
+
+        if (id == Guid.Empty)
+        {
+            _log.GetSawmill(Sawmill).Warning("Unable to override ID to empty. Use ClearId instead.");
+            return false;
+        }
+
+        var oldId = ent.Comp.Id;
+        ent.Comp.Id = id;
+        Dirty(ent);
+
+        var ev = new PersistentIdChangedEvent(ent, oldId, ent.Comp.Id, behaviour);
+        RaiseLocalEvent(ref ev);
+        return true;
+    }
+
+    /// <summary>
+    /// Attempts to resolve a given id on a source entity. Will prioritize an existing <see cref="PersistentIdRegisterComponent"/> and may add one if none are available.
+    /// </summary>
+    /// <param name="sourceUid">The Uid of the entity to look into.</param>
+    /// <param name="id">The desired id.</param>
+    /// <param name="ent">The output variable storing the retrieved entity.</param>
+    /// <param name="conditional">A conditional function applied to the search.</param>
+    /// <param name="useFetchIfFalse">If true, the resolve method will attempt to fetch the entity using <see cref="TryFetchId"/> if unable to resolve using the source registry.</param>
+    /// <param name="ensureRegistry">If true, the resolve method will ensure the existence of a <see cref="PersistentIdRegisterComponent"/> on the source Uid.</param> 
+    /// <returns>True if able to successfully resolve the id, otherwise false.</returns>
+    public bool TryResolveId(
+        EntityUid sourceUid,
+        Guid id,
+        out Entity<PersistentIdentifierComponent> ent,
+        Func<Entity<PersistentIdentifierComponent>, bool>? conditional = null,
+        bool useFetchIfFalse = true, bool ensureRegistry = true)
+    {
+        ent = default!;
+        conditional ??= _ => true;
+
+        PersistentIdRegisterComponent? registry;
+        if (ensureRegistry)
+        {
+            EnsureComp<PersistentIdRegisterComponent>(sourceUid, out registry);
+            if (registry.TryGet(id, out ent, _entMan) && conditional(ent))
+                return true;
+        }
+        else if (
+            TryComp<PersistentIdRegisterComponent>(sourceUid, out registry) &&
+            registry.TryGet(id, out ent, _entMan) &&
+            conditional(ent))
+        {
+            return true;
+        }
+
+        if (useFetchIfFalse)
+            return TryFetchId(id, out ent, conditional, registry);
+        return false;
+    }
+
+    /// <summary>
+    /// Fetches an id from all existing <see cref="PersistentIdentifierComponent"/>. Attempts to add valid ids to an existing <see cref="PersistentIdRegisterComponent"/> 
+    /// </summary>
+    /// <param name="id">The desired id.</param>
+    /// <param name="ent">The output variable storing the retrieved entity.</param>
+    /// <param name="conditional">A conditional function applied to the search.</param>
+    /// <param name="registry">An optional registry to register valid ids to when found. Improves speed of future searches.</param>
+    /// <returns></returns>
+    public bool TryFetchId(
+        Guid id,
+        out Entity<PersistentIdentifierComponent> ent,
+        Func<Entity<PersistentIdentifierComponent>, bool>? conditional = null,
+        PersistentIdRegisterComponent? registry = null)
+    {
+        ent = default!;
+        conditional ??= _ => true;
+
+        _log.GetSawmill(Sawmill).Info($"Attempting to fetch persistent id: {id}");
+
+        var lookup = EntityQueryEnumerator<PersistentIdentifierComponent>();
+
+        while (lookup.MoveNext(out var uid, out var idComp))
+        {
+            if (idComp.Id == id && conditional((uid, idComp)))
+            {
+                ent = (uid, idComp);
+                if (registry is not null) registry.TryRegister(ent, _entMan);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void OnRegisterIdChange(EntityUid uid, PersistentIdRegisterComponent register, ref PersistentIdChangedEvent args)
+    {
+        // Culling will remove the existing reference as the new ID will not match that stored in the key.
+        register.CullStaleEntities(_entMan);
+
+        if (args.NewId == Guid.Empty || args.NewId == args.OldId || args.Behaviour == PersistentIdChangeBehaviour.Sever)
+            return; // Nothing more to do.
+
+        if (!TryComp<PersistentIdentifierComponent>(args.Uid, out var idComp))
+            return; // What would this even mean...?
+
+        register.TryRegister((args.Uid, idComp), _entMan);
+    }
+}

--- a/Content.Shared/_Persistence14/PersistentIdentifier/PersitentIdentifierEvent.cs
+++ b/Content.Shared/_Persistence14/PersistentIdentifier/PersitentIdentifierEvent.cs
@@ -4,7 +4,7 @@ namespace Content.Shared._Persistence14.PersistentIdentifier;
 /// An event signifying a change to a the ID stored within a <see cref="PersistentIdentifierComponent"/> 
 /// </summary>
 [ByRefEvent]
-public record struct PersistentIdChangedEvent(EntityUid Uid, Guid OldId, Guid NewId, PersistentIdChangeBehaviour Behaviour);
+public record struct PersistentIdChangedEvent(EntityUid Uid, string OldId, string NewId, PersistentIdChangeBehaviour Behaviour);
 
 public enum PersistentIdChangeBehaviour
 {

--- a/Content.Shared/_Persistence14/PersistentIdentifier/PersitentIdentifierEvent.cs
+++ b/Content.Shared/_Persistence14/PersistentIdentifier/PersitentIdentifierEvent.cs
@@ -1,0 +1,13 @@
+namespace Content.Shared._Persistence14.PersistentIdentifier;
+
+/// <summary>
+/// An event signifying a change to a the ID stored within a <see cref="PersistentIdentifierComponent"/> 
+/// </summary>
+[ByRefEvent]
+public record struct PersistentIdChangedEvent(EntityUid Uid, Guid OldId, Guid NewId, PersistentIdChangeBehaviour Behaviour);
+
+public enum PersistentIdChangeBehaviour
+{
+    Sever, // Delete any references to the ID.
+    Alter, // Change any references to match the new ID.
+}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds a new backend system for persistent linking of sources call the PersistentIdentifierComponent. This component provides access to a string ID generated via GUIDs that can be stored locally for easy access to that exact entity in the future. This reference persists safely across saves where EntityUid and NetEntId do not.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This has been a recurring problem, where a reference to an object is needed between saves. EntityUids are not guarenteed to remain constant between saves and thus breaks when a reference to it is made. Same with NetEntIds.

## Technical details
<!-- Summary of code changes for easier review. -->
* Adds a new PersistentIdentifierComponent and related PersistentIdentifierSystem.
* Adds new PersistentIdRegisterComponent, also defined in PersistentIdentifierSystem.
* Updated QSIs to use the new id system
* Updated Fultons to use the new ID system
* Updated device links to use the new ID system
* Added an initialization method to QSIs to allow existing QSI links to persist on reset.

### Notable API Methods
* EnsureId can be used on an entity to make sure it has a valid id that can be referenced. If you don't want to generate a new id but do want to see if one exists, TryGetId also works. 
* TryResolveId is used when you want to query to find an existing ID that you should, in theory, be linked to. It first checks any local PeristentIdRegisterComponent for a valid linked reference before calling TryFetchId described below.
* TryFetchId querries all existing PersistentIdentifierComponents to check against the ID. Needless to say this can get computationally expensive. TryResolveId should always be prefered if possible.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
* Unfortunately, all existing device links are at risk of breaking. The change that allows the remote signaller and similar devices to serialize safely also requires that they be stored as strings instead of EntityUids. I was unable to find a way to fix this disconnect.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: A bunch of backend stuff regarding persistent IDs.
