### PR TITLE
SL RD suit light color change

### DIFF
--- a/Resources/Prototypes/_Persistence14/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/_Persistence14/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -116,7 +116,7 @@
     sprite: _Persistence14/Clothing/Head/Helmets/Hardsuits/rd.rsi
   - type: PointLight
     radius: 5
-    color: "#d6adff"
+    color: "#ffc065"
   - type: PressureProtection
     highPressureMultiplier: 0.60
     lowPressureMultiplier: 1000


### PR DESCRIPTION
Changed the head lamp light color on the SL RD suit from purple to orange to match the sprite's light layer color.


## About the PR
Just changed the color projected from the light on the SL RD hardsuit.

## Why / Balance
The sprite clearly shows an orange flashlight glare, while the projected light cone was purple. This is to fix the inconsistency.

## Technical details
Changed the PointLight color from purple to orange in the hardsuit-helmets.yml under the _Persistence14 directory for prototypes.

## Media
<img width="456" height="437" alt="image" src="https://github.com/user-attachments/assets/4e83e7df-af61-4817-bd3a-778f5fea7aaa" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None that I am aware of.

**Changelog**
- fix: Fixed the Solar Legion Research Director Hardsuit lamp color. No longer does an orange flashlight emit purple light!
