### PR TITLE
Node Scanner Bugfix

### DIFF
--- a/Content.Client/Xenoarchaeology/Ui/NodeScannerBoundUserInterface.cs
+++ b/Content.Client/Xenoarchaeology/Ui/NodeScannerBoundUserInterface.cs
@@ -1,3 +1,4 @@
+using Content.Shared._Persistence14.PersistentIdentifier;
 using Robust.Client.UserInterface;
 
 namespace Content.Client.Xenoarchaeology.Ui;

--- a/Content.Client/Xenoarchaeology/Ui/NodeScannerDisplay.xaml.cs
+++ b/Content.Client/Xenoarchaeology/Ui/NodeScannerDisplay.xaml.cs
@@ -1,4 +1,5 @@
 using Content.Client.UserInterface.Controls;
+using Content.Shared._Persistence14.PersistentIdentifier;
 using Content.Shared.NameIdentifier;
 using Content.Shared.Xenoarchaeology.Artifact;
 using Content.Shared.Xenoarchaeology.Artifact.Components;
@@ -21,6 +22,7 @@ public sealed partial class NodeScannerDisplay : FancyWindow
     private EntityUid _owner;
     private TimeSpan _updateFromAttachedFrequency;
     private readonly HashSet<string> _triggeredNodeNames = new();
+    private PersistentIdentifierSystem _pid;
 
     public NodeScannerDisplay()
     {
@@ -29,6 +31,7 @@ public sealed partial class NodeScannerDisplay : FancyWindow
         IoCManager.InjectDependencies(this);
 
         _artifact = _ent.System<SharedXenoArtifactSystem>();
+        _pid = _ent.System<PersistentIdentifierSystem>();
     }
 
     /// <summary>
@@ -63,7 +66,8 @@ public sealed partial class NodeScannerDisplay : FancyWindow
             return;
         }
 
-        var attachedArtifactEnt = connectedScanner.AttachedTo;
+        if (!_pid.TryResolveId(connectedScanner.AttachedTo, out var attachedArtifactEnt))
+            return;
         if (!_ent.TryGetComponent(attachedArtifactEnt, out XenoArtifactComponent? artifactComponent))
             return;
 

--- a/Content.Shared/Xenoarchaeology/Equipment/Components/NodeScannerComponent.cs
+++ b/Content.Shared/Xenoarchaeology/Equipment/Components/NodeScannerComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared._Persistence14.PersistentIdentifier.Reference;
 using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
@@ -35,7 +36,7 @@ public sealed partial class NodeScannerConnectedComponent : Component
     /// Upon detaching this component should be removed.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public EntityUid AttachedTo;
+    public PersistentEntityReference AttachedTo;
 
     /// <summary>
     /// Next update tick gametime.

--- a/Content.Shared/Xenoarchaeology/Equipment/NodeScannerSystem.cs
+++ b/Content.Shared/Xenoarchaeology/Equipment/NodeScannerSystem.cs
@@ -36,7 +36,10 @@ public sealed class NodeScannerSystem : EntitySystem
             connected.NextUpdate = _timing.CurTime + connected.LinkUpdateInterval;
 
             if (!_pid.TryResolveId(connected.AttachedTo, out var attachedArtifact))
+            {
                 RemCompDeferred(uid, connected); // Scanner not connected to valid entity
+                continue;
+            }
 
             var artifactCoordinates = Transform(attachedArtifact).Coordinates;
             if (!_transform.InRange(artifactCoordinates, transform.Coordinates, scanner.MaxLinkedRange))

--- a/Content.Shared/Xenoarchaeology/Equipment/NodeScannerSystem.cs
+++ b/Content.Shared/Xenoarchaeology/Equipment/NodeScannerSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._Persistence14.PersistentIdentifier;
 using Content.Shared.Interaction;
 using Content.Shared.Timing;
 using Content.Shared.Verbs;
@@ -14,6 +15,7 @@ public sealed class NodeScannerSystem : EntitySystem
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly SharedUserInterfaceSystem _ui = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private PersistentIdentifierSystem _pid = default!;
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -33,7 +35,9 @@ public sealed class NodeScannerSystem : EntitySystem
 
             connected.NextUpdate = _timing.CurTime + connected.LinkUpdateInterval;
 
-            var attachedArtifact = connected.AttachedTo;
+            if (!_pid.TryResolveId(connected.AttachedTo, out var attachedArtifact))
+                RemCompDeferred(uid, connected); // Scanner not connected to valid entity
+
             var artifactCoordinates = Transform(attachedArtifact).Coordinates;
             if (!_transform.InRange(artifactCoordinates, transform.Coordinates, scanner.MaxLinkedRange))
             {
@@ -89,9 +93,9 @@ public sealed class NodeScannerSystem : EntitySystem
 
         var connected = EnsureComp<NodeScannerConnectedComponent>(device);
         EntityUid artifact = unlockingEnt;
-        if (connected.AttachedTo != artifact)
+        if (!_pid.TryResolveId(connected.AttachedTo, out var connectedArtifact) || connectedArtifact.Owner != artifact)
         {
-            connected.AttachedTo = artifact;
+            _pid.AssignIdReference(ref connected.AttachedTo, artifact);
             Dirty(device, connected);
         }
 

--- a/Content.Shared/_Persistence14/PersistentIdentifier/PersistentIdRegisteryComponent.cs
+++ b/Content.Shared/_Persistence14/PersistentIdentifier/PersistentIdRegisteryComponent.cs
@@ -11,6 +11,9 @@ public sealed partial class PersistentIdRegisterComponent : Component
     [ViewVariables(VVAccess.ReadOnly)]
     private Dictionary<string, Entity<PersistentIdentifierComponent>> _registeredEntities = new();
 
+    [DataField]
+    public bool Global = false;
+
     /// <summary>
     /// Verifies the existance of a valid entity within the register matching a provided key.
     /// </summary>

--- a/Content.Shared/_Persistence14/PersistentIdentifier/PersistentIdentifierSystem.cs
+++ b/Content.Shared/_Persistence14/PersistentIdentifier/PersistentIdentifierSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared._Persistence14.PersistentIdentifier.Reference;
+using Robust.Shared.Map;
 
 namespace Content.Shared._Persistence14.PersistentIdentifier;
 
@@ -6,6 +7,9 @@ public sealed partial class PersistentIdentifierSystem : EntitySystem
 {
     [Dependency] private IEntityManager _entMan = default!;
     [Dependency] private ILogManager _log = default!;
+    [Dependency] private IComponentFactory _factory = default!;
+
+    private Entity<PersistentIdRegisterComponent>? _globalRegister;
 
     /// <summary>
     /// The Sawmill key for all ID related log messages.
@@ -121,25 +125,17 @@ public sealed partial class PersistentIdentifierSystem : EntitySystem
         string id,
         out Entity<PersistentIdentifierComponent> ent,
         Func<Entity<PersistentIdentifierComponent>, bool>? conditional = null,
-        bool useFetchIfFalse = true, bool ensureRegistry = true)
+        bool useFetchIfFalse = true)
     {
         ent = default!;
         conditional ??= _ => true;
 
-        PersistentIdRegisterComponent? registry;
-        if (ensureRegistry)
-        {
-            EnsureComp<PersistentIdRegisterComponent>(sourceUid, out registry);
-            if (registry.TryGet(id, out ent, _entMan) && conditional(ent))
-                return true;
-        }
-        else if (
-            TryComp<PersistentIdRegisterComponent>(sourceUid, out registry) &&
-            registry.TryGet(id, out ent, _entMan) &&
-            conditional(ent))
-        {
+
+        if (TryComp<PersistentIdRegisterComponent>(sourceUid, out var registry) && registry.TryGet(id, out ent, _entMan) && conditional(ent))
             return true;
-        }
+
+        else if (EnsureGlobalRegister().Comp.TryGet(id, out ent, _entMan) && conditional(ent))
+            return true;
 
         if (useFetchIfFalse)
             return TryFetchId(id, out ent, conditional, registry);
@@ -150,8 +146,22 @@ public sealed partial class PersistentIdentifierSystem : EntitySystem
     /// Attempts to resolve a provided <see cref="PersistentEntityReference"/> into an entity.
     /// </summary>
     /// <returns>True if the reference sucessfully resolved into an entity, otherwise false.</returns>
-    public bool TryResolveId(PersistentEntityReference reference, out Entity<PersistentIdentifierComponent> ent)
-        => reference.TryResolve(this, out ent, _log.GetSawmill(Sawmill));
+    public bool TryResolveId(
+        PersistentEntityReference reference,
+        out Entity<PersistentIdentifierComponent> ent,
+        Func<Entity<PersistentIdentifierComponent>, bool>? conditional = null,
+        bool useFetchIfFalse = true)
+    {
+        ent = default!;
+        conditional ??= _ => true;
+        var register = EnsureGlobalRegister();
+        if (register.Comp.TryGet(reference.TargetId, out ent, _entMan) && conditional(ent))
+            return true;
+
+        if (useFetchIfFalse)
+            return TryFetchId(reference.TargetId, out ent, conditional, register);
+        return false;
+    }
 
     /// <summary>
     /// Fetches an id from all existing <see cref="PersistentIdentifierComponent"/>. Attempts to add valid ids to an existing <see cref="PersistentIdRegisterComponent"/> 
@@ -161,7 +171,7 @@ public sealed partial class PersistentIdentifierSystem : EntitySystem
     /// <param name="conditional">A conditional function applied to the search.</param>
     /// <param name="registry">An optional registry to register valid ids to when found. Improves speed of future searches.</param>
     /// <returns></returns>
-    public bool TryFetchId(
+    private bool TryFetchId(
         string id,
         out Entity<PersistentIdentifierComponent> ent,
         Func<Entity<PersistentIdentifierComponent>, bool>? conditional = null,
@@ -218,16 +228,41 @@ public sealed partial class PersistentIdentifierSystem : EntitySystem
 
     public void AssignIdReference(ref PersistentEntityReference reference, string id)
     {
-        _log.GetSawmill(Sawmill).Info($"Assigning id ({id}) to entity reference.");
-        reference.TargetId = id;
+        reference = id;
     }
-    public void AssignIdReference(ref PersistentEntityReference reference, Entity<PersistentIdentifierComponent> ent) {
-        _log.GetSawmill(Sawmill).Info($"Assigning id from {ToPrettyString(ent)}");
+    public void AssignIdReference(ref PersistentEntityReference reference, Entity<PersistentIdentifierComponent> ent)
+    {
         AssignIdReference(ref reference, ent.Comp.Id);
     }
     public void AssignIdReference(ref PersistentEntityReference reference, EntityUid uid)
     {
         var id = EnsureId(uid);
         AssignIdReference(ref reference, id);
+    }
+
+    private Entity<PersistentIdRegisterComponent> EnsureGlobalRegister()
+    {
+        if (_globalRegister is { } register)
+        {
+            register.Comp.Global = true;
+            return register;
+        }
+
+        var registerQuery = EntityQueryEnumerator<PersistentIdRegisterComponent>();
+
+        while (registerQuery.MoveNext(out var uid, out var registerComp))
+        {
+            if (!registerComp.Global) continue;
+
+            _globalRegister = (uid, registerComp);
+            return _globalRegister.Value;
+        }
+
+        _log.GetSawmill(Sawmill).Info($"Constructing new Global Register");
+        var newUid = Spawn(null, MapCoordinates.Nullspace);
+        EnsureComp<PersistentIdRegisterComponent>(newUid, out var newComp);
+        newComp.Global = true;
+        _globalRegister = (newUid, newComp);
+        return _globalRegister.Value;
     }
 }

--- a/Content.Shared/_Persistence14/PersistentIdentifier/Reference/PersistentEntitityReference.cs
+++ b/Content.Shared/_Persistence14/PersistentIdentifier/Reference/PersistentEntitityReference.cs
@@ -1,46 +1,23 @@
+using Robust.Shared.Serialization;
+
 namespace Content.Shared._Persistence14.PersistentIdentifier.Reference;
 
-[DataDefinition]
-public partial struct PersistentEntityReference
+[DataDefinition, NetSerializable, Serializable]
+public partial record struct PersistentEntityReference
 {
-    [DataField(readOnly: true), ViewVariables(VVAccess.ReadOnly)]
-    public string TargetId = PersistentIdentifierSystem.EmptyId;
+    [DataField("targetId", readOnly: true)] private string? _targetId;
+    public string TargetId => _targetId ?? PersistentIdentifierSystem.EmptyId;
 
-    [ViewVariables(VVAccess.ReadOnly)]
-    private Entity<PersistentIdentifierComponent>? _cachedEntity = null;
-
-    public PersistentEntityReference() { }
-
-    /// <summary>
-    /// Attempts to resolve the reference into an entity with a matching ID.
-    /// </summary>
-    /// <returns>True if the reference succesfully resolves into an entity, otherwise false.</returns>
-    public bool TryResolve(PersistentIdentifierSystem pid, out Entity<PersistentIdentifierComponent> entity, ISawmill? sawmill = null)
+    public PersistentEntityReference()
     {
-        if (sawmill is { }) sawmill.Info("Attempting to resolve ID reference.");
-        if (_cachedEntity is { } cached && cached.Comp.Id == TargetId)
-        {
-            entity = cached;
-            if (sawmill is { }) sawmill.Info("Cached entity found, returning.");
-            return true;
-        }
-        if (!pid.TryFetchId(TargetId, out entity, sendLogs: true))
-        {
-            return false;
-        }
-        if (entity.Comp.Id != TargetId)
-        {
-            if (sawmill is { }) sawmill.Info($"Fetched ID does not match target id... somehow (Expected:{TargetId}, Actual: {entity.Comp.Id}).");
-            return false;
-        }
+        _targetId = null;
+    }
 
-        _cachedEntity = entity;
-        if (sawmill is { }) sawmill.Info("Entity cached and valid.");
-        return true;
-    }
-    public void Reset()
+    public PersistentEntityReference(string targetId)
     {
-        TargetId = PersistentIdentifierSystem.EmptyId;
-        _cachedEntity = null;
+        _targetId = targetId;
     }
-}
+
+    public static implicit operator PersistentEntityReference(string targetId) => new(targetId);
+    public static implicit operator string(PersistentEntityReference reference) => reference.TargetId;
+};

--- a/Content.Shared/_Persistence14/PersistentIdentifier/Reference/PersistentEntityReferenceSerializer.cs
+++ b/Content.Shared/_Persistence14/PersistentIdentifier/Reference/PersistentEntityReferenceSerializer.cs
@@ -1,0 +1,27 @@
+using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.Manager;
+using Robust.Shared.Serialization.Markdown.Validation;
+using Robust.Shared.Serialization.Markdown.Value;
+using Robust.Shared.Serialization.TypeSerializers.Interfaces;
+
+namespace Content.Shared._Persistence14.PersistentIdentifier.Reference;
+
+[TypeSerializer]
+public sealed class RandomTableValueSerializer : ITypeReader<PersistentEntityReference, ValueDataNode>
+{
+    public PersistentEntityReference Read(
+        ISerializationManager serializationManager,
+        ValueDataNode node,
+        IDependencyCollection dependencies,
+        SerializationHookContext hookCtx,
+        ISerializationContext? context = null,
+        ISerializationManager.InstantiationDelegate<PersistentEntityReference>? instanceProvider = null)
+    {
+        return node.Value;
+    }
+
+    public ValidationNode Validate(ISerializationManager serializationManager, ValueDataNode node, IDependencyCollection dependencies, ISerializationContext? context = null)
+    {
+        return new ValidatedValueNode(node);
+    }
+}

--- a/Content.Shared/_Persistence14/RandomTable/RandomTableSerializer.cs
+++ b/Content.Shared/_Persistence14/RandomTable/RandomTableSerializer.cs
@@ -14,7 +14,13 @@ namespace Content.Shared._Persistence14.RandomTable;
 public sealed class RandomTableTypeSerializer :
     ITypeReader<RandomTableSelector, MappingDataNode>
 {
-    public RandomTableSelector Read(ISerializationManager serializationManager, MappingDataNode node, IDependencyCollection dependencies, SerializationHookContext hookCtx, ISerializationContext? context = null, ISerializationManager.InstantiationDelegate<RandomTableSelector>? instanceProvider = null)
+    public RandomTableSelector Read(
+        ISerializationManager serializationManager, 
+        MappingDataNode node, 
+        IDependencyCollection dependencies, 
+        SerializationHookContext hookCtx, 
+        ISerializationContext? context = null, 
+        ISerializationManager.InstantiationDelegate<RandomTableSelector>? instanceProvider = null)
     {
         if (node.Has("value")) return ReadAsValue(serializationManager, node, dependencies, hookCtx, context, instanceProvider);
         if (node.Has("prototype")) return ReadAsPrototype(serializationManager, node, dependencies, hookCtx, context, instanceProvider);
@@ -100,7 +106,13 @@ public sealed class RandomTableTypeSerializer :
 [TypeSerializer]
 public sealed class RandomTableValueSerializer : ITypeReader<RandomTableSelector, ValueDataNode>
 {
-    public RandomTableSelector Read(ISerializationManager serializationManager, ValueDataNode node, IDependencyCollection dependencies, SerializationHookContext hookCtx, ISerializationContext? context = null, ISerializationManager.InstantiationDelegate<RandomTableSelector>? instanceProvider = null)
+    public RandomTableSelector Read(
+        ISerializationManager serializationManager, 
+        ValueDataNode node, 
+        IDependencyCollection dependencies, 
+        SerializationHookContext hookCtx, 
+        ISerializationContext? context = null, 
+        ISerializationManager.InstantiationDelegate<RandomTableSelector>? instanceProvider = null)
     {
         if (int.TryParse(node.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var intValue))
             return (RandomTableIntValueDefinition)intValue;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Modifies PersitentEntityReference to be a record struct and all functionality moved to the PID system. Fixed bug in Node Scanner causing errors and possible crashing. Added global register for easier resolution of PIDs moving forward.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Bug fixing and expanding functionality for the PID system.

## Technical details
<!-- Summary of code changes for easier review. -->
See diffs for specifics. Mostly small changes.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
All existing links to Node Scanners and Artifacts will break. Not a huge loss.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Node scanners no longer call out in pain in the console.