### PR TITLE
Bags in Lathes

### DIFF
--- a/Resources/Locale/en-US/_Persistence14/bags.ftl
+++ b/Resources/Locale/en-US/_Persistence14/bags.ftl
@@ -1,0 +1,1 @@
+lathe-category-bags = Bags

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -538,9 +538,12 @@
     - Carpets
     - Bedsheets
     - NFWallets # Frontier
+    - CivilianBags
+    - CommandBags
   - type: EmagLatheRecipes
     emagStaticPacks:
     - ClothingSyndie
+    - ContrabandBags
   - type: MaterialStorage
     whitelist: *StandardMaterialWhitelist
   - type: OreSiloClient

--- a/Resources/Prototypes/Recipes/Lathes/categories.yml
+++ b/Resources/Prototypes/Recipes/Lathes/categories.yml
@@ -199,3 +199,7 @@
 - type: latheCategory
   id: Masks
   name: lathe-category-masks
+
+- type: latheCategory
+  id: Bags
+  name: lathe-category-bags

--- a/Resources/Prototypes/_Persistence14/Recipes/Lathe/Packs/bags.yml
+++ b/Resources/Prototypes/_Persistence14/Recipes/Lathe/Packs/bags.yml
@@ -1,0 +1,104 @@
+# Civilian Bags
+- type: latheRecipePack
+  id: CivilianBags
+  recipes:
+  - Backpack
+  - BackpackClown
+  - BackpackMime
+  - BackpackEngineering
+  - BackpackAtmospherics
+  - BackpackMedical
+  - BackpackChemistry
+  - BackpackHydroponics
+  - BackpackScience
+  - BackpackVirology
+  - BackpackGenetics
+  - BackpackCargo
+  - BackpackSalvage
+
+  - Satchel
+  - SatchelLeather
+  - SatchelEngineering
+  - SatchelAtmospherics
+  - SatchelClown
+  - SatchelMime
+  - SatchelMedical
+  - SatchelChemistry
+  - SatchelVirology
+  - SatchelGenetics
+  - SatchelScience
+  - SatchelHydroponics
+  - SatchelCargo
+  - SatchelSalvage
+
+  - Duffel
+  - DuffelEngineering
+  - DuffelAtmospherics
+  - DuffelMedical
+  - DuffelClown
+  - DuffelChemistry
+  - DuffelVirology
+  - DuffelGenetics
+  - DuffelMime
+  - DuffelScience
+  - DuffelHydroponics
+  - DuffelCargo
+  - DuffelSalvage
+
+
+# Command Bags
+- type: latheRecipePack
+  id: CommandBags
+  recipes:
+  - BackpackCaptain
+  - BackpackIan
+  - BackpackSecurity
+  - BackpackBrigmedic
+
+  - SatchelCaptain
+  - SatchelSecurity
+  - SatchelBrigmedic
+
+  - DuffelCaptain
+  - DuffelSecurity
+  - DuffelBrigmedic
+
+# CC Bags
+- type: latheRecipePack
+  id: CentralCommandBags
+  recipes: 
+  - BackpackERTLeader
+  - BackpackERTSecurity
+  - BackpackERTMedical
+  - BackpackERTEngineer
+  - BackpackERTJanitor
+  - BackpackERTClown
+  - BackpackERTChaplain 
+  - BackpackDeathSquad
+  - DuffelCBURN
+
+# Contraband Bags
+- type: latheRecipePack
+  id: ContrabandBags
+  recipes:
+  - BackpackMerc
+  - BackpackSyndicate
+  - BackpackCluwne
+
+  - SatchelNinja
+
+  - DuffelSyndicate
+  - DuffelSyndicateAmmo
+  - DuffelSyndicateMedical
+
+
+# Debug Bags
+- type: latheRecipePack
+  id: DebugBags
+  recipes:
+  - BackpackDebug
+  - BackpackDebug2
+  - BackpackDebug3
+  - BackpackDebug4
+
+  - SatchelAdmin

--- a/Resources/Prototypes/_Persistence14/Recipes/Lathe/backpacks.yml
+++ b/Resources/Prototypes/_Persistence14/Recipes/Lathe/backpacks.yml
@@ -1,0 +1,168 @@
+# Civilian Backpacks
+- type: latheRecipe
+  id: Backpack
+  parent: BaseBackpack
+  result: ClothingBackpack
+
+- type: latheRecipe
+  id: BackpackClown
+  parent: BaseBackpack
+  result: ClothingBackpackClown
+
+- type: latheRecipe
+  id: BackpackMime
+  parent: BaseBackpack
+  result: ClothingBackpackMime
+
+- type: latheRecipe
+  id: BackpackEngineering
+  parent: BaseBackpack
+  result: ClothingBackpackEngineering
+
+- type: latheRecipe
+  id: BackpackAtmospherics
+  parent: BaseBackpack
+  result: ClothingBackpackAtmospherics
+
+- type: latheRecipe
+  id: BackpackMedical
+  parent: BaseBackpack
+  result: ClothingBackpackMedical
+
+- type: latheRecipe
+  id: BackpackChemistry
+  parent: BaseBackpack
+  result: ClothingBackpackChemistry
+
+- type: latheRecipe
+  id: BackpackHydroponics
+  parent: BaseBackpack
+  result: ClothingBackpackHydroponics
+
+- type: latheRecipe
+  id: BackpackScience
+  parent: BaseBackpack
+  result: ClothingBackpackScience
+
+- type: latheRecipe
+  id: BackpackVirology
+  parent: BaseBackpack
+  result: ClothingBackpackVirology
+
+- type: latheRecipe
+  id: BackpackGenetics
+  parent: BaseBackpack
+  result: ClothingBackpackGenetics
+
+- type: latheRecipe
+  id: BackpackCargo
+  parent: BaseBackpack
+  result: ClothingBackpackCargo
+
+- type: latheRecipe
+  id: BackpackSalvage
+  parent: BaseBackpack
+  result: ClothingBackpackSalvage
+
+
+# Command Backpacks
+- type: latheRecipe
+  id: BackpackCaptain
+  parent: BaseBackpack
+  result: ClothingBackpackCaptain
+
+- type: latheRecipe
+  id: BackpackIan
+  parent: BaseBackpack
+  result: ClothingBackpackIan
+
+- type: latheRecipe
+  id: BackpackSecurity
+  parent: BaseBackpack
+  result: ClothingBackpackSecurity
+
+- type: latheRecipe
+  id: BackpackBrigmedic
+  parent: BaseBackpack
+  result: ClothingBackpackBrigmedic
+
+
+# ERT Bags
+- type: latheRecipe
+  id: BackpackERTLeader
+  parent: BaseBackpack
+  result: ClothingBackpackERTLeader
+
+- type: latheRecipe
+  id: BackpackERTSecurity
+  parent: BaseBackpack
+  result: ClothingBackpackERTSecurity
+
+- type: latheRecipe
+  id: BackpackERTMedical
+  parent: BaseBackpack
+  result: ClothingBackpackERTMedical
+
+- type: latheRecipe
+  id: BackpackERTEngineer
+  parent: BaseBackpack
+  result: ClothingBackpackERTEngineer
+
+- type: latheRecipe
+  id: BackpackERTJanitor
+  parent: BaseBackpack
+  result: ClothingBackpackERTJanitor
+
+- type: latheRecipe
+  id: BackpackERTClown
+  parent: BaseBackpack
+  result: ClothingBackpackERTClown
+
+- type: latheRecipe
+  id: BackpackERTChaplain
+  parent: BaseBackpack
+  result: ClothingBackpackERTChaplain
+
+
+# Contraband Backpacks
+- type: latheRecipe
+  id: BackpackMerc
+  parent: BaseBackpack
+  result: ClothingBackpackMerc
+
+- type: latheRecipe
+  id: BackpackDeathSquad
+  parent: BaseBackpack
+  result: ClothingBackpackDeathSquad
+
+- type: latheRecipe
+  id: BackpackSyndicate
+  parent: BaseBackpack
+  result: ClothingBackpackSyndicate
+
+- type: latheRecipe
+  id: BackpackCluwne
+  parent: BaseBackpack
+  result: ClothingBackpackCluwne
+
+
+# Debug Backpacks
+- type: latheRecipe
+  id: BackpackDebug
+  parent: BaseBackpack
+  result: ClothingBackpackDebug
+
+- type: latheRecipe
+  id: BackpackDebug2
+  parent: BaseBackpack
+  result: ClothingBackpackDebug2
+
+- type: latheRecipe
+  id: BackpackDebug3
+  parent: BaseBackpack
+  result: ClothingBackpackDebug3
+
+- type: latheRecipe
+  id: BackpackDebug4
+  parent: BaseBackpack
+  result: ClothingBackpackDebug4

--- a/Resources/Prototypes/_Persistence14/Recipes/Lathe/base_bags.yml
+++ b/Resources/Prototypes/_Persistence14/Recipes/Lathe/base_bags.yml
@@ -1,0 +1,26 @@
+- type: latheRecipe
+  id: BaseBackpack
+  abstract: true
+  completetime: 3
+  categories:
+  - Bags
+  materials:
+   Steel: 50
+   Cloth: 500
+  
+- type: latheRecipe
+  id: BaseSatchel
+  parent: BaseBackpack
+  abstract: true
+  completetime: 3
+  materials:
+    Cloth: 500
+
+- type: latheRecipe
+  id: BaseDuffelBag
+  parent: BaseBackpack
+  abstract: true
+  completetime: 3
+  materials:
+    Steel: 50
+    Cloth: 500

--- a/Resources/Prototypes/_Persistence14/Recipes/Lathe/dufflebags.yml
+++ b/Resources/Prototypes/_Persistence14/Recipes/Lathe/dufflebags.yml
@@ -1,0 +1,104 @@
+# Civilian Duffel Bags
+- type: latheRecipe
+  id: Duffel
+  parent: BaseDuffelBag
+  result: ClothingBackpackDuffel
+
+- type: latheRecipe
+  id: DuffelEngineering
+  parent: BaseDuffelBag
+  result: ClothingBackpackDuffelEngineering
+
+- type: latheRecipe
+  id: DuffelAtmospherics
+  parent: BaseDuffelBag
+  result: ClothingBackpackDuffelAtmospherics
+
+- type: latheRecipe
+  id: DuffelMedical
+  parent: BaseDuffelBag
+  result: ClothingBackpackDuffelMedical
+
+- type: latheRecipe
+  id: DuffelClown
+  parent: BaseDuffelBag
+  result: ClothingBackpackDuffelClown
+
+- type: latheRecipe
+  id: DuffelChemistry
+  parent: BaseDuffelBag
+  result: ClothingBackpackDuffelChemistry
+
+- type: latheRecipe
+  id: DuffelVirology
+  parent: BaseDuffelBag
+  result: ClothingBackpackDuffelVirology
+
+- type: latheRecipe
+  id: DuffelGenetics
+  parent: BaseDuffelBag
+  result: ClothingBackpackDuffelGenetics
+
+- type: latheRecipe
+  id: DuffelMime
+  parent: BaseDuffelBag
+  result: ClothingBackpackDuffelMime
+
+- type: latheRecipe
+  id: DuffelScience
+  parent: BaseDuffelBag
+  result: ClothingBackpackDuffelScience
+
+- type: latheRecipe
+  id: DuffelHydroponics
+  parent: BaseDuffelBag
+  result: ClothingBackpackDuffelHydroponics
+
+- type: latheRecipe
+  id: DuffelCargo
+  parent: BaseDuffelBag
+  result: ClothingBackpackDuffelCargo
+
+- type: latheRecipe
+  id: DuffelSalvage
+  parent: BaseDuffelBag
+  result: ClothingBackpackDuffelSalvage
+
+
+# Command Duffel Bags
+- type: latheRecipe
+  id: DuffelCaptain
+  parent: BaseDuffelBag
+  result: ClothingBackpackDuffelCaptain
+
+- type: latheRecipe
+  id: DuffelSecurity
+  parent: BaseDuffelBag
+  result: ClothingBackpackDuffelSecurity
+
+- type: latheRecipe
+  id: DuffelBrigmedic
+  parent: BaseDuffelBag
+  result: ClothingBackpackDuffelBrigmedic
+
+
+# Contraband Duffel Bags
+- type: latheRecipe
+  id: DuffelSyndicate
+  parent: BaseDuffelBag
+  result: ClothingBackpackDuffelSyndicate
+
+- type: latheRecipe
+  id: DuffelSyndicateAmmo
+  parent: BaseDuffelBag
+  result: ClothingBackpackDuffelSyndicateAmmo
+
+- type: latheRecipe
+  id: DuffelSyndicateMedical
+  parent: BaseDuffelBag
+  result: ClothingBackpackDuffelSyndicateMedical
+
+- type: latheRecipe
+  id: DuffelCBURN
+  parent: BaseDuffelBag
+  result: ClothingBackpackDuffelCBURN

--- a/Resources/Prototypes/_Persistence14/Recipes/Lathe/satchels.yml
+++ b/Resources/Prototypes/_Persistence14/Recipes/Lathe/satchels.yml
@@ -1,0 +1,99 @@
+# Civilian Satchels
+- type: latheRecipe
+  id: Satchel
+  parent: BaseSatchel
+  result: ClothingBackpackSatchel
+
+- type: latheRecipe
+  id: SatchelLeather
+  parent: BaseSatchel
+  result: ClothingBackpackSatchelLeather
+
+- type: latheRecipe
+  id: SatchelEngineering
+  parent: BaseSatchel
+  result: ClothingBackpackSatchelEngineering
+
+- type: latheRecipe
+  id: SatchelAtmospherics
+  parent: BaseSatchel
+  result: ClothingBackpackSatchelAtmospherics
+
+- type: latheRecipe
+  id: SatchelClown
+  parent: BaseSatchel
+  result: ClothingBackpackSatchelClown
+
+- type: latheRecipe
+  id: SatchelMime
+  parent: BaseSatchel
+  result: ClothingBackpackSatchelMime
+
+- type: latheRecipe
+  id: SatchelMedical
+  parent: BaseSatchel
+  result: ClothingBackpackSatchelMedical
+
+- type: latheRecipe
+  id: SatchelChemistry
+  parent: BaseSatchel
+  result: ClothingBackpackSatchelChemistry
+
+- type: latheRecipe
+  id: SatchelVirology
+  parent: BaseSatchel
+  result: ClothingBackpackSatchelVirology
+
+- type: latheRecipe
+  id: SatchelGenetics
+  parent: BaseSatchel
+  result: ClothingBackpackSatchelGenetics
+
+- type: latheRecipe
+  id: SatchelScience
+  parent: BaseSatchel
+  result: ClothingBackpackSatchelScience
+
+- type: latheRecipe
+  id: SatchelHydroponics
+  parent: BaseSatchel
+  result: ClothingBackpackSatchelHydroponics
+
+- type: latheRecipe
+  id: SatchelCargo
+  parent: BaseSatchel
+  result: ClothingBackpackSatchelCargo
+
+- type: latheRecipe
+  id: SatchelSalvage
+  parent: BaseSatchel
+  result: ClothingBackpackSatchelSalvage
+
+
+# Command Satchels
+- type: latheRecipe
+  id: SatchelSecurity
+  parent: BaseSatchel
+  result: ClothingBackpackSatchelSecurity
+
+- type: latheRecipe
+  id: SatchelBrigmedic
+  parent: BaseSatchel
+  result: ClothingBackpackSatchelBrigmedic
+
+- type: latheRecipe
+  id: SatchelCaptain
+  parent: BaseSatchel
+  result: ClothingBackpackSatchelCaptain
+
+# Contraband Satchels
+- type: latheRecipe
+  id: SatchelNinja
+  parent: BaseSatchel
+  result: ClothingBackpackSatchelNinja
+
+# Debug Satchels
+- type: latheRecipe
+  id: SatchelAdmin
+  parent: BaseSatchel
+  result: ClothingBackpackSatchelAdmin


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds lathe recipes to the clothing fabricator for all standard bags. Now you can get your hands on all the fancy bags you want from base SS14. Currently includes all the base station bags from normal play you could previously only get from vendor restocks. Also added contraband bags to the emag list for the clothing fabricator.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I see no reason why these shouldn't be craftable. Currently, these are only obtainable through specific vendor restocks and even then I think some are unobtainable. This simple change allows for easy access to more fashion items for people to use for stuff!

## Technical details
<!-- Summary of code changes for easier review. -->
A bunch of yaml. Created new recipes, recipe packs, and added those packs to the lathe packs on the clothing fabricator.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
No known breaking changes

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Bags can now be printed in the clothing fabricator!
