### PR TITLE
Entity References, Entity Void, and Polymorph Bugfixes

### DIFF
--- a/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
@@ -1,3 +1,4 @@
+using Content.Server.Administration.Managers;
 using Content.Server.Atmos.EntitySystems;
 using Content.Server.Body.Systems;
 using Content.Server.Electrocution;
@@ -95,6 +96,7 @@ public sealed partial class AdminVerbSystem
     [Dependency] private readonly SlipperySystem _slipperySystem = default!;
     [Dependency] private readonly GibbingSystem _gibbing = default!;
     [Dependency] private readonly DamageableSystem _damageable = default!;
+
 
     private readonly EntProtoId _actionViewLawsProtoId = "ActionViewLaws";
     private readonly ProtoId<SiliconLawsetPrototype> _crewsimovLawset = "Crewsimov";

--- a/Content.Server/ImmovableRod/ImmovableRodSystem.cs
+++ b/Content.Server/ImmovableRod/ImmovableRodSystem.cs
@@ -1,6 +1,7 @@
 using Content.Server.Destructible;
 using Content.Server.Polymorph.Components;
 using Content.Server.Popups;
+using Content.Shared._Persistence14.PersistentIdentifier;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Body;
 using Content.Shared.Damage.Systems;
@@ -31,6 +32,7 @@ public sealed class ImmovableRodSystem : EntitySystem
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly SharedMapSystem _map = default!;
     [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
+    [Dependency] private PersistentIdentifierSystem _pid = default!;
 
     public override void Update(float frameTime)
     {
@@ -111,8 +113,7 @@ public sealed class ImmovableRodSystem : EntitySystem
         // dont delete/hurt self if polymoprhed into a rod
         if (TryComp<PolymorphedEntityComponent>(uid, out var polymorphed))
         {
-            if (polymorphed.Parent == ent)
-                return;
+            return;
         }
 
         // gib or damage em

--- a/Content.Server/Polymorph/Components/PolymorphedEntityComponent.cs
+++ b/Content.Server/Polymorph/Components/PolymorphedEntityComponent.cs
@@ -1,10 +1,12 @@
 using Content.Server.Polymorph.Systems;
+using Content.Shared._Persistence14.PersistentIdentifier;
+using Content.Shared._Persistence14.PersistentIdentifier.Reference;
 using Content.Shared.Polymorph;
 
 namespace Content.Server.Polymorph.Components;
 
 [RegisterComponent]
-[Access(typeof(PolymorphSystem))]
+[Access(typeof(PolymorphSystem), typeof(PersistentIdentifierSystem))]
 public sealed partial class PolymorphedEntityComponent : Component
 {
     /// <summary>
@@ -17,8 +19,8 @@ public sealed partial class PolymorphedEntityComponent : Component
     /// <summary>
     /// The original entity that the player will revert back into
     /// </summary>
-    [DataField(required: true)]
-    public EntityUid? Parent;
+    [DataField]
+    public string ParentPersistentId;
 
     /// <summary>
     /// Whether this polymorph has been reverted.

--- a/Content.Server/Polymorph/Systems/PolymorphSystem.cs
+++ b/Content.Server/Polymorph/Systems/PolymorphSystem.cs
@@ -1,6 +1,12 @@
 using Content.Server.Actions;
+using Content.Server.Administration.Managers;
+using Content.Server.Administration.Systems;
+using Content.Server.Database;
 using Content.Server.Inventory;
 using Content.Server.Polymorph.Components;
+using Content.Server._Persistence14.EntityVoid;
+using Content.Shared._Persistence14.PersistentIdentifier;
+using Content.Shared.Administration;
 using Content.Shared.Body;
 using Content.Shared.Buckle;
 using Content.Shared.Coordinates;
@@ -15,12 +21,17 @@ using Content.Shared.Mobs.Systems;
 using Content.Shared.Nutrition;
 using Content.Shared.Polymorph;
 using Content.Shared.Popups;
+using Content.Shared.Verbs;
 using Robust.Server.Audio;
 using Robust.Server.Containers;
 using Robust.Server.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
+using Content.Shared._Persistence14.EntityVoid;
 
 namespace Content.Server.Polymorph.Systems;
 
@@ -43,6 +54,11 @@ public sealed partial class PolymorphSystem : EntitySystem
     [Dependency] private readonly SharedVisualBodySystem _visualBody = default!;
     [Dependency] private readonly SharedMindSystem _mindSystem = default!;
     [Dependency] private readonly MetaDataSystem _metaData = default!;
+    [Dependency] private PersistentIdentifierSystem _pid = default!;
+    [Dependency] private AdminVerbSystem _adminVerb = default!;
+    [Dependency] private readonly IAdminManager _adminManager = default!;
+    [Dependency] private readonly ILogManager _log = default!;
+    [Dependency] private EntityVoidSystem _void = default!;
 
     private const string RevertPolymorphId = "ActionRevertPolymorph";
 
@@ -57,6 +73,8 @@ public sealed partial class PolymorphSystem : EntitySystem
         SubscribeLocalEvent<PolymorphedEntityComponent, BeforeFullySlicedEvent>(OnBeforeFullySliced);
         SubscribeLocalEvent<PolymorphedEntityComponent, DestructionEventArgs>(OnDestruction);
         SubscribeLocalEvent<PolymorphedEntityComponent, EntityTerminatingEvent>(OnPolymorphedTerminating);
+
+        SubscribeLocalEvent<PolymorphedEntityComponent, GetVerbsEvent<Verb>>(AddPolymorphVerbs);
 
         InitializeMap();
     }
@@ -104,11 +122,13 @@ public sealed partial class PolymorphSystem : EntitySystem
         if (component.Configuration.Forced)
             return;
 
-        if (_actions.AddAction(uid, ref component.Action, out var action, RevertPolymorphId))
+        /*
+        if (_actions.AddAction(uid, ref component.Action, out var action, RevertPolymorphId) &&
+            _pid.TryResolveId(component.Parent, out var parentEnt))
         {
-            _actions.SetEntityIcon((component.Action.Value, action), component.Parent);
+            _actions.SetEntityIcon((component.Action.Value, action), parentEnt);
             _actions.SetUseDelay(component.Action.Value, TimeSpan.FromSeconds(component.Configuration.Delay));
-        }
+        }*/
     }
 
     private void OnPolymorphActionEvent(Entity<PolymorphableComponent> ent, ref PolymorphActionEvent args)
@@ -155,10 +175,6 @@ public sealed partial class PolymorphSystem : EntitySystem
 
         if (ent.Comp.Configuration.RevertOnDelete)
             Revert(ent.AsNullable());
-
-        // Remove our original entity too
-        // Note that Revert will set Parent to null, so reverted entities will not be deleted
-        QueueDel(ent.Comp.Parent);
     }
 
     /// <summary>
@@ -180,6 +196,9 @@ public sealed partial class PolymorphSystem : EntitySystem
     /// <returns>The new entity, or null if the polymorph failed.</returns>
     public EntityUid? PolymorphEntity(EntityUid uid, PolymorphConfiguration configuration)
     {
+        if (HasComp<VoidedComponent>(uid))
+            return null;
+
         // If they're morphed, check their current config to see if they can be
         // morphed again
         if (!configuration.IgnoreAllowRepeatedMorphs
@@ -193,6 +212,8 @@ public sealed partial class PolymorphSystem : EntitySystem
             polymorphableComponent.LastPolymorphEnd != null &&
             _gameTiming.CurTime < polymorphableComponent.LastPolymorphEnd + configuration.Cooldown)
             return null;
+
+        var pid = _pid.EnsureId(uid, out var pidEntity);
 
         // mostly just for vehicles
         _buckle.TryUnbuckle(uid, uid, true);
@@ -213,8 +234,8 @@ public sealed partial class PolymorphSystem : EntitySystem
         _mindSystem.MakeSentient(child);
 
         var polymorphedComp = Factory.GetComponent<PolymorphedEntityComponent>();
-        polymorphedComp.Parent = uid;
         polymorphedComp.Configuration = configuration;
+        polymorphedComp.ParentPersistentId = pid;
         AddComp(child, polymorphedComp);
 
         var childXform = Transform(child);
@@ -268,10 +289,13 @@ public sealed partial class PolymorphSystem : EntitySystem
         if (_mindSystem.TryGetMind(uid, out var mindId, out var mind))
             _mindSystem.TransferTo(mindId, child, mind: mind);
 
-        //Ensures a map to banish the entity to
-        EnsurePausedMap();
-        if (PausedMap != null)
-            _transform.SetParent(uid, targetTransformComp, PausedMap.Value);
+        if (!_void.TryVoidEntity(uid))
+        {
+            if (_mindSystem.TryGetMind(child, out var childMindId, out var childMind))
+                _mindSystem.TransferTo(child, childMindId, mind: childMind);
+            QueueDel(child);
+            return null;
+        }
 
         // Raise an event to inform anything that wants to know about the entity swap
         var ev = new PolymorphedEvent(uid, child, false);
@@ -298,42 +322,40 @@ public sealed partial class PolymorphSystem : EntitySystem
         if (Deleted(uid))
             return null;
 
-        if (component.Parent is not { } parent)
-            return null;
-
-        if (Deleted(parent))
+        if (ent.Comp?.ParentPersistentId is not { } pid)
             return null;
 
         var uidXform = Transform(uid);
-        var parentXform = Transform(parent);
 
         // Don't swap back onto a terminating grid
         if (TerminatingOrDeleted(uidXform.ParentUid))
             return null;
 
+        var coords = _transform.ToMapCoordinates(uidXform.Coordinates);
+
+        if (!_void.TryReconstructEntity(pid, coords, out var parentEnt))
+            return null;
+
         if (component.Configuration.ExitPolymorphSound != null)
             _audio.PlayPvs(component.Configuration.ExitPolymorphSound, uidXform.Coordinates);
-
-        _transform.SetParent(parent, parentXform, uidXform.ParentUid);
-        _transform.SetCoordinates(parent, parentXform, uidXform.Coordinates, uidXform.LocalRotation);
 
         component.Reverted = true;
 
         if (component.Configuration.TransferDamage &&
-            TryComp<DamageableComponent>(parent, out var damageParent) &&
-            _mobThreshold.GetScaledDamage(uid, parent, out var damage) &&
+            TryComp<DamageableComponent>(parentEnt, out var damageParent) &&
+            _mobThreshold.GetScaledDamage(uid, parentEnt, out var damage) &&
             damage != null)
         {
-            _damageable.SetDamage((parent, damageParent), damage);
+            _damageable.SetDamage((parentEnt, damageParent), damage);
         }
 
         if (component.Configuration.Inventory == PolymorphInventoryChange.Transfer)
         {
-            _inventory.TransferEntityInventories(uid, parent);
+            _inventory.TransferEntityInventories(uid, parentEnt);
             foreach (var held in _hands.EnumerateHeld(uid))
             {
                 _hands.TryDrop(uid, held);
-                _hands.TryPickupAnyHand(parent, held, checkActionBlocker: false);
+                _hands.TryPickupAnyHand(parentEnt, held, checkActionBlocker: false);
             }
         }
         else if (component.Configuration.Inventory == PolymorphInventoryChange.Drop)
@@ -353,30 +375,32 @@ public sealed partial class PolymorphSystem : EntitySystem
         }
 
         if (_mindSystem.TryGetMind(uid, out var mindId, out var mind))
-            _mindSystem.TransferTo(mindId, parent, mind: mind);
+            _mindSystem.TransferTo(mindId, parentEnt, mind: mind);
 
-        if (TryComp<PolymorphableComponent>(parent, out var polymorphableComponent))
+        if (TryComp<PolymorphableComponent>(parentEnt, out var polymorphableComponent))
             polymorphableComponent.LastPolymorphEnd = _gameTiming.CurTime;
 
+        var parentXform = Transform(parentEnt);
+
         // if an item polymorph was picked up, put it back down after reverting
-        _transform.AttachToGridOrMap(parent, parentXform);
+        _transform.AttachToGridOrMap(parentEnt, parentXform);
 
         // Raise an event to inform anything that wants to know about the entity swap
-        var ev = new PolymorphedEvent(uid, parent, true);
+        var ev = new PolymorphedEvent(uid, parentEnt, true);
         RaiseLocalEvent(uid, ref ev);
 
         // visual effect spawn
         if (component.Configuration.EffectProto != null)
-            SpawnAttachedTo(component.Configuration.EffectProto, parent.ToCoordinates());
+            SpawnAttachedTo(component.Configuration.EffectProto, parentEnt.ToCoordinates());
 
         if (component.Configuration.ExitPolymorphPopup != null)
             _popup.PopupEntity(Loc.GetString(component.Configuration.ExitPolymorphPopup,
                 ("parent", Identity.Entity(uid, EntityManager)),
-                ("child", Identity.Entity(parent, EntityManager))),
-                parent);
+                ("child", Identity.Entity(parentEnt, EntityManager))),
+                parentEnt);
         QueueDel(uid);
 
-        return parent;
+        return parentEnt;
     }
 
     /// <summary>
@@ -419,5 +443,26 @@ public sealed partial class PolymorphSystem : EntitySystem
 
         if (actions.TryGetValue(id, out var action))
             _actions.RemoveAction(target.Owner, action);
+    }
+
+    public void AddPolymorphVerbs(EntityUid uid, PolymorphedEntityComponent component, ref GetVerbsEvent<Verb> args)
+    {
+        if (!TryComp(args.User, out ActorComponent? actor))
+            return;
+
+        var player = actor.PlayerSession;
+
+        if (!_adminManager.HasAdminFlag(player, AdminFlags.Admin))
+            return;
+
+        if (HasComp<MapComponent>(args.Target) || HasComp<MapGridComponent>(args.Target))
+            return;
+
+        args.Verbs.Add(new Verb
+        {
+            Text = "revert-polymorph-verb",
+            Category = VerbCategory.Admin,
+            Act = () => Revert((uid, component)),
+        });
     }
 }

--- a/Content.Server/_Persistence14/EntityVoid/EntityVoidSystem.cs
+++ b/Content.Server/_Persistence14/EntityVoid/EntityVoidSystem.cs
@@ -1,0 +1,88 @@
+using Content.Shared._Persistence14.EntityVoid;
+using Content.Shared._Persistence14.PersistentIdentifier;
+using Robust.Server.GameObjects;
+using Robust.Shared.ContentPack;
+using Robust.Shared.EntitySerialization.Systems;
+using Robust.Shared.Map;
+using Robust.Shared.Utility;
+
+namespace Content.Server._Persistence14.EntityVoid;
+
+/// <summary>
+/// A system for shucking entities into the void to be handled later. Set up to allow persistent reference to these entities through a GUID.
+/// </summary>
+public sealed partial class EntityVoidSystem : EntitySystem
+{
+    [Dependency] private PersistentIdentifierSystem _pid = default!;
+    [Dependency] private MapLoaderSystem _mapLoader = default!;
+    [Dependency] private SharedTransformSystem _transform = default!;
+    [Dependency] private IResourceManager _resourceManager = default!;
+    [Dependency] private PhysicsSystem _physics = default!;
+
+    /// <summary>
+    /// Attempts to serialize an entity and remove it from the world for storage.
+    /// </summary>
+
+    public bool TryVoidEntity(EntityUid uid)
+    {
+        if (!Exists(uid))
+            return false;
+
+        if (HasComp<VoidedComponent>(uid)) // Don't void twice, if voided already... something is wrong.
+            return false;
+
+        AddComp<VoidedComponent>(uid);
+
+        var id = _pid.EnsureId(uid); // Piggy backing off of PID for the GUID system. Keeps things symetric.
+        var path = BuildPath(id);
+
+        if (!_mapLoader.TrySaveEntity(uid, path))
+            return false;
+
+        QueueDel(uid);
+        return true;
+    }
+
+    /// <summary>
+    /// Attempts to regenerate a given ID's entity from the serialized file and place it at a given set of coordiantes.
+    /// </summary>
+    public bool TryReconstructEntity(string persistentId, MapCoordinates coordinates, out EntityUid uid)
+    {
+        uid = EntityUid.Invalid;
+
+
+        var path = BuildPath(persistentId);
+
+        if (!_mapLoader.TryLoadEntity(path, out var entity))
+            return false;
+
+
+        uid = entity.Value.Owner;
+        _transform.SetMapCoordinates(uid, coordinates);
+        _physics.WakeBody(uid);
+
+        if (HasComp<VoidedComponent>(uid))
+            RemComp<VoidedComponent>(uid);
+
+
+        RemoveEntity(persistentId);
+
+        return true;
+    }
+
+    /// <summary>
+    /// Turns an id into a path to be consumed by other void functions.
+    /// </summary>
+    private ResPath BuildPath(string persistentId) => new ResPath($"/EntityVoid/{persistentId}");
+
+    /// <summary>
+    /// Removes an entity file from storage, functionally deleting it.
+    /// </summary>
+    public void RemoveEntity(string persistentId)
+    {
+        var path = BuildPath(persistentId);
+
+        if (_resourceManager.UserData.Exists(path))
+            _resourceManager.UserData.Delete(path);
+    }
+}

--- a/Content.Shared/_Persistence14/EntityVoid/VoidedComponent.cs
+++ b/Content.Shared/_Persistence14/EntityVoid/VoidedComponent.cs
@@ -1,0 +1,7 @@
+namespace Content.Shared._Persistence14.EntityVoid;
+
+/// <summary>
+/// A simple component identifying an entity as voided. Used in double-call protection attempts for the <see cref="EntityVoidSystem"/> 
+/// </summary>
+[RegisterComponent]
+public sealed partial class VoidedComponent : Component { }

--- a/Content.Shared/_Persistence14/PersistentIdentifier/PersistentIdentifierComponent.cs
+++ b/Content.Shared/_Persistence14/PersistentIdentifier/PersistentIdentifierComponent.cs
@@ -12,7 +12,7 @@ public sealed partial class PersistentIdentifierComponent : Component
     /// A serialized identifier used to reference the entity this component is attached to between runtimes.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadOnly), AutoNetworkedField]
-    public string Id = Guid.Empty.ToString();
+    public string Id = PersistentIdentifierSystem.EmptyId;
 
     /// <summary>
     /// Shows the current initialization state of the ID and allows for basic manipulation of that ID.<br/><br/>
@@ -20,5 +20,5 @@ public sealed partial class PersistentIdentifierComponent : Component
     /// Returns false when the ID is null.
     /// </summary>
     [ViewVariables(VVAccess.ReadOnly)]
-    public bool IdInit => Id != Guid.Empty.ToString();
+    public bool IdInit => Id != PersistentIdentifierSystem.EmptyId;
 }

--- a/Content.Shared/_Persistence14/PersistentIdentifier/PersistentIdentifierSystem.cs
+++ b/Content.Shared/_Persistence14/PersistentIdentifier/PersistentIdentifierSystem.cs
@@ -1,3 +1,5 @@
+using Content.Shared._Persistence14.PersistentIdentifier.Reference;
+
 namespace Content.Shared._Persistence14.PersistentIdentifier;
 
 public sealed partial class PersistentIdentifierSystem : EntitySystem
@@ -8,7 +10,9 @@ public sealed partial class PersistentIdentifierSystem : EntitySystem
     /// <summary>
     /// The Sawmill key for all ID related log messages.
     /// </summary>
-    public const string Sawmill = "Persistent ID";
+    public const string Sawmill = "persistent-id";
+
+    public static string EmptyId = Guid.Empty.ToString();
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -27,9 +31,11 @@ public sealed partial class PersistentIdentifierSystem : EntitySystem
         return id;
     }
 
-    public string EnsureId(EntityUid uid)
+    public string EnsureId(EntityUid uid) => EnsureId(uid, out _);
+    public string EnsureId(EntityUid uid, out Entity<PersistentIdentifierComponent> ent)
     {
         EnsureComp<PersistentIdentifierComponent>(uid, out var idComp);
+        ent = (uid, idComp);
         return EnsureId((uid, idComp));
     }
 
@@ -45,7 +51,7 @@ public sealed partial class PersistentIdentifierSystem : EntitySystem
             return true;
         }
 
-        id = Guid.Empty.ToString();
+        id = EmptyId;
         return false;
     }
 
@@ -74,7 +80,7 @@ public sealed partial class PersistentIdentifierSystem : EntitySystem
         if (!ent.Comp.IdInit) return;
 
         var oldId = ent.Comp.Id;
-        ent.Comp.Id = Guid.Empty.ToString();
+        ent.Comp.Id = EmptyId;
         Dirty(ent);
 
         var ev = new PersistentIdChangedEvent(ent, oldId, ent.Comp.Id, behaviour);
@@ -85,7 +91,7 @@ public sealed partial class PersistentIdentifierSystem : EntitySystem
     {
         if (id == ent.Comp.Id) return false;
 
-        if (id == Guid.Empty.ToString())
+        if (IsEmptyId(id))
         {
             _log.GetSawmill(Sawmill).Warning("Unable to override ID to empty. Use ClearId instead.");
             return false;
@@ -141,6 +147,13 @@ public sealed partial class PersistentIdentifierSystem : EntitySystem
     }
 
     /// <summary>
+    /// Attempts to resolve a provided <see cref="PersistentEntityReference"/> into an entity.
+    /// </summary>
+    /// <returns>True if the reference sucessfully resolved into an entity, otherwise false.</returns>
+    public bool TryResolveId(PersistentEntityReference reference, out Entity<PersistentIdentifierComponent> ent)
+        => reference.TryResolve(this, out ent, _log.GetSawmill(Sawmill));
+
+    /// <summary>
     /// Fetches an id from all existing <see cref="PersistentIdentifierComponent"/>. Attempts to add valid ids to an existing <see cref="PersistentIdRegisterComponent"/> 
     /// </summary>
     /// <param name="id">The desired id.</param>
@@ -152,12 +165,13 @@ public sealed partial class PersistentIdentifierSystem : EntitySystem
         string id,
         out Entity<PersistentIdentifierComponent> ent,
         Func<Entity<PersistentIdentifierComponent>, bool>? conditional = null,
-        PersistentIdRegisterComponent? registry = null)
+        PersistentIdRegisterComponent? registry = null,
+        bool sendLogs = true)
     {
         ent = default!;
         conditional ??= _ => true;
 
-        _log.GetSawmill(Sawmill).Info($"Attempting to fetch persistent id: {id}");
+        if (sendLogs) _log.GetSawmill(Sawmill).Info($"Attempting to fetch persistent id: {id}");
 
         var lookup = EntityQueryEnumerator<PersistentIdentifierComponent>();
 
@@ -167,12 +181,12 @@ public sealed partial class PersistentIdentifierSystem : EntitySystem
             {
                 ent = (uid, idComp);
                 if (registry is not null) registry.TryRegister(ent, _entMan);
-                _log.GetSawmill(Sawmill).Info($"Entity found: {uid}");
+                if (sendLogs) _log.GetSawmill(Sawmill).Info($"Entity found: {uid}");
                 return true;
             }
         }
 
-        _log.GetSawmill(Sawmill).Warning($"Unable to find entity with matching pid.");
+        if (sendLogs) _log.GetSawmill(Sawmill).Warning($"Unable to find entity with matching pid.");
         return false;
     }
 
@@ -181,12 +195,39 @@ public sealed partial class PersistentIdentifierSystem : EntitySystem
         // Culling will remove the existing reference as the new ID will not match that stored in the key.
         register.CullStaleEntities(_entMan);
 
-        if (args.NewId == Guid.Empty.ToString() || args.NewId == args.OldId || args.Behaviour == PersistentIdChangeBehaviour.Sever)
+        if (IsEmptyId(args.NewId) || args.NewId == args.OldId || args.Behaviour == PersistentIdChangeBehaviour.Sever)
             return; // Nothing more to do.
 
         if (!TryComp<PersistentIdentifierComponent>(args.Uid, out var idComp))
             return; // What would this even mean...?
 
         register.TryRegister((args.Uid, idComp), _entMan);
+    }
+
+    private bool IsEmptyId(string id) => id == EmptyId;
+
+    public bool CompareId(PersistentEntityReference reference, string id)
+        => !IsEmptyId(id) && reference.TargetId == id;
+    public bool CompareId(PersistentEntityReference reference, Entity<PersistentIdentifierComponent> ent)
+        => ent.Comp.IdInit && reference.TargetId == ent.Comp.Id;
+    public bool CompareId(PersistentEntityReference reference, EntityUid uid)
+    {
+        var id = EnsureId(uid);
+        return CompareId(reference, id);
+    }
+
+    public void AssignIdReference(ref PersistentEntityReference reference, string id)
+    {
+        _log.GetSawmill(Sawmill).Info($"Assigning id ({id}) to entity reference.");
+        reference.TargetId = id;
+    }
+    public void AssignIdReference(ref PersistentEntityReference reference, Entity<PersistentIdentifierComponent> ent) {
+        _log.GetSawmill(Sawmill).Info($"Assigning id from {ToPrettyString(ent)}");
+        AssignIdReference(ref reference, ent.Comp.Id);
+    }
+    public void AssignIdReference(ref PersistentEntityReference reference, EntityUid uid)
+    {
+        var id = EnsureId(uid);
+        AssignIdReference(ref reference, id);
     }
 }

--- a/Content.Shared/_Persistence14/PersistentIdentifier/Reference/PersistentEntitityReference.cs
+++ b/Content.Shared/_Persistence14/PersistentIdentifier/Reference/PersistentEntitityReference.cs
@@ -1,0 +1,46 @@
+namespace Content.Shared._Persistence14.PersistentIdentifier.Reference;
+
+[DataDefinition]
+public partial struct PersistentEntityReference
+{
+    [DataField(readOnly: true), ViewVariables(VVAccess.ReadOnly)]
+    public string TargetId = PersistentIdentifierSystem.EmptyId;
+
+    [ViewVariables(VVAccess.ReadOnly)]
+    private Entity<PersistentIdentifierComponent>? _cachedEntity = null;
+
+    public PersistentEntityReference() { }
+
+    /// <summary>
+    /// Attempts to resolve the reference into an entity with a matching ID.
+    /// </summary>
+    /// <returns>True if the reference succesfully resolves into an entity, otherwise false.</returns>
+    public bool TryResolve(PersistentIdentifierSystem pid, out Entity<PersistentIdentifierComponent> entity, ISawmill? sawmill = null)
+    {
+        if (sawmill is { }) sawmill.Info("Attempting to resolve ID reference.");
+        if (_cachedEntity is { } cached && cached.Comp.Id == TargetId)
+        {
+            entity = cached;
+            if (sawmill is { }) sawmill.Info("Cached entity found, returning.");
+            return true;
+        }
+        if (!pid.TryFetchId(TargetId, out entity, sendLogs: true))
+        {
+            return false;
+        }
+        if (entity.Comp.Id != TargetId)
+        {
+            if (sawmill is { }) sawmill.Info($"Fetched ID does not match target id... somehow (Expected:{TargetId}, Actual: {entity.Comp.Id}).");
+            return false;
+        }
+
+        _cachedEntity = entity;
+        if (sawmill is { }) sawmill.Info("Entity cached and valid.");
+        return true;
+    }
+    public void Reset()
+    {
+        TargetId = PersistentIdentifierSystem.EmptyId;
+        _cachedEntity = null;
+    }
+}

--- a/Resources/Locale/en-US/_Persistence14/polymorph.ftl
+++ b/Resources/Locale/en-US/_Persistence14/polymorph.ftl
@@ -1,0 +1,1 @@
+revert-polymorph-verb = revert polymorph


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Oh goodness... a lot actually. First and foremost this PR fixes a major bug with how polymorph works. The existing code will cause saves to fail to load as it relies on shunting an entity to a new empty and paused map. To resolve this, I created what I call the EntityVoidSystem which serializes entities and stores them in files that can be called back at a later date. Files are saved in a safe place and labeled  with an entity's PersistentIdentifier so they are persistent safe.

As a side note (and as was my *original* goal before getting sucked down the polymorph rabbit hole), added a PersistentEntityReference data type to naturally hold onto PIDs in the future. Integrated into the PersistentIdentifierSystem and is the easiest way to modify existing systems to use PIDs.

Finally, since this has a lot to do with polymorphing, added a verb for admins to manually de-polymorph someone if they want to.

### Note
I tested this as best as I could, but I am ultimately one person with one person's worth of time. There should be no game breaking bugs in this.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
1) Bugfixes are important
2) Expanding the capabilities of the PID to make it easier for people to use.

## Technical details
<!-- Summary of code changes for easier review. -->
Theres... there's a lot. Read the diffs or ask me if you have big questions. Comments are there to hopefully help too.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
This may break existing code relying on the inner workings of the polymorph system. It *should* be plug and play and works with existing implementations but the #429 may need some tweaking, not sure.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Being polymorphed will no longer break the save!
