### PR TITLE
Hardhats now print in uniform printers & autolathes

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/hardhats.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardhats.yml
@@ -69,6 +69,7 @@
   - type: PhysicalComposition
     materialComposition:
       Steel: 50
+      Glass: 50
       Plastic: 50
 
 - type: entity
@@ -154,3 +155,54 @@
         Slash: 0.8
         Piercing: 0.9
         Heat: 0.8
+
+# Persi14
+- type: entity
+  parent: ClothingHeadHatHardhatBlue
+  id: ClothingHeadHatHardhatBlueEmpty
+  suffix: Empty
+  components:
+  - type: ItemSlots
+    slots:
+      cell_slot:
+        name: power-cell-slot-component-slot-name-default
+
+- type: entity
+  parent: ClothingHeadHatHardhatOrange
+  id: ClothingHeadHatHardhatOrangeEmpty
+  suffix: Empty
+  components:
+  - type: ItemSlots
+    slots:
+      cell_slot:
+        name: power-cell-slot-component-slot-name-default
+
+- type: entity
+  parent: ClothingHeadHatHardhatRed
+  id: ClothingHeadHatHardhatRedEmpty
+  suffix: Empty
+  components:
+  - type: ItemSlots
+    slots:
+      cell_slot:
+        name: power-cell-slot-component-slot-name-default
+
+- type: entity
+  parent: ClothingHeadHatHardhatWhite
+  id: ClothingHeadHatHardhatWhiteEmpty
+  suffix: Empty
+  components:
+  - type: ItemSlots
+    slots:
+      cell_slot:
+        name: power-cell-slot-component-slot-name-default
+
+- type: entity
+  parent: ClothingHeadHatHardhatYellow
+  id: ClothingHeadHatHardhatYellowEmpty
+  suffix: Empty
+  components:
+  - type: ItemSlots
+    slots:
+      cell_slot:
+        name: power-cell-slot-component-slot-name-default

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -538,12 +538,10 @@
     - Carpets
     - Bedsheets
     - NFWallets # Frontier
-    - CivilianBags
-    - CommandBags
+    - EngineeringHardhatsStatic # Persi14
   - type: EmagLatheRecipes
     emagStaticPacks:
     - ClothingSyndie
-    - ContrabandBags
   - type: MaterialStorage
     whitelist: *StandardMaterialWhitelist
   - type: OreSiloClient

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -539,9 +539,13 @@
     - Bedsheets
     - NFWallets # Frontier
     - EngineeringHardhatsStatic # Persi14
+    - CivilianBags
+    - CommandBags
   - type: EmagLatheRecipes
     emagStaticPacks:
     - ClothingSyndie
+    - ContrabandBags
+    - CentralCommandBags
   - type: MaterialStorage
     whitelist: *StandardMaterialWhitelist
   - type: OreSiloClient

--- a/Resources/Prototypes/Recipes/Lathes/Packs/engineering.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/engineering.yml
@@ -70,6 +70,15 @@
   - TrappedFluidExtractorMachineCircuitboard
   - GridControlComputerCircuitboard
 
+- type: latheRecipePack
+  id: EngineeringHardhatsStatic # Persi14
+  recipes:
+  - ClothingHeadHatHardhatBlueEmpty
+  - ClothingHeadHatHardhatOrangeEmpty
+  - ClothingHeadHatHardhatRedEmpty
+  - ClothingHeadHatHardhatWhiteEmpty
+  - ClothingHeadHatHardhatYellowEmpty
+
 ## Dynamic
 
 - type: latheRecipePack

--- a/Resources/Prototypes/Recipes/Lathes/Packs/engineering.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/engineering.yml
@@ -22,6 +22,7 @@
   - HandheldStationMap
   - ClothingHeadHatWelding
   - ClothingHeadHatCone
+  - ClothingHeadHatHardhatYellowEmpty
   - AccessConfigurator
   - ToolboxMechanical
   - VoiceSensorCopper

--- a/Resources/Prototypes/Recipes/Lathes/clothing.yml
+++ b/Resources/Prototypes/Recipes/Lathes/clothing.yml
@@ -2702,3 +2702,49 @@
   parent: BaseNeckClothingRecipe
   id: ClothingNeckCloakPan 
   result: ClothingNeckCloakPan 
+
+# Persi14 Head
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingHeadHatHardhatBlueEmpty
+  result: ClothingHeadHatHardhatBlueEmpty
+  materials:
+    Steel: 100
+    Glass: 100
+    Plastic: 100 # Same as flashlight
+
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingHeadHatHardhatOrangeEmpty
+  result: ClothingHeadHatHardhatOrangeEmpty
+  materials:
+    Steel: 100
+    Glass: 100
+    Plastic: 100
+
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingHeadHatHardhatRedEmpty
+  result: ClothingHeadHatHardhatRedEmpty
+  materials:
+    Steel: 100
+    Glass: 100
+    Plastic: 100
+
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingHeadHatHardhatWhiteEmpty
+  result: ClothingHeadHatHardhatWhiteEmpty
+  materials:
+    Steel: 100
+    Glass: 100
+    Plastic: 100
+
+- type: latheRecipe
+  parent: BaseHatRecipe
+  id: ClothingHeadHatHardhatYellowEmpty
+  result: ClothingHeadHatHardhatYellowEmpty
+  materials:
+    Steel: 100
+    Glass: 100
+    Plastic: 100


### PR DESCRIPTION
## About the PR
The uniform printer now prints hardhats in 5 colors and the autolathe prints a yellow hardhat for general use. Armorless hardhats cost & recycle the same as a flashlight and don't come with a cell.

There are 7 hardhats in SS14:
Yellow, white, red, orange, dark yellow, blue, and armored. 
<img width="261" height="60" alt="1783456151412" src="https://github.com/user-attachments/assets/460eb289-fa6b-4b0b-b5a0-8438b139cb8d" />

Dark yellow and armored are leftovers from [an unimplemented 2023 WizDen ship vs ship gamemode](https://github.com/space-wizards/space-station-14/pull/17800) and have never been cared for since. The armored hardhat has never been used and the dark yellow hardhat was only placed once probably on accident so I ignored them for now.

It's my first PR so let me know if there's any quirks to iron out. Also let me know & feel free to alter this if e.g: autolathes printing a generic hardhat isn't wanted.

## Media
<img width="240" height="209" alt="Screenshot from 2026-07-08 09-36-23" src="https://github.com/user-attachments/assets/f3cc757d-bfc3-42e9-b81d-80852f1b2d7e" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->