### PR TITLE
Borg Hand Duplication Bugfix (Take 2)

### DIFF
--- a/Content.Shared/Silicons/Borgs/SharedBorgSystem.Module.cs
+++ b/Content.Shared/Silicons/Borgs/SharedBorgSystem.Module.cs
@@ -176,7 +176,7 @@ public abstract partial class SharedBorgSystem
         for (var i = 0; i < module.Comp.Hands.Count; i++)
         {
             var hand = module.Comp.Hands[i];
-            var handId = $"{GetNetEntity(module.Owner)}-hand-{i}";
+            var handId = GetHandId(module, i);
 
             _hands.AddHand((chassis.Owner, hands), handId, hand.Hand);
             EntityUid? item = null;
@@ -224,7 +224,7 @@ public abstract partial class SharedBorgSystem
 
         for (var i = 0; i < module.Comp.Hands.Count; i++)
         {
-            var handId = $"{GetNetEntity(module.Owner)}-hand-{i}";
+            var handId = GetHandId(module.Owner, i);
 
             if (_hands.TryGetHeldItem((chassis.Owner, hands), handId, out var held))
             {
@@ -242,6 +242,8 @@ public abstract partial class SharedBorgSystem
 
         Dirty(module);
     }
+
+    private string GetHandId(EntityUid uid, int handIndex) => $"{_pid.EnsureId(uid)}-hand-{handIndex}";
     #endregion
 
     #region ComponentBorgModule

--- a/Content.Shared/Silicons/Borgs/SharedBorgSystem.cs
+++ b/Content.Shared/Silicons/Borgs/SharedBorgSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._Persistence14.PersistentIdentifier;
 using Content.Shared.Access.Systems;
 using Content.Shared.Actions;
 using Content.Shared.Administration.Logs;
@@ -63,6 +64,7 @@ public abstract partial class SharedBorgSystem : EntitySystem
     [Dependency] private readonly SharedHandheldLightSystem _handheldLight = default!;
     [Dependency] private readonly SharedAccessSystem _access = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private PersistentIdentifierSystem _pid = default!;
 
     /// <inheritdoc/>
     public override void Initialize()


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes the borg hand duplication glitch (again?)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bugfix to help make borgs viable.

## Technical details
<!-- Summary of code changes for easier review. -->
Changes SharedBorgSystem.Module to use EnsureId(uid) instead of GetNetEntity(uid) when generating the hand ID.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Existing borgs in save will still have the old hand names.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: No more borg hand duplication
