### PR TITLE
mech labels

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Mech/mechs.yml
@@ -61,6 +61,7 @@
     tags:
     - DoorBumpOpener
     - FootstepSound
+    - BaseMech
   - type: Pullable
   - type: Physics
     bodyType: KinematicController

--- a/Resources/Prototypes/Entities/Objects/Tools/hand_labeler.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/hand_labeler.yml
@@ -29,6 +29,7 @@
           - AirAlarm
           - Structure
           - AirSensor
+          - BaseMech
     - type: PhysicalComposition
       materialComposition:
         Plastic: 50

--- a/Resources/Prototypes/_Persistence14/tags.yml
+++ b/Resources/Prototypes/_Persistence14/tags.yml
@@ -1,0 +1,57 @@
+# THIS IS FOR PERSISTENCE ONLY TAGS
+# PUT YOUR TAGS IN ALPHABETICAL ORDER
+# ALSO DOCUMENT WHAT THE HELL THEY DO
+
+## A ##
+
+## B ##
+- type: Tag
+  id: BaseMech # Identifies all mechs.
+
+## C ##
+
+## D ##
+
+## E ##
+
+## F ##
+
+## G ##
+
+## H ##
+
+## I ##
+
+## J ##
+
+## K ##
+
+## L ##
+
+## M ##
+
+## N ##
+
+## O ##
+
+## P ##
+
+## Q ##
+
+## R ##
+
+## S ##
+
+## T ##
+
+## U ##
+
+## V ##
+
+## W ##
+
+## X ##
+
+## Y ##
+
+## Z ##


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds a BaseMech tag to the base mech prototype and added BaseMech to the hand labeler whitelist, making all mechs able to have a label. If there's a better way of doing this, please let me know.


## Media
<img width="434" height="243" alt="Screenshot_09072026_152628" src="https://github.com/user-attachments/assets/084d4ac7-2b28-4bfe-83a6-a9f5ba4fc206" />

**Changelog**
added BaseMech tag to mechs.yml
added BaseMech to hand labeler whitelist
