### PR TITLE
Cryogenics Omnizine

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -848,15 +848,21 @@
   physicalDesc: reagent-physical-desc-soothing
   flavor: medicine
   color: "#fcf7f9"
+  worksOnTheDead: true
   metabolisms:
     Bloodstream:
       effects:
       - !type:EvenHealthChange
+        conditions:
+        - !type:TemperatureCondition
+        #Minimum added so it can't work in space atmos
+          min: 50.0 
+          max: 180.0
         damage:
-          Burn: -0.2
-          Toxin: -0.2
-          Airloss: -0.2
-          Brute: -0.2
+          Burn: -2
+          Toxin: -2
+          Airloss: -2
+          Brute: -2
 
 - type: reagent
   id: Ultravasculine


### PR DESCRIPTION
I set the omni heal levels back to base levels. I added a min and max so space is too cold for it but also the max temp needed is lower that other cryo chems, all that does is make it take longer for a body to cool down before it is usable.

I wanted Omni to still be in the server and usable. This will also double as a cryo chem that heals poison and rads from dead people.