### PR TITLE
QSI Research Rebalance

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/devices.yml
+++ b/Resources/Prototypes/Recipes/Lathes/devices.yml
@@ -10,7 +10,7 @@
   result: SignalTrigger
   unlockUses: 4
 
-- type: latheRecipe
+- type: latheRecipe 
   parent: BasePartRecipe
   id: VoiceTrigger
   result: VoiceTrigger
@@ -197,6 +197,7 @@
     Steel: 700
     Glass: 100
     Uranium: 100
+  unlockUses: 2 # These are a pair so uh, two.
 
 - type: latheRecipe
   id: DeviceDesynchronizer


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Incearsed research unlock amount for QSIs from 1 to 2

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
QSIs are a linked pair, a research giving only 1 feels very silly.

## Technical details
<!-- Summary of code changes for easier review. -->
* Added field to QSI recipe: unlockUses: 2

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Changed QSI count from research from 1 to 2
