### PR TITLE
Atmos Device Labeling

### DIFF
--- a/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml.cs
+++ b/Content.Client/Atmos/Monitor/UI/AirAlarmWindow.xaml.cs
@@ -106,9 +106,9 @@ public sealed partial class AirAlarmWindow : FancyWindow
                     ("state", state.AlarmType)));
         UpdateModeSelector(state.Mode);
         UpdateAutoMode(state.AutoMode);
-        foreach (var (addr, dev) in state.DeviceData)
+        foreach (var (addr, name, dev) in state.DeviceData)
         {
-            UpdateDeviceData(addr, dev);
+            UpdateDeviceData(addr, name, dev);
         }
         _modes.Visible = !state.PanicWireCut;
         CModeSelectLocked.Visible = state.PanicWireCut;
@@ -124,14 +124,14 @@ public sealed partial class AirAlarmWindow : FancyWindow
         _autoMode.Pressed = enabled;
     }
 
-    public void UpdateDeviceData(string addr, IAtmosDeviceData device)
+    public void UpdateDeviceData(string addr, string name, IAtmosDeviceData device)
     {
         switch (device)
         {
             case GasVentPumpData pump:
                 if (!_pumps.TryGetValue(addr, out var pumpControl))
                 {
-                    var control = new PumpControl(pump, addr);
+                    var control = new PumpControl(pump, addr, name);
                     control.PumpDataChanged += AtmosDeviceDataChanged;
                     control.PumpDataCopied += AtmosDeviceDataCopied;
                     _pumps.Add(addr, control);
@@ -146,7 +146,7 @@ public sealed partial class AirAlarmWindow : FancyWindow
             case GasVentScrubberData scrubber:
                 if (!_scrubbers.TryGetValue(addr, out var scrubberControl))
                 {
-                    var control = new ScrubberControl(scrubber, addr);
+                    var control = new ScrubberControl(scrubber, addr, name);
                     control.ScrubberDataChanged += AtmosDeviceDataChanged;
                     control.ScrubberDataCopied += AtmosDeviceDataCopied;
                     _scrubbers.Add(addr, control);
@@ -161,7 +161,7 @@ public sealed partial class AirAlarmWindow : FancyWindow
             case AtmosSensorData sensor:
                 if (!_sensors.TryGetValue(addr, out var sensorControl))
                 {
-                    var control = new SensorInfo(sensor, addr);
+                    var control = new SensorInfo(sensor, addr, name);
                     control.OnThresholdUpdate += AtmosAlarmThresholdChanged;
                     control.SensorDataCopied += AtmosDeviceDataCopied;
                     _sensors.Add(addr, control);

--- a/Content.Client/Atmos/Monitor/UI/Widgets/PumpControl.xaml.cs
+++ b/Content.Client/Atmos/Monitor/UI/Widgets/PumpControl.xaml.cs
@@ -23,7 +23,7 @@ public sealed partial class PumpControl : BoxContainer
     private FloatSpinBox _internalBound => CInternalBound;
     private Button _copySettings => CCopySettings;
 
-    public PumpControl(GasVentPumpData data, string address)
+    public PumpControl(GasVentPumpData data, string address, string name)
     {
         RobustXamlLoader.Load(this);
 
@@ -32,7 +32,9 @@ public sealed partial class PumpControl : BoxContainer
         _data = data;
         _address = address;
 
-        _addressLabel.Title = Loc.GetString("air-alarm-ui-atmos-net-device-label", ("address", $"{address}"));
+        var nameOrAddr = name == "" ? address : name;
+
+        _addressLabel.Title = Loc.GetString("air-alarm-ui-atmos-net-device-label", ("address", $"{nameOrAddr}"));
 
         _enabled.Pressed = data.Enabled;
         _enabled.OnToggled += _ =>
@@ -105,5 +107,7 @@ public sealed partial class PumpControl : BoxContainer
 
         _data.InternalPressureBound = data.InternalPressureBound;
         _internalBound.Value = _data.InternalPressureBound;
+
+        _data.Name = data.Name;
     }
 }

--- a/Content.Client/Atmos/Monitor/UI/Widgets/ScrubberControl.xaml.cs
+++ b/Content.Client/Atmos/Monitor/UI/Widgets/ScrubberControl.xaml.cs
@@ -34,7 +34,7 @@ public sealed partial class ScrubberControl : BoxContainer
     private GridContainer _gases => CGasContainer;
     private Dictionary<Gas, Button> _gasControls = new();
 
-    public ScrubberControl(GasVentScrubberData data, string address)
+    public ScrubberControl(GasVentScrubberData data, string address, string name)
     {
 
         IoCManager.InjectDependencies(this);
@@ -47,7 +47,8 @@ public sealed partial class ScrubberControl : BoxContainer
         _data = data;
         _address = address;
 
-        _addressLabel.Title = Loc.GetString("air-alarm-ui-atmos-net-device-label", ("address", $"{address}"));
+        var nameOrAddr = name == "" ? address : name;
+        _addressLabel.Title = Loc.GetString("air-alarm-ui-atmos-net-device-label", ("address", $"{nameOrAddr}"));
 
         _enabled.Pressed = data.Enabled;
         _enabled.OnToggled += _ =>
@@ -146,6 +147,8 @@ public sealed partial class ScrubberControl : BoxContainer
         _data.WideNet = data.WideNet;
         _wideNet.Pressed = _data.WideNet;
         _data.FilterGases = data.FilterGases;
+
+        _data.Name = data.Name;
 
         foreach (var value in Enum.GetValues<Gas>())
         {

--- a/Content.Client/Atmos/Monitor/UI/Widgets/SensorInfo.xaml.cs
+++ b/Content.Client/Atmos/Monitor/UI/Widgets/SensorInfo.xaml.cs
@@ -27,7 +27,7 @@ public sealed partial class SensorInfo : BoxContainer
     private Dictionary<Gas, RichTextLabel> _gasLabels = new();
     private Button _copySettings => CCopySettings;
 
-    public SensorInfo(AtmosSensorData data, string address)
+    public SensorInfo(AtmosSensorData data, string address, string name)
     {
         IoCManager.InjectDependencies(this);
         var atmosphereSystem = _entMan.System<SharedAtmosphereSystem>();
@@ -35,8 +35,8 @@ public sealed partial class SensorInfo : BoxContainer
         RobustXamlLoader.Load(this);
 
         _address = address;
-
-        SensorAddress.Title = Loc.GetString("air-alarm-ui-window-listing-title", ("address", _address), ("state", data.AlarmState));
+        var nameOrAddr = name == "" ? address : name;
+        SensorAddress.Title = Loc.GetString("air-alarm-ui-window-listing-title", ("address", nameOrAddr), ("state", data.AlarmState));
 
         AlarmStateLabel.SetMarkup(Loc.GetString("air-alarm-ui-window-alarm-state-indicator",
                     ("color", AirAlarmWindow.ColorForAlarm(data.AlarmState)),
@@ -111,7 +111,8 @@ public sealed partial class SensorInfo : BoxContainer
         IoCManager.InjectDependencies(this);
         var atmosphereSystem = _entMan.System<SharedAtmosphereSystem>();
 
-        SensorAddress.Title = Loc.GetString("air-alarm-ui-window-listing-title", ("address", _address), ("state", data.AlarmState));
+        var nameOrAddr = data.Name == "" ? _address : data.Name;
+        SensorAddress.Title = Loc.GetString("air-alarm-ui-window-listing-title", ("address", nameOrAddr), ("state", data.AlarmState));
 
         AlarmStateLabel.SetMarkup(Loc.GetString("air-alarm-ui-window-alarm-state-indicator",
                     ("color", AirAlarmWindow.ColorForAlarm(data.AlarmState)),

--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -650,20 +650,20 @@ public sealed class AirAlarmSystem : EntitySystem
 
         var pressure = CalculatePressureAverage(alarm);
         var temperature = CalculateTemperatureAverage(alarm);
-        var dataToSend = new List<(string, IAtmosDeviceData)>();
+        var dataToSend = new List<(string, string, IAtmosDeviceData)>();
 
         foreach (var (addr, data) in alarm.VentData)
         {
-            dataToSend.Add((addr, data));
+            dataToSend.Add((addr, data.Name, data));
         }
         foreach (var (addr, data) in alarm.ScrubberData)
         {
             data.AirAlarmPanicWireCut = alarm.PanicWireCut;
-            dataToSend.Add((addr, data));
+            dataToSend.Add((addr, data.Name, data));
         }
         foreach (var (addr, data) in alarm.SensorData)
         {
-            dataToSend.Add((addr, data));
+            dataToSend.Add((addr, data.Name, data));
         }
 
         var deviceCount = alarm.KnownDevices.Count;

--- a/Content.Server/Atmos/Monitor/Systems/AtmosMonitoringSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AtmosMonitoringSystem.cs
@@ -14,6 +14,7 @@ using Content.Shared.Atmos.Piping.Components;
 using Content.Shared.Database;
 using Content.Shared.DeviceNetwork;
 using Content.Shared.DeviceNetwork.Events;
+using Content.Shared.Labels.Components;
 using Content.Shared.Power;
 using Content.Shared.Tag;
 using Robust.Shared.Prototypes;
@@ -166,6 +167,10 @@ public sealed class AtmosMonitorSystem : EntitySystem
                         gases.Add(gas, component.TileGas.GetMoles(gas));
                     }
 
+                    var name = "";
+                    if (TryComp<LabelComponent>(uid, out var labelComp))
+                        name = labelComp.CurrentLabel ?? "";
+
                     payload.Add(AtmosDeviceNetworkSystem.SyncData, new AtmosSensorData(
                         component.TileGas.Pressure,
                         component.TileGas.Temperature,
@@ -174,7 +179,8 @@ public sealed class AtmosMonitorSystem : EntitySystem
                         gases,
                         component.PressureThreshold ?? new(),
                         component.TemperatureThreshold ?? new(),
-                        component.GasThresholds ?? new()
+                        component.GasThresholds ?? new(),
+                        name
                     ));
                 }
 

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentPumpSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentPumpSystem.cs
@@ -22,6 +22,7 @@ using Content.Shared.DeviceNetwork.Components;
 using Content.Shared.DeviceNetwork.Events;
 using Content.Shared.DoAfter;
 using Content.Shared.Examine;
+using Content.Shared.Labels.Components;
 using Content.Shared.Power;
 using Content.Shared.Tools.Systems;
 using Content.Shared.Verbs;
@@ -228,7 +229,12 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
             {
                 case AtmosDeviceNetworkSystem.SyncData:
                     payload.Add(DeviceNetworkConstants.Command, AtmosDeviceNetworkSystem.SyncData);
-                    payload.Add(AtmosDeviceNetworkSystem.SyncData, component.ToAirAlarmData());
+                    var name = "";
+                    if (TryComp<LabelComponent>(uid, out var labelComponent))
+                        name = labelComponent.CurrentLabel ?? "";
+                    var alarmData = component.ToAirAlarmData();
+                    alarmData.Name = name;
+                    payload.Add(AtmosDeviceNetworkSystem.SyncData, alarmData);
 
                     _deviceNetSystem.QueuePacket(uid, args.SenderAddress, payload, device: netConn);
 

--- a/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentScrubberSystem.cs
+++ b/Content.Server/Atmos/Piping/Unary/EntitySystems/GasVentScrubberSystem.cs
@@ -17,6 +17,7 @@ using Content.Shared.Database;
 using Content.Shared.DeviceNetwork;
 using Content.Shared.DeviceNetwork.Components;
 using Content.Shared.DeviceNetwork.Events;
+using Content.Shared.Labels.Components;
 using Content.Shared.Power;
 using Content.Shared.Tools.Systems;
 using JetBrains.Annotations;
@@ -158,7 +159,14 @@ namespace Content.Server.Atmos.Piping.Unary.EntitySystems
             {
                 case AtmosDeviceNetworkSystem.SyncData:
                     payload.Add(DeviceNetworkConstants.Command, AtmosDeviceNetworkSystem.SyncData);
-                    payload.Add(AtmosDeviceNetworkSystem.SyncData, component.ToAirAlarmData());
+
+                    var name = "";
+                    if (TryComp<LabelComponent>(uid, out var labelComponent))
+                        name = labelComponent.CurrentLabel ?? "";
+                    var alarmData = component.ToAirAlarmData();
+                    alarmData.Name = name;
+
+                    payload.Add(AtmosDeviceNetworkSystem.SyncData, alarmData);
 
                     _deviceNetSystem.QueuePacket(uid, args.SenderAddress, payload, device: netConn);
 

--- a/Content.Shared/Atmos/Monitor/AtmosSensorData.cs
+++ b/Content.Shared/Atmos/Monitor/AtmosSensorData.cs
@@ -6,7 +6,7 @@ namespace Content.Shared.Atmos.Monitor;
 [Serializable, NetSerializable]
 public sealed class AtmosSensorData : IAtmosDeviceData
 {
-    public AtmosSensorData(float pressure, float temperature, float totalMoles, AtmosAlarmType alarmState, Dictionary<Gas, float> gases, AtmosAlarmThreshold pressureThreshold, AtmosAlarmThreshold temperatureThreshold, Dictionary<Gas, AtmosAlarmThreshold> gasThresholds)
+    public AtmosSensorData(float pressure, float temperature, float totalMoles, AtmosAlarmType alarmState, Dictionary<Gas, float> gases, AtmosAlarmThreshold pressureThreshold, AtmosAlarmThreshold temperatureThreshold, Dictionary<Gas, AtmosAlarmThreshold> gasThresholds, string name)
     {
         Pressure = pressure;
         Temperature = temperature;
@@ -16,6 +16,7 @@ public sealed class AtmosSensorData : IAtmosDeviceData
         PressureThreshold = pressureThreshold;
         TemperatureThreshold = temperatureThreshold;
         GasThresholds = gasThresholds;
+        Name = name;
     }
 
     public bool Enabled { get; set; }
@@ -48,4 +49,5 @@ public sealed class AtmosSensorData : IAtmosDeviceData
     public AtmosAlarmThreshold PressureThreshold { get; }
     public AtmosAlarmThreshold TemperatureThreshold { get; }
     public Dictionary<Gas, AtmosAlarmThreshold> GasThresholds { get; }
+    public string Name { get; set; } = "";
 }

--- a/Content.Shared/Atmos/Monitor/Components/SharedAirAlarmComponent.cs
+++ b/Content.Shared/Atmos/Monitor/Components/SharedAirAlarmComponent.cs
@@ -32,12 +32,13 @@ public interface IAtmosDeviceData
     public bool Enabled { get; set; }
     public bool Dirty { get; set; }
     public bool IgnoreAlarms { get; set; }
+    public string Name { get; set; }
 }
 
 [Serializable, NetSerializable]
 public sealed class AirAlarmUIState : BoundUserInterfaceState
 {
-    public AirAlarmUIState(string address, int deviceCount, float pressureAverage, float temperatureAverage, List<(string, IAtmosDeviceData)> deviceData, AirAlarmMode mode, AtmosAlarmType alarmType, bool autoMode, bool panicWireCut)
+    public AirAlarmUIState(string address, int deviceCount, float pressureAverage, float temperatureAverage, List<(string address, string name, IAtmosDeviceData)> deviceData, AirAlarmMode mode, AtmosAlarmType alarmType, bool autoMode, bool panicWireCut)
     {
         Address = address;
         DeviceCount = deviceCount;
@@ -61,7 +62,7 @@ public sealed class AirAlarmUIState : BoundUserInterfaceState
     ///     data. The same address may appear multiple times, if
     ///     that device provides multiple functions.
     /// </summary>
-    public List<(string, IAtmosDeviceData)> DeviceData { get; }
+    public List<(string address, string name, IAtmosDeviceData)> DeviceData { get; }
     public AirAlarmMode Mode { get; }
     public AtmosAlarmType AlarmType { get; }
     public bool AutoMode { get; }

--- a/Content.Shared/Atmos/Piping/Unary/Components/SharedVentPumpComponent.cs
+++ b/Content.Shared/Atmos/Piping/Unary/Components/SharedVentPumpComponent.cs
@@ -14,6 +14,7 @@ namespace Content.Shared.Atmos.Piping.Unary.Components
         public float ExternalPressureBound { get; set; } = Atmospherics.OneAtmosphere;
         public float InternalPressureBound { get; set; } = 0f;
         public bool PressureLockoutOverride { get; set; } = false;
+        public string Name { get; set; } = "";
 
         // Presets for 'dumb' air alarm modes
 

--- a/Content.Shared/Atmos/Piping/Unary/Components/SharedVentScrubberComponent.cs
+++ b/Content.Shared/Atmos/Piping/Unary/Components/SharedVentScrubberComponent.cs
@@ -14,6 +14,7 @@ namespace Content.Shared.Atmos.Piping.Unary.Components
         public float VolumeRate { get; set; } = 200f;
         public bool WideNet { get; set; } = false;
         public bool AirAlarmPanicWireCut { get; set; }
+        public string Name { get; set; } = "";
 
         public static HashSet<Gas> DefaultFilterGases = new()
         {

--- a/Resources/Locale/en-US/atmos/air-alarm-ui.ftl
+++ b/Resources/Locale/en-US/atmos/air-alarm-ui.ftl
@@ -67,7 +67,7 @@ air-alarm-ui-widget-enable = Enabled
 air-alarm-ui-widget-copy = Copy settings to similar devices
 air-alarm-ui-widget-copy-tooltip = Copies the settings of this device to all devices in this air alarm tab.
 air-alarm-ui-widget-ignore = Ignore
-air-alarm-ui-atmos-net-device-label = Address: {$address}
+air-alarm-ui-atmos-net-device-label = {$address}
 
 ### Vent pumps
 

--- a/Resources/Prototypes/Entities/Objects/Tools/hand_labeler.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/hand_labeler.yml
@@ -28,6 +28,7 @@
           - StorageCounter
           - AirAlarm
           - Structure
+          - AirSensor
     - type: PhysicalComposition
       materialComposition:
         Plastic: 50

--- a/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/sensor.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Atmospherics/sensor.yml
@@ -29,6 +29,7 @@
     guides:
     - DeviceMonitoringAndControl
     - AtmosphericsSystems
+  - type: Label
 
 - type: entity
   id: AirSensor


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Atmos devices, namely vents, sensors, and scrubbers, can now be labeled with a hand labeler. These labels will show up as the name of the device on the Air Alarm UI.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Simple QoL update allowing you to label the various scrubbers and whatnot in the UI of the Air Alarm. Allows complex atmos setups to be easier to communicate.

## Technical details
<!-- Summary of code changes for easier review. -->
* Added the LabelComponent to the AirSensorBase prototype (parented to all the various sensor devices including vents and scrubbers)
* Added sensors to the hand labeler whitelist
* Added CurrentLabel as a name field withing all sensor data constructors for air alarm network signals.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="483" height="448" alt="Screenshot 2026-06-30 102138" src="https://github.com/user-attachments/assets/517aa52b-c7bb-401f-a2bf-fff400b51ff5" />
<img width="486" height="448" alt="Screenshot 2026-06-30 102132" src="https://github.com/user-attachments/assets/91a92481-23a8-45be-9718-df4062d7e337" />
<img width="481" height="448" alt="Screenshot 2026-06-30 102126" src="https://github.com/user-attachments/assets/79af8a4c-ee9b-4f89-8d68-17d406119d1c" />

If no label is present, it still uses the address.
<img width="484" height="449" alt="Screenshot 2026-06-30 102035" src="https://github.com/user-attachments/assets/e26b6fac-085a-417e-9926-05edae0bc420" />
<img width="487" height="447" alt="Screenshot 2026-06-30 101959" src="https://github.com/user-attachments/assets/8a0ecde1-523c-4aa0-a82a-143b9666329f" />
<img width="485" height="452" alt="Screenshot 2026-06-30 102041" src="https://github.com/user-attachments/assets/ef1f9e34-ab41-4c0d-9b86-c5ef1cd5288f" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
No known breaking changes

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Atmos devices can now be labeled and appear with their names on Air Alarms