### PR TITLE
Move device linking components from Thruster and Gyroscope to BaseThruster.

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
@@ -57,6 +57,17 @@
     - type: GuideHelp
       guides:
       - ShuttleCraft
+  # Frontier: linkable thrusters, pirate bounties
+    - type: DeviceNetwork
+      deviceNetId: Wireless
+      receiveFrequencyId: BasicDevice
+    - type: WirelessNetworkConnection
+      range: 200
+    - type: DeviceLinkSink
+      ports:
+      - On
+      - Off
+      - Toggle
   placement:
     mode: SnapgridCenter
 
@@ -100,17 +111,6 @@
       shader: unshaded
       visible: false
       offset: 0, 1
-    # Frontier: linkable thrusters, pirate bounties
-  - type: DeviceNetwork
-    deviceNetId: Wireless
-    receiveFrequencyId: BasicDevice
-  - type: WirelessNetworkConnection
-    range: 200
-  - type: DeviceLinkSink
-    ports:
-    - On
-    - Off
-    - Toggle
 
 - type: entity
   parent: Thruster
@@ -402,16 +402,6 @@
     damageModifierSet: Electronic
   - type: StaticPrice
     price: 150
-  - type: DeviceNetwork
-    deviceNetId: Wireless
-    receiveFrequencyId: BasicDevice
-  - type: WirelessNetworkConnection
-    range: 200
-  - type: DeviceLinkSink
-    ports:
-    - On
-    - Off
-    - Toggle
 
 - type: entity
   id: GyroscopeUnanchored


### PR DESCRIPTION
…uster

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Wallmount thrusters, subfloor gyroscopes, xenoborg thrusters, large thrusters, rusted thrusters, and all other forms of non-standard thruster can now be linked

## Why / Balance
Consistency between different types of thruster.

## Technical details
YAML only.