### PR TITLE
Bugfix: Bag Closing After Polymorph

### DIFF
--- a/Content.Client/UserInterface/Systems/CloseWindow/CloseAllWindowsUIController.cs
+++ b/Content.Client/UserInterface/Systems/CloseWindow/CloseAllWindowsUIController.cs
@@ -1,5 +1,6 @@
 using Content.Client.Gameplay;
 using Content.Client.Info;
+using Content.Shared._Persistence14.UserInterface;
 using Robust.Client.Input;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controllers;
@@ -18,6 +19,8 @@ public sealed class CloseAllWindowsUIController : UIController
     {
         _inputManager.SetInputCommand(EngineKeyFunctions.WindowCloseAll,
             InputCmdHandler.FromDelegate(session => CloseAllWindows()));
+
+        SubscribeNetworkEvent<CloseAllWindowsEvent>((_, __) => CloseAllWindows());
     }
 
     private void CloseAllWindows()

--- a/Content.Server/Polymorph/Systems/PolymorphSystem.cs
+++ b/Content.Server/Polymorph/Systems/PolymorphSystem.cs
@@ -32,6 +32,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using Content.Shared._Persistence14.EntityVoid;
+using Content.Shared._Persistence14.UserInterface;
 
 namespace Content.Server.Polymorph.Systems;
 
@@ -250,6 +251,14 @@ public sealed partial class PolymorphSystem : EntitySystem
             polymorphableComponent.LastPolymorphEnd != null &&
             _gameTiming.CurTime < polymorphableComponent.LastPolymorphEnd + configuration.Cooldown)
             return null;
+
+
+        // Close player client windows
+        if (TryComp<ActorComponent>(uid, out var actor))
+        {
+            RaiseNetworkEvent(new CloseAllWindowsEvent(), actor.PlayerSession);
+            if (RemComp<UserInterfaceUserComponent>(uid)) { }
+        }
 
         var pid = _pid.EnsureId(uid, out var pidEntity);
 

--- a/Content.Shared/_Persistence14/UserInterface/UIEvents.cs
+++ b/Content.Shared/_Persistence14/UserInterface/UIEvents.cs
@@ -1,0 +1,6 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._Persistence14.UserInterface;
+
+[Serializable, NetSerializable]
+public sealed class CloseAllWindowsEvent : EntityEventArgs;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes a bug where the UserInterfaceUserComponent would throw a hissy fit after restoring a polymorphed entity and close peoples open bags constantly.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Its a bugfix.

## Technical details
<!-- Summary of code changes for easier review. -->
* PolymorphSystem now closes an entities bags before polymorphing them. This isn't an *ideal* fix but it is the best I can manage without a modification to the toolbox.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
No known breaking changes.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Bug where bags would constantly close after polymorphing with them open.
