### PR TITLE
Artifact Node Balance Changes

### DIFF
--- a/Content.Shared/Xenoarchaeology/Artifact/Components/XenoArtifactNodeComponent.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/Components/XenoArtifactNodeComponent.cs
@@ -81,19 +81,19 @@ public sealed partial class XenoArtifactNodeComponent : Component
     /// The threshold at which the node has a <see cref="ControlPointShatterProbability"/> chance of shattering on activation.
     /// </summary>
     [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]
-    public int ControlPointShatterDurabilityThreshold = 10;
+    public int ControlPointShatterDurabilityThreshold = 15;
 
     /// <summary>
     /// The probability the node will shatter at <see cref="ControlPointShatterDurabilityThreshold"/> 
     /// </summary>
     [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]
-    public float ControlPointShatterProbability = .2f;
+    public float ControlPointShatterProbability = .1f;
 
     /// <summary>
     /// The threshold at which the node has a 100% chance of shattering on activation.
     /// </summary>
     [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadWrite)]
-    public int MaxShatterDurabilityThreshold = 25;
+    public int MaxShatterDurabilityThreshold = 40;
 
     /// <summary>
     /// Shattered nodes cannot be have their durability increased.

--- a/Resources/Prototypes/XenoArch/effect_tables.yml
+++ b/Resources/Prototypes/XenoArch/effect_tables.yml
@@ -4,7 +4,7 @@
     children:
     - !type:NestedSelector
       tableId: XenoArtifactEffectsRoot
-      weight: 397.0 # Total weights of the table so distribution remains even
+      weight: 403.0 # Total weights of the table so distribution remains even
     # Eventually full size only artifact effects will go here
 
 - type: entityTable
@@ -31,7 +31,7 @@
     children:
     - !type:NestedSelector
       tableId: XenoArtifactEffectsRoot
-      weight: 397.0 # Total weights of the table so distribution remains even
+      weight: 403.0 # Total weights of the table so distribution remains even
     - !type:NestedSelector
       tableId: XenoArtifactEffectsRootHandheldOnly
       weight: 54.0 # Total weights of the table so distribution remains even
@@ -75,9 +75,9 @@
     - id: XenoArtifactOldCashSpawn
       weight: 8.0
     - id: XenoArtifactChargeBatteryLow
-      weight: 3.0
+      weight: 8.0
     - id: XenoArtifactChargeBattery
-      weight: 0.0 # Here for parity
+      weight: 1.0
     - id: XenoArtifactChemicalPuddle
       weight: 10.0
     - id: XenoArtifactColdWave

--- a/Resources/Prototypes/XenoArch/effects.yml
+++ b/Resources/Prototypes/XenoArch/effects.yml
@@ -681,7 +681,7 @@
   description: Partially charges nearby batteries
   components:
   - type: XAEChargeBattery
-    chargePercent: 20.0
+    chargePercent: 30.0
   - type: XAETelepathic
     messages:
     - charge-artifact-popup


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Increased occurrence rate of charge effects in root nodes, and flattened the curve for 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Charge nodes were far too rare leading to frankly far too much time spent chasing them. Additionally, multiple people have stated it feels like artifacts shatter too quickly and I tend to agree. You only get a couple uses currently before shattering which doesn't feel great.

## Technical details
<!-- Summary of code changes for easier review. -->
* Increased root node weight for XenoArtifactChargeBatteryLow from 3.0 -> 8.0
* Increased root node weight for XenoArtifactChargeBattery from 0.0 -> 1.0
* Increased chargePercent for XenoArtifactChargeBatteryLow from 20.0 -> 30.0

* Increased ControlPointShatterDurabilityThreshold from 10 -> 15
* Decreased ControlPointShatterProbability from .2 -> .1
* Increased MaxShatterDurabilityThreshold from 25 -> 40

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
No known breaking changes

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Artifact nodes now need more activations to shatter
- tweak: Charging artifact nodes are slightly more common