### PR TITLE
Changes to the rot system to cap the total amount of rot allowed to accumulate.

### DIFF
--- a/Content.Server/Atmos/Rotting/RottingSystem.cs
+++ b/Content.Server/Atmos/Rotting/RottingSystem.cs
@@ -107,6 +107,8 @@ public sealed class RottingSystem : SharedRottingSystem
             if (!IsRotProgressing(uid, perishable))
                 continue;
             rotting.TotalRotTime += rotting.RotUpdateRate * GetRotRate(uid);
+            if (rotting.TotalRotTime >= rotting.MaximumTotalRotTime)
+                rotting.TotalRotTime = rotting.MaximumTotalRotTime;
 
             if (rotting.DealDamage)
             {

--- a/Content.Shared/Atmos/Rotting/RottingComponent.cs
+++ b/Content.Shared/Atmos/Rotting/RottingComponent.cs
@@ -38,6 +38,12 @@ public sealed partial class RottingComponent : Component
     public TimeSpan TotalRotTime = TimeSpan.Zero;
 
     /// <summary>
+    /// The absolute maximum amount of time an object can acculate rot for.
+    /// </summary>
+    [DataField]
+    public TimeSpan MaximumTotalRotTime = TimeSpan.FromSeconds(7200);
+
+    /// <summary>
     /// The damage dealt by rotting.
     /// </summary>
     [DataField]


### PR DESCRIPTION
Changes to the rot system to cap the total amount of rot allowed to accumulate.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds a configurable maximum to the rot system.

## Why / Balance
It is currently possible for corpses to accumulate infinite rot over time.
Resulting in extreme amounts of opporizine being required to revive them.
Additionally, this allows for an extreme amount of Ammonia to be generated when a corpse is butchered/gibbed.

## Technical details
Adds a new datafield called `MaximumTotalRotTime`
Adds a check to the `RottingSystem`'s `Update` method to prevent rot damage from going over this maximum.

## Media
N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
No significant changes.

**Changelog**
:cl:
- add: Configurable maximum for rotting.
- fix: Rot no longer accumulates endlessly.
