### PR TITLE
Fixes the ChemMaster not loading correctly when reinitialized.

### DIFF
--- a/Content.Server/Chemistry/EntitySystems/ChemMasterSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/ChemMasterSystem.cs
@@ -45,7 +45,8 @@ namespace Content.Server.Chemistry.EntitySystems
         {
             base.Initialize();
 
-            SubscribeLocalEvent<ChemMasterComponent, ComponentStartup>(SubscribeUpdateUiState);
+            SubscribeLocalEvent<ChemMasterComponent, ComponentStartup>(SubscribeComponentStartup);
+
             SubscribeLocalEvent<ChemMasterComponent, SolutionContainerChangedEvent>(SubscribeUpdateUiState);
             SubscribeLocalEvent<ChemMasterComponent, EntInsertedIntoContainerMessage>(SubscribeUpdateUiState);
             SubscribeLocalEvent<ChemMasterComponent, EntRemovedFromContainerMessage>(SubscribeUpdateUiState);
@@ -58,6 +59,17 @@ namespace Content.Server.Chemistry.EntitySystems
             SubscribeLocalEvent<ChemMasterComponent, ChemMasterCreatePillsMessage>(OnCreatePillsMessage);
             SubscribeLocalEvent<ChemMasterComponent, ChemMasterOutputToBottleMessage>(OnOutputToBottleMessage);
             SubscribeLocalEvent<ChemMasterComponent, ChemMasterOutputDrawSourceMessage>(OnSetDrawSourceMessage);
+        }
+
+        private void SubscribeComponentStartup<T>(Entity<ChemMasterComponent> ent, ref T ev)
+        {
+            UpdateUiState(ent);
+
+            var (owner, chemMaster) = ent;
+            if (!_solutionContainerSystem.TryGetSolution(owner, SharedChemMaster.BufferSolutionName, out _, out var bufferSolution))
+                return;
+            if (bufferSolution.MaxVolume < FixedPoint2.MaxValue)
+                bufferSolution.MaxVolume = FixedPoint2.MaxValue;
         }
 
         private void SubscribeUpdateUiState<T>(Entity<ChemMasterComponent> ent, ref T ev)

--- a/Resources/Prototypes/Entities/Structures/Machines/chem_master.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/chem_master.yml
@@ -94,6 +94,7 @@
     solutions:
       buffer:
         canReact: false
+        maxVol: MaxValue
   - type: DumpableSolution
     solution: buffer
     unlimited: true


### PR DESCRIPTION
Fixes the ChemMaster not loading correctly when reinitialized.

## About the PR
Makes the ChemMaster set its solution's `MaxVolume` to `FixedPoint2.MaxValue`

## Why / Balance
Currently when ChemMasters are loaded for the first time after being saved. The Solution init detects that the `MaxVolume` (`maxVol` in the save file) is FixedPoint2.Zero and sets it to the current solution's `Volume`.
When the ChemMaster is saved and loaded again the solution checks if the volume is greater than the max volume and it spills into the void.
This results in some chems being removed in order to bring the solution back below the maximum.
Once this happens that particular ChemMaster is forever stuck only being able to store whatever its max was when it got saved/loaded.
Heres the savedata from a working ChemMaster before its loaded.
<img width="225" height="389" alt="image" src="https://github.com/user-attachments/assets/a2af06c3-f612-4585-a161-f78137bb10bc" />
And the Result.
<img width="610" height="232" alt="image" src="https://github.com/user-attachments/assets/3e84c01f-d13e-48b1-ab66-6d400153ddf6" />

And the savedata from a broken ChemMaster
<img width="262" height="386" alt="image" src="https://github.com/user-attachments/assets/f26fee2b-6a9b-4521-ae5d-d73c95f60b49" />
And the Result.
<img width="613" height="253" alt="image" src="https://github.com/user-attachments/assets/9bc677de-5814-49d0-8b3d-ad9ae1d9e409" />

## Technical details
This PR changes the ChemMasters component init to set the maxVolume to the maximum possible storage.
Note that this does not functionally change how much a ChemMaster can store. Because they are infinite anyways.
This just fixes them in the context of saving/loading.
This also includes a YAML change that sets the ChemMasters default maxVol to FixedPoint2.MaxValue
The code change is only necessary to affect the ChemMasters on existing saves/grids.

## Media
N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
Adds SubscribeComponentStartup to ChemMasterSystem in Content.Server.
This most likely wont break anything. But I've listed it here since it involves a method being added to a class.

**Changelog**
:cl:
- fix: Fixes the saving and loading of the ChemMaster
