### PR TITLE
Made Chemmaster buffer searchable

### DIFF
--- a/Content.Client/Chemistry/UI/ChemMasterWindow.xaml
+++ b/Content.Client/Chemistry/UI/ChemMasterWindow.xaml
@@ -34,9 +34,9 @@
                 <Label Text="{Loc 'chem-master-window-buffer-text'}" />
                 <LineEdit
                     Name="SearchBar"
-                    PlaceHolder="{Loc 'shuttle-console-map-objects-search'}"
-                    HorizontalExpand="True"/>
-                <Control HorizontalExpand="True" />
+                    PlaceHolder="{Loc 'chem-master-window-buffer-search'}"
+                    HorizontalExpand="True"
+                    Margin="10 0"/>
                 <Button MinSize="80 0" Margin="0 0 10 0" Name="BufferSortButton" Access="Public" Text="{Loc 'chem-master-window-sort-type-none'}" />
                 <Button MinSize="80 0" Name="BufferTransferButton" Access="Public" Text="{Loc 'chem-master-window-transfer-button'}" ToggleMode="True" StyleClasses="OpenRight" />
                 <Button MinSize="80 0" Name="BufferDiscardButton" Access="Public" Text="{Loc 'chem-master-window-discard-button'}" ToggleMode="True" StyleClasses="OpenLeft" />

--- a/Content.Client/Chemistry/UI/ChemMasterWindow.xaml
+++ b/Content.Client/Chemistry/UI/ChemMasterWindow.xaml
@@ -32,6 +32,10 @@
             <!-- Buffer -->
             <BoxContainer Orientation="Horizontal">
                 <Label Text="{Loc 'chem-master-window-buffer-text'}" />
+                <LineEdit
+                    Name="SearchBar"
+                    PlaceHolder="{Loc 'shuttle-console-map-objects-search'}"
+                    HorizontalExpand="True"/>
                 <Control HorizontalExpand="True" />
                 <Button MinSize="80 0" Margin="0 0 10 0" Name="BufferSortButton" Access="Public" Text="{Loc 'chem-master-window-sort-type-none'}" />
                 <Button MinSize="80 0" Name="BufferTransferButton" Access="Public" Text="{Loc 'chem-master-window-transfer-button'}" ToggleMode="True" StyleClasses="OpenRight" />

--- a/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
+++ b/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
@@ -329,7 +329,7 @@ namespace Content.Client.Chemistry.UI
             bufferHBox.AddChild(bufferLabel);
             var bufferVol = new Label
             {
-                Text = $"{_bufferReagents.Sum(x => x.Quantity.Value)}u",
+                Text = $"{_bufferReagents.Sum(x => x.Quantity.Int())}u",
                 StyleClasses = { StyleClass.LabelWeak }
             };
             bufferHBox.AddChild(bufferVol);

--- a/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
+++ b/Content.Client/Chemistry/UI/ChemMasterWindow.xaml.cs
@@ -33,6 +33,9 @@ namespace Content.Client.Chemistry.UI
 
         private const string PillsRsiPath = "/Textures/Objects/Specific/Chemistry/pills.rsi";
 
+        private List<ReagentItem> _bufferReagents = [];
+        private ChemMasterSortingType _sortType;
+
         /// <summary>
         /// Create and initialize the chem master UI client-side. Creates the basic layout,
         /// actual data isn't filled in until the server sends data about the chem master.
@@ -93,6 +96,8 @@ namespace Content.Client.Chemistry.UI
 
             Tabs.SetTabTitle(0, Loc.GetString("chem-master-window-input-tab"));
             Tabs.SetTabTitle(1, Loc.GetString("chem-master-window-output-tab"));
+
+            SearchBar.OnTextChanged += _ => FilterBufferReagents();
         }
 
         private ReagentButton MakeReagentButton(string text, ChemMasterReagentAmount amount, ReagentId id, bool isBuffer, string styleClass)
@@ -246,8 +251,6 @@ namespace Content.Client.Chemistry.UI
             BuildContainerUI(InputContainerInfo, state.InputContainerInfo, true);
             BuildContainerUI(OutputContainerInfo, state.OutputContainerInfo, false);
 
-            BufferInfo.Children.Clear();
-
             // This has to happen here due to people possibly
             // setting sorting before putting any chemicals
             BufferSortButton.Text = state.SortingType switch
@@ -261,7 +264,55 @@ namespace Content.Client.Chemistry.UI
             OutputBufferDraw.Pressed = state.DrawSource == ChemMasterDrawSource.Internal;
             OutputBeakerDraw.Pressed = state.DrawSource == ChemMasterDrawSource.External;
 
-            if (!state.BufferReagents.Any())
+            // This sets up the needed data for sorting later in a list
+            // Its done this way to not repeat having to use same code twice (once for sorting
+            // and once for displaying)
+            _bufferReagents.Clear();
+            foreach (var (reagent, quantity) in state.BufferReagents)
+            {
+                var reagentId = reagent;
+                _prototypeManager.TryIndex(reagentId.Prototype, out ReagentPrototype? proto);
+                var name = proto?.LocalizedName ?? Loc.GetString("chem-master-window-unknown-reagent-text");
+                var reagentColor = proto?.SubstanceColor ?? default(Color);
+                _bufferReagents.Add(new ReagentItem(reagentId, name, reagentColor, quantity));
+            }
+
+            _sortType = state.SortingType;
+
+            FilterBufferReagents();
+        }
+
+        private void FilterBufferReagents()
+        {
+            //Filter by search bar, if there is any input
+            var sortedReagents = SearchBar.Text.Trim().Length > 0
+                ? _bufferReagents.Where(x => x.Name.Contains(SearchBar.Text.Trim(), StringComparison.InvariantCultureIgnoreCase)).ToList()
+                : _bufferReagents;
+
+            // We sort here since we need sorted list to be filled first.
+            // You can easily add any new params you need to it.
+            switch (_sortType)
+            {
+                case ChemMasterSortingType.Alphabetical:
+                    sortedReagents = sortedReagents.OrderBy(x => x.Name).ToList();
+                    break;
+
+                case ChemMasterSortingType.Quantity:
+                    sortedReagents = sortedReagents.OrderByDescending(x => x.Quantity).ToList();
+                    break;
+                case ChemMasterSortingType.Latest:
+                    sortedReagents = Enumerable.Reverse(sortedReagents).ToList();
+                    break;
+
+                case ChemMasterSortingType.None:
+                default:
+                    // This case is pointless but it is there for readability
+                    break;
+            }
+
+            BufferInfo.Children.Clear();
+
+            if (!sortedReagents.Any())
             {
                 BufferInfo.Children.Add(new Label { Text = Loc.GetString("chem-master-window-buffer-empty-text") });
 
@@ -278,50 +329,16 @@ namespace Content.Client.Chemistry.UI
             bufferHBox.AddChild(bufferLabel);
             var bufferVol = new Label
             {
-                Text = $"{state.BufferCurrentVolume}u",
+                Text = $"{_bufferReagents.Sum(x => x.Quantity.Value)}u",
                 StyleClasses = { StyleClass.LabelWeak }
             };
             bufferHBox.AddChild(bufferVol);
 
-            // This sets up the needed data for sorting later in a list
-            // Its done this way to not repeat having to use same code twice (once for sorting
-            // and once for displaying)
-            var reagentList = new List<(ReagentId reagentId, string name, Color color, FixedPoint2 quantity)>();
-            foreach (var (reagent, quantity) in state.BufferReagents)
-            {
-                var reagentId = reagent;
-                _prototypeManager.TryIndex(reagentId.Prototype, out ReagentPrototype? proto);
-                var name = proto?.LocalizedName ?? Loc.GetString("chem-master-window-unknown-reagent-text");
-                var reagentColor = proto?.SubstanceColor ?? default(Color);
-                reagentList.Add(new(reagentId, name, reagentColor, quantity));
-            }
-
-            // We sort here since we need sorted list to be filled first.
-            // You can easily add any new params you need to it.
-            switch (state.SortingType)
-            {
-                case ChemMasterSortingType.Alphabetical:
-                    reagentList = reagentList.OrderBy(x => x.name).ToList();
-                    break;
-
-                case ChemMasterSortingType.Quantity:
-                    reagentList = reagentList.OrderByDescending(x => x.quantity).ToList();
-                    break;
-                case ChemMasterSortingType.Latest:
-                    reagentList = Enumerable.Reverse(reagentList).ToList();
-                    break;
-
-                case ChemMasterSortingType.None:
-                default:
-                    // This case is pointless but it is there for readability
-                    break;
-            }
-
             // initialises rowCount to allow for striped rows
             var rowCount = 0;
-            foreach (var reagent in reagentList)
+            foreach (var reagent in sortedReagents)
             {
-                BufferInfo.Children.Add(BuildReagentRow(reagent.color, rowCount++, reagent.name, reagent.reagentId, reagent.quantity, true, true));
+                BufferInfo.Children.Add(BuildReagentRow(reagent.Color, rowCount++, reagent.Name, reagent.ReagentId, reagent.Quantity, true, true));
             }
         }
 
@@ -463,4 +480,6 @@ namespace Content.Client.Chemistry.UI
             IsBuffer = isBuffer;
         }
     }
+
+    public sealed record ReagentItem(ReagentId ReagentId, string Name, Color Color, FixedPoint2 Quantity);
 }

--- a/Resources/Locale/en-US/chemistry/components/chem-master-component.ftl
+++ b/Resources/Locale/en-US/chemistry/components/chem-master-component.ftl
@@ -18,6 +18,7 @@ chem-master-window-buffer-label = buffer:
 chem-master-window-buffer-all-amount = All
 chem-master-window-buffer-empty-text = Buffer empty.
 chem-master-window-buffer-low-text = Not enough solution in buffer
+chem-master-window-buffer-search = Search buffer
 chem-master-window-transfer-button = Transfer
 chem-master-window-discard-button = Discard
 chem-master-window-packaging-text = Packaging


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added a search bar to Chemmaster buffer

## Why / Balance
Chemmasters tend to accumulate large numbers of chems over time, resulting in the buffer becoming a long scroll zone with no way to search. Having to spend over half your time doing chemistry just scrolling through dozens of rows to pick out the one chem you need is extremely tedious and unpleasant, this aims to fix that.

## Technical details
-Search bar added to xaml
-BufferReagents and SortType are now stored as private variables in the codebehind, instead of only existing in the scope of a state update.
-BufferInfo update has been moved out of UpdatePanelInfo into its own helper function, which is also called when the search bar is updated
-Added new ReagentItem record, replacing the tuple used by the reagentLists variable in the original code, as this is the data type _bufferReagents is stored as

## Media
<img width="560" height="599" alt="image" src="https://github.com/user-attachments/assets/84226621-dca5-4dd7-bd75-662808b62459" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added search bar to the Chemmaster buffer