### PR TITLE
feat: Faction Tag System

### DIFF
--- a/Content.Client/CrewAssignments/BUI/StationModificationConsoleBoundUserInterface.cs
+++ b/Content.Client/CrewAssignments/BUI/StationModificationConsoleBoundUserInterface.cs
@@ -61,6 +61,7 @@ public sealed class StationModificationConsoleBoundUserInterface : BoundUserInte
         _menu.OnOwnerPressed += RemoveOwner;
         _menu.NewOwnerConfirm.OnPressed += AddOwner;
         _menu.StationNameConfirm.OnPressed += ChangeStationName;
+        _menu.FactionTagConfirm.OnPressed += ChangeFactionTag;
         _menu.AccessCreateConfirm.OnPressed += CreateNewAccess;
         _menu.AccessDeleteConfirm.OnPressed += DeleteAccess;
         _menu.CreateAssignment.OnPressed += CreateAssignment;
@@ -101,7 +102,7 @@ public sealed class StationModificationConsoleBoundUserInterface : BoundUserInte
         Accesses = cState.CrewAccess;
         Assignments = cState.CrewAssignments;
         _menu?.UpdateOwners(owners);
-        _menu?.UpdateStation(station, cState.Name);
+        _menu?.UpdateStation(station, cState.Name, cState.FactionTag);
         _menu?.UpdateAccesses(Accesses);
         _menu?.UpdateAssignments(Assignments);
         _menu?.UpdateUpgrades(cState.Level, cState.AccountBalance);
@@ -179,6 +180,14 @@ public sealed class StationModificationConsoleBoundUserInterface : BoundUserInte
         string newName = _menu.StationNameField.Text;
         if (newName == null || newName == "") return;
         SendMessage(new StationModificationChangeName(newName));
+    }
+
+    private void ChangeFactionTag(ButtonEventArgs args)
+    {
+        if (_menu == null)
+            return;
+
+        SendMessage(new StationModificationChangeFactionTag(_menu.FactionTagField.Text));
     }
 
     private void CreateNewAccess(ButtonEventArgs args)

--- a/Content.Client/CrewAssignments/UI/StationModificationMenu.xaml
+++ b/Content.Client/CrewAssignments/UI/StationModificationMenu.xaml
@@ -26,6 +26,19 @@
                     Access="Public"
                     Text="Save"/>
                 </BoxContainer>
+                                <Control MinHeight="10"/>
+                                <BoxContainer Orientation="Horizontal">
+                                        <Label Text="Faction Tag:"
+                                            StyleClasses="LabelKeyText" />
+                                        <Control MinWidth="20"/>
+                                        <LineEdit Name="FactionTagField"
+                                        Access="Public"
+                                        MinWidth="48"
+                                        HorizontalExpand="False" />
+                                        <Button Name="FactionTagConfirm"
+                                        Access="Public"
+                                        Text="Save"/>
+                                </BoxContainer>
                 <Control MinHeight="15"/>
                 <BoxContainer Orientation="Horizontal" MinHeight="80">
                     <Label Text="Current Faction Owners:"

--- a/Content.Client/CrewAssignments/UI/StationModificationMenu.xaml.cs
+++ b/Content.Client/CrewAssignments/UI/StationModificationMenu.xaml.cs
@@ -41,6 +41,7 @@ namespace Content.Client.CrewAssignments.UI
         public event Action<ButtonEventArgs>? OnOwnerPressed;
         public event Action<ButtonToggledEventArgs>? OnAssignmentAccessPressed;
         public event Action<ButtonToggledEventArgs>? OnChannelAccessPressed;
+
         public StationModificationMenu(EntityUid owner, IEntityManager entMan, IPrototypeManager protoManager, SpriteSystem spriteSystem)
         {
             RobustXamlLoader.Load(this);
@@ -58,6 +59,14 @@ namespace Content.Client.CrewAssignments.UI
             PossibleAccesses.OnItemSelected += OnDelAccessSelected;
             PossibleAssignments.OnItemSelected += OnAssignmentSelected;
             PossibleChannels.OnItemSelected += OnChannelSelected;
+            FactionTagField.OnTextChanged += _ =>
+            {
+                if (FactionTagField.Text.Length <= 4)
+                    return;
+
+                FactionTagField.Text = FactionTagField.Text[..4];
+                FactionTagField.CursorPosition = FactionTagField.Text.Length;
+            };
 
         }
         private void OnChannelSelected(OptionButton.ItemSelectedEventArgs args)
@@ -79,12 +88,13 @@ namespace Content.Client.CrewAssignments.UI
             UpdateAssignment();
 
         }
-        public void UpdateStation(EntityUid station, string name)
+        public void UpdateStation(EntityUid station, string name, string factionTag)
         {
 
             _station = station;
             StationNameLabel.Text = name;
             StationNameField.Text = name;
+            FactionTagField.Text = factionTag;
         }
         public void UpdateOwners(List<string> owners)
         {

--- a/Content.Client/Shuttles/BUI/IFFConsoleBoundUserInterface.cs
+++ b/Content.Client/Shuttles/BUI/IFFConsoleBoundUserInterface.cs
@@ -24,6 +24,7 @@ public sealed class IFFConsoleBoundUserInterface : BoundUserInterface
         _window = this.CreateWindowCenteredLeft<IFFConsoleWindow>();
         _window.ShowIFF += SendIFFMessage;
         _window.ShowVessel += SendVesselMessage;
+        _window.ShowFactionTag += SendFactionTagMessage;
         _window.OnSetColor += SendColorMessage;
         _window.SetDesignation += SendDesignationMessage;
     }
@@ -49,6 +50,14 @@ public sealed class IFFConsoleBoundUserInterface : BoundUserInterface
     private void SendVesselMessage(bool obj)
     {
         SendMessage(new IFFShowVesselMessage()
+        {
+            Show = obj,
+        });
+    }
+
+    private void SendFactionTagMessage(bool obj)
+    {
+        SendMessage(new IFFShowFactionTagMessage()
         {
             Show = obj,
         });

--- a/Content.Client/Shuttles/UI/IFFConsoleWindow.xaml
+++ b/Content.Client/Shuttles/UI/IFFConsoleWindow.xaml
@@ -16,6 +16,12 @@
                 <Button Name="ShowVesselOffButton" Text="{Loc 'iff-console-off'}" StyleClasses="OpenLeft" />
             </BoxContainer>
 
+            <Label Name="ShowFactionTagLabel" Text="{Loc 'iff-console-show-faction-tag-label'}" HorizontalExpand="True" StyleClasses="highlight" />
+            <BoxContainer Orientation="Horizontal" MinWidth="120">
+                <Button Name="ShowFactionTagOnButton" Text="{Loc 'iff-console-on'}" StyleClasses="OpenRight" />
+                <Button Name="ShowFactionTagOffButton" Text="{Loc 'iff-console-off'}" StyleClasses="OpenLeft" />
+            </BoxContainer>
+
             <Label Text="{Loc 'iff-console-designation-label'}" HorizontalExpand="True" StyleClasses="highlight" />
             <OptionButton Name="DesignationOptionButton" MinWidth="120" />
 

--- a/Content.Client/Shuttles/UI/IFFConsoleWindow.xaml.cs
+++ b/Content.Client/Shuttles/UI/IFFConsoleWindow.xaml.cs
@@ -18,6 +18,7 @@ public sealed partial class IFFConsoleWindow : FancyWindow,
     private const int SignatureHexLength = 6;
     private readonly ButtonGroup _showIFFButtonGroup = new();
     private readonly ButtonGroup _showVesselButtonGroup = new();
+    private readonly ButtonGroup _showFactionTagButtonGroup = new();
     private readonly StyleBoxFlat _swatchStyleBox = new();
     private bool _canEditColor;
     private bool _canEditDesignation;
@@ -26,6 +27,7 @@ public sealed partial class IFFConsoleWindow : FancyWindow,
     private bool _updatingColorControls;
     public event Action<bool>? ShowIFF;
     public event Action<bool>? ShowVessel;
+    public event Action<bool>? ShowFactionTag;
     public event Action<string>? OnSetColor;
     public event Action<IFFDesignation>? SetDesignation;
 
@@ -43,6 +45,11 @@ public sealed partial class IFFConsoleWindow : FancyWindow,
         ShowVesselOnButton.Group = _showVesselButtonGroup;
         ShowVesselOnButton.OnPressed += args => ShowVesselPressed(true);
         ShowVesselOffButton.OnPressed += args => ShowVesselPressed(false);
+
+        ShowFactionTagOffButton.Group = _showFactionTagButtonGroup;
+        ShowFactionTagOnButton.Group = _showFactionTagButtonGroup;
+        ShowFactionTagOnButton.OnPressed += args => ShowFactionTagPressed(true);
+        ShowFactionTagOffButton.OnPressed += args => ShowFactionTagPressed(false);
 
         SignatureColorSwatch.PanelOverride = _swatchStyleBox;
         DesignationOptionButton.OnItemSelected += args => OnDesignationSelected(args.Id);
@@ -68,6 +75,11 @@ public sealed partial class IFFConsoleWindow : FancyWindow,
     private void ShowVesselPressed(bool pressed)
     {
         ShowVessel?.Invoke(pressed);
+    }
+
+    private void ShowFactionTagPressed(bool pressed)
+    {
+        ShowFactionTag?.Invoke(pressed);
     }
 
     private void ApplySignatureColor()
@@ -184,6 +196,13 @@ public sealed partial class IFFConsoleWindow : FancyWindow,
             ShowVesselOffButton.Disabled = true;
             ShowVesselOnButton.Disabled = true;
         }
+
+        ShowFactionTagOffButton.Disabled = false;
+        ShowFactionTagOnButton.Disabled = false;
+        if (state.ShowFactionTag)
+            ShowFactionTagOnButton.Pressed = true;
+        else
+            ShowFactionTagOffButton.Pressed = true;
 
         _canEditColor = state.ColorEditable;
         UpdateApplyButtonState();

--- a/Content.Server/Access/Systems/IdCardSystem.cs
+++ b/Content.Server/Access/Systems/IdCardSystem.cs
@@ -14,6 +14,7 @@ using Content.Shared.CrewRecords.Components;
 using Content.Shared.Database;
 using Content.Shared.Kitchen;
 using Content.Shared.Popups;
+using Content.Shared.Station.Components;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using System.Linq;
@@ -163,6 +164,20 @@ public sealed class IdCardSystem : SharedIdCardSystem
         }
     }
 
+    public void RefreshStationIds(int stationId)
+    {
+        var query = EntityQueryEnumerator<IdCardComponent>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            if (comp.stationID != stationId)
+                continue;
+
+            RebuildJob(uid, comp);
+            UpdateEntityName(uid, comp);
+            Dirty(uid, comp);
+        }
+    }
+
     public override void ExpireId(Entity<ExpireIdCardComponent> ent)
     {
         if (ent.Comp.Expired)
@@ -214,7 +229,15 @@ public sealed class IdCardSystem : SharedIdCardSystem
                 {
                     if (crewAssignments.TryGetAssignment(crewRecord.AssignmentID, out var crewAssignment) && crewAssignment != null)
                     {
-                        comp.LocalizedJobTitle = crewAssignment.Name;
+                        // IDs show assignment as "[TAG] Job" so players can quickly identify
+                        // which faction the card holder currently works for.
+                        var factionTag = string.Empty;
+                        if (TryComp<StationDataComponent>(station, out var stationData))
+                            factionTag = stationData.GetResolvedFactionTag(MetaData(station.Value).EntityName);
+
+                        comp.LocalizedJobTitle = string.IsNullOrEmpty(factionTag)
+                            ? crewAssignment.Name
+                            : $"[{factionTag}] {crewAssignment.Name}";
                         found = true;
                     }
                 }

--- a/Content.Server/CrewAssignments/Systems/CrewAssignmentsSystem.SMUI.cs
+++ b/Content.Server/CrewAssignments/Systems/CrewAssignmentsSystem.SMUI.cs
@@ -646,6 +646,23 @@ public sealed partial class CrewAssignmentSystem
 
         // Normalize keeps this safe/consistent even if client-side filtering is bypassed.
         var normalized = StationDataComponent.NormalizeFactionTag(args.Tag);
+
+        if (string.IsNullOrEmpty(normalized))
+        {
+            // Clearing custom value falls back to generated tag. Prevent collisions there too.
+            var fallback = stationData.GetResolvedFactionTag(MetaData(station.Value).EntityName);
+            if (FactionTagExistsOnAnotherStation(station.Value, fallback))
+            {
+                ConsolePopup(player, $"Faction tag '{fallback}' is already used by another faction.");
+                return;
+            }
+        }
+        else if (FactionTagExistsOnAnotherStation(station.Value, normalized))
+        {
+            ConsolePopup(player, $"Faction tag '{normalized}' is already used by another faction.");
+            return;
+        }
+
         stationData.FactionTag = string.IsNullOrEmpty(normalized) ? null : normalized;
         Dirty(station.Value, stationData);
 
@@ -655,6 +672,29 @@ public sealed partial class CrewAssignmentSystem
             _idCard.RefreshStationIds(stationData.UID);
 
         UpdateOrders(station.Value);
+    }
+
+    private bool FactionTagExistsOnAnotherStation(EntityUid station, string candidateTag)
+    {
+        var normalizedCandidate = StationDataComponent.NormalizeFactionTag(candidateTag);
+        if (string.IsNullOrEmpty(normalizedCandidate))
+            return false;
+
+        var query = EntityQueryEnumerator<StationDataComponent>();
+        while (query.MoveNext(out var otherStation, out var otherData))
+        {
+            if (otherStation == station)
+                continue;
+
+            var otherResolved = otherData.GetResolvedFactionTag(MetaData(otherStation).EntityName);
+            if (string.IsNullOrEmpty(otherResolved))
+                continue;
+
+            if (string.Equals(otherResolved, normalizedCandidate, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
     }
     private void OnAddOwner(EntityUid uid, StationModificationConsoleComponent component, StationModificationAddOwner args)
     {

--- a/Content.Server/CrewAssignments/Systems/CrewAssignmentsSystem.SMUI.cs
+++ b/Content.Server/CrewAssignments/Systems/CrewAssignmentsSystem.SMUI.cs
@@ -22,6 +22,7 @@ public sealed partial class CrewAssignmentSystem
         SubscribeLocalEvent<StationModificationConsoleComponent, StationModificationRemoveOwner>(OnRemoveOwner);
         SubscribeLocalEvent<StationModificationConsoleComponent, StationModificationAddOwner>(OnAddOwner);
         SubscribeLocalEvent<StationModificationConsoleComponent, StationModificationChangeName>(OnChangeName);
+        SubscribeLocalEvent<StationModificationConsoleComponent, StationModificationChangeFactionTag>(OnChangeFactionTag);
         SubscribeLocalEvent<StationModificationConsoleComponent, StationModificationAddAccess>(OnAddAccess);
         SubscribeLocalEvent<StationModificationConsoleComponent, StationModificationRemoveAccess>(OnDeleteAccess);
         SubscribeLocalEvent<StationModificationConsoleComponent, StationModificationCreateAssignment>(OnCreateAssignment);
@@ -630,6 +631,31 @@ public sealed partial class CrewAssignmentSystem
         UpdateOrders(station.Value);
 
     }
+
+    private void OnChangeFactionTag(EntityUid uid, StationModificationConsoleComponent component, StationModificationChangeFactionTag args)
+    {
+        if (args.Actor is not { Valid: true } player)
+            return;
+
+        var station = _station.GetOwningStation(uid);
+        if (station == null)
+            return;
+
+        if (!Validate(uid, component, player, out var stationData) || stationData == null)
+            return;
+
+        // Normalize keeps this safe/consistent even if client-side filtering is bypassed.
+        var normalized = StationDataComponent.NormalizeFactionTag(args.Tag);
+        stationData.FactionTag = string.IsNullOrEmpty(normalized) ? null : normalized;
+        Dirty(station.Value, stationData);
+
+        // Refresh issued IDs so the new tag appears right away instead of waiting
+        // for players to reassign or regenerate their cards.
+        if (stationData.UID != 0)
+            _idCard.RefreshStationIds(stationData.UID);
+
+        UpdateOrders(station.Value);
+    }
     private void OnAddOwner(EntityUid uid, StationModificationConsoleComponent component, StationModificationAddOwner args)
     {
         if (args.Actor is not { Valid: true } player)
@@ -740,6 +766,7 @@ public sealed partial class CrewAssignmentSystem
                 StationModUiKey.StationMod,
                 new StationModificationInterfaceState(
                 MetaData(station!.Value).EntityName,
+                data.GetResolvedFactionTag(MetaData(station.Value).EntityName),
                 GetNetEntity(station.Value),
                 data.Owners,
                 cadata.CrewAccesses,

--- a/Content.Server/CrewAssignments/Systems/CrewAssignmentsSystem.cs
+++ b/Content.Server/CrewAssignments/Systems/CrewAssignmentsSystem.cs
@@ -4,6 +4,7 @@ using Content.Server.GameTicking;
 using Content.Server.Popups;
 using Content.Server.Preferences.Managers;
 using Content.Server.Radio.EntitySystems;
+using Content.Server.Access.Systems;
 using Content.Server.Stack;
 using Content.Server.Station.Systems;
 using Content.Shared.Access.Systems;
@@ -31,6 +32,7 @@ public sealed partial class CrewAssignmentSystem : SharedCrewAssignmentSystem
     [Dependency] private readonly IPrototypeManager _protoMan = default!;
     [Dependency] private readonly StationSystem _station2 = default!;
     [Dependency] private readonly CargoSystem _cargo = default!;
+    [Dependency] private readonly IdCardSystem _idCard = default!;
 
 
 

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.IFF.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.IFF.cs
@@ -12,6 +12,7 @@ public sealed partial class ShuttleSystem
     {
         SubscribeLocalEvent<IFFConsoleComponent, AnchorStateChangedEvent>(OnIFFConsoleAnchor);
         SubscribeLocalEvent<IFFConsoleComponent, IFFShowIFFMessage>(OnIFFShow);
+        SubscribeLocalEvent<IFFConsoleComponent, IFFShowFactionTagMessage>(OnIFFShowFactionTag);
         SubscribeLocalEvent<IFFConsoleComponent, IFFSetColorMessage>(OnIFFSetColor);
         SubscribeLocalEvent<IFFConsoleComponent, IFFSetDesignationMessage>(OnIFFSetDesignation);
         SubscribeLocalEvent<IFFConsoleComponent, MapInitEvent>(OnInitIFFConsole);
@@ -53,6 +54,20 @@ public sealed partial class ShuttleSystem
             RemoveIFFFlag(xform.GridUid.Value, IFFFlags.HideLabel);
             RemoveIFFFlag(xform.GridUid.Value, IFFFlags.Hide);
         }
+    }
+
+    private void OnIFFShowFactionTag(EntityUid uid, IFFConsoleComponent component, IFFShowFactionTagMessage args)
+    {
+        if (!TryComp(uid, out TransformComponent? xform) || xform.GridUid is not { } gridUid)
+            return;
+
+        var iff = EnsureComp<IFFComponent>(gridUid);
+        if (iff.ShowFactionTag == args.Show)
+            return;
+
+        iff.ShowFactionTag = args.Show;
+        Dirty(gridUid, iff);
+        UpdateIFFInterfaces(gridUid, iff);
     }
 
     private void OnInitIFFConsole(EntityUid uid, IFFConsoleComponent component, MapInitEvent args)
@@ -118,6 +133,7 @@ public sealed partial class ShuttleSystem
                 ColorEditable = component.AllowColorChange,
                 Designation = IFFDesignation.Other,
                 DesignationEditable = component.AllowDesignationChange,
+                ShowFactionTag = true,
             });
         }
         else
@@ -130,6 +146,7 @@ public sealed partial class ShuttleSystem
                 ColorEditable = component.AllowColorChange,
                 Designation = iff.Designation,
                 DesignationEditable = component.AllowDesignationChange,
+                ShowFactionTag = iff.ShowFactionTag,
             });
         }
     }
@@ -152,6 +169,7 @@ public sealed partial class ShuttleSystem
                 ColorEditable = comp.AllowColorChange,
                 Designation = component.Designation,
                 DesignationEditable = comp.AllowDesignationChange,
+                ShowFactionTag = component.ShowFactionTag,
             });
         }
     }

--- a/Content.Shared/CrewAssignments/BUI/StationModificationInterfaceState.cs
+++ b/Content.Shared/CrewAssignments/BUI/StationModificationInterfaceState.cs
@@ -12,6 +12,7 @@ namespace Content.Shared.Cargo.BUI;
 public sealed class StationModificationInterfaceState : BoundUserInterfaceState
 {
     public string Name;
+    public string FactionTag;
     public NetEntity Station;
     public List<string> Owners;
     public Dictionary<string, CrewAccess> CrewAccess;
@@ -25,9 +26,10 @@ public sealed class StationModificationInterfaceState : BoundUserInterfaceState
     public bool JobNetEnabled;
     public bool TradeStationClaimed;
 
-    public StationModificationInterfaceState(string name, NetEntity station, List<string> owners, Dictionary<string, CrewAccess> crewAccess, Dictionary<int, CrewAssignment> crewAssignments, int importTax, int exportTax, int salesTax, ProtoId<FactionLevelPrototype> level, int accountBalance, Dictionary<ProtoId<RadioChannelPrototype>, FactionRadioData> radioData, bool jobNetEnabled, bool tradeStationClaimed)
+    public StationModificationInterfaceState(string name, string factionTag, NetEntity station, List<string> owners, Dictionary<string, CrewAccess> crewAccess, Dictionary<int, CrewAssignment> crewAssignments, int importTax, int exportTax, int salesTax, ProtoId<FactionLevelPrototype> level, int accountBalance, Dictionary<ProtoId<RadioChannelPrototype>, FactionRadioData> radioData, bool jobNetEnabled, bool tradeStationClaimed)
     {
         Name = name;
+        FactionTag = factionTag;
         Station = station;
         Owners = owners;
         CrewAccess = crewAccess;

--- a/Content.Shared/CrewAssignments/Events/StationModificationChangeFactionTag.cs
+++ b/Content.Shared/CrewAssignments/Events/StationModificationChangeFactionTag.cs
@@ -1,0 +1,14 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Cargo.Events;
+
+[Serializable, NetSerializable]
+public sealed class StationModificationChangeFactionTag : BoundUserInterfaceMessage
+{
+    public string Tag;
+
+    public StationModificationChangeFactionTag(string tag)
+    {
+        Tag = tag;
+    }
+}

--- a/Content.Shared/Shuttles/BUIStates/IFFConsoleBoundUserInterfaceState.cs
+++ b/Content.Shared/Shuttles/BUIStates/IFFConsoleBoundUserInterfaceState.cs
@@ -12,6 +12,7 @@ public sealed class IFFConsoleBoundUserInterfaceState : BoundUserInterfaceState
     public bool ColorEditable;
     public IFFDesignation Designation;
     public bool DesignationEditable;
+    public bool ShowFactionTag;
 }
 
 [Serializable, NetSerializable]

--- a/Content.Shared/Shuttles/Components/IFFComponent.cs
+++ b/Content.Shared/Shuttles/Components/IFFComponent.cs
@@ -36,6 +36,9 @@ public sealed partial class IFFComponent : Component
     [ViewVariables(VVAccess.ReadWrite), DataField, AutoNetworkedField]
     public Color Color = IFFColor;
 
+    [ViewVariables(VVAccess.ReadWrite), DataField, AutoNetworkedField]
+    public bool ShowFactionTag = true;
+
     public static Color NormalizeSignatureColor(Color color)
     {
         var hsv = Color.ToHsv(color);

--- a/Content.Shared/Shuttles/Events/IFFShowFactionTagMessage.cs
+++ b/Content.Shared/Shuttles/Events/IFFShowFactionTagMessage.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Shuttles.Events;
+
+[Serializable, NetSerializable]
+public sealed class IFFShowFactionTagMessage : BoundUserInterfaceMessage
+{
+    public bool Show;
+}

--- a/Content.Shared/Shuttles/Systems/SharedShuttleSystem.IFF.cs
+++ b/Content.Shared/Shuttles/Systems/SharedShuttleSystem.IFF.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.Shared.Station.Components;
 using Content.Shared.Shuttles.Components;
 using JetBrains.Annotations;
 
@@ -31,17 +32,31 @@ public abstract partial class SharedShuttleSystem
     {
         var entName = MetaData(gridUid).EntityName;
 
-        if (self)
-        {
-            return entName;
-        }
+        var baseName = string.IsNullOrEmpty(entName) ? Loc.GetString("shuttle-console-unknown") : entName;
 
-        if (Resolve(gridUid, ref component, false) && (component.Flags & (IFFFlags.HideLabel | IFFFlags.Hide)) != 0x0)
+        Resolve(gridUid, ref component, false);
+
+        if (!self && component != null && (component.Flags & (IFFFlags.HideLabel | IFFFlags.Hide)) != 0x0)
         {
             return null;
         }
 
-        return string.IsNullOrEmpty(entName) ? Loc.GetString("shuttle-console-unknown") : entName;
+        // Default to showing faction tags when there is no IFF component yet.
+        // This keeps claimed/owned grids readable on radar without extra setup.
+        var showFactionTag = component?.ShowFactionTag ?? true;
+        if (showFactionTag)
+        {
+            var station = Station.GetOwningStation(gridUid);
+            if (station != null && TryComp<StationDataComponent>(station, out var stationData))
+            {
+            // Prefix format mirrors ID cards for quick visual consistency.
+                var tag = stationData.GetResolvedFactionTag(MetaData(station.Value).EntityName);
+                if (!string.IsNullOrEmpty(tag))
+                    return $"[{tag}] {baseName}";
+            }
+        }
+
+        return baseName;
     }
 
     /// <summary>

--- a/Content.Shared/Shuttles/Systems/SharedShuttleSystem.cs
+++ b/Content.Shared/Shuttles/Systems/SharedShuttleSystem.cs
@@ -1,6 +1,7 @@
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Shuttles.Components;
 using Content.Shared.Shuttles.UI.MapObjects;
+using Content.Shared.Station;
 using Content.Shared.Whitelist;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
@@ -14,6 +15,7 @@ namespace Content.Shared.Shuttles.Systems;
 public abstract partial class SharedShuttleSystem : EntitySystem
 {
     [Dependency] private readonly IMapManager _mapManager = default!;
+    [Dependency] protected readonly SharedStationSystem Station = default!;
     [Dependency] private readonly ItemSlotsSystem _itemSlots = default!;
     [Dependency] protected readonly FixtureSystem Fixtures = default!;
     [Dependency] protected readonly SharedMapSystem Maps = default!;

--- a/Content.Shared/Station/Components/StationDataComponent.cs
+++ b/Content.Shared/Station/Components/StationDataComponent.cs
@@ -2,6 +2,7 @@ using Content.Shared.CrewAssignments.Prototypes;
 using Content.Shared.Radio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
+using System.Text;
 
 namespace Content.Shared.Station.Components;
 
@@ -12,6 +13,11 @@ namespace Content.Shared.Station.Components;
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class StationDataComponent : Component
 {
+    /// <summary>
+    /// Hard cap for any faction tag shown in UI, IDs, and IFF labels.
+    /// </summary>
+    public const int MaxFactionTagLength = 4;
+
     /// <summary>
     /// The game map prototype, if any, associated with this station.
     /// </summary>
@@ -62,6 +68,74 @@ public sealed partial class StationDataComponent : Component
         { "Service", new FactionRadioData() },
         { "Supply", new FactionRadioData() }
     };
+
+    /// <summary>
+    /// Optional custom faction tag set from the station modification console.
+    /// If null or empty, we fall back to an auto-generated tag.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public string? FactionTag;
+
+    /// <summary>
+    /// Returns the tag that should actually be displayed to players.
+    /// Prefer the configured value, otherwise derive one from the faction name.
+    /// </summary>
+    public string GetResolvedFactionTag(string factionName)
+    {
+        var configured = NormalizeFactionTag(FactionTag);
+        if (!string.IsNullOrEmpty(configured))
+            return configured;
+
+        return GenerateFactionTag(factionName);
+    }
+
+    /// <summary>
+    /// Sanitizes player input so the tag is compact and predictable.
+    /// We strip whitespace and enforce a 4-character cap.
+    /// </summary>
+    public static string NormalizeFactionTag(string? tag)
+    {
+        if (string.IsNullOrWhiteSpace(tag))
+            return string.Empty;
+
+        var sb = new StringBuilder(MaxFactionTagLength);
+        foreach (var ch in tag.Trim())
+        {
+            if (char.IsWhiteSpace(ch))
+                continue;
+
+            sb.Append(ch);
+            if (sb.Length >= MaxFactionTagLength)
+                break;
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Generates a default tag from the first letter of each word in the faction name.
+    /// Example: "Wayfarer Dynamics" becomes "WD".
+    /// </summary>
+    public static string GenerateFactionTag(string factionName)
+    {
+        if (string.IsNullOrWhiteSpace(factionName))
+            return string.Empty;
+
+        var sb = new StringBuilder(MaxFactionTagLength);
+        var words = factionName.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        foreach (var word in words)
+        {
+            if (word.Length == 0)
+                continue;
+
+            sb.Append(word[0]);
+            if (sb.Length >= MaxFactionTagLength)
+                break;
+        }
+
+        return sb.ToString();
+    }
 
     public bool IsOwner(string owner)
     {

--- a/Resources/Locale/en-US/shuttles/iff.ftl
+++ b/Resources/Locale/en-US/shuttles/iff.ftl
@@ -1,6 +1,7 @@
 iff-console-window-title = IFF console
 iff-console-show-iff-label = Show IFF
 iff-console-show-vessel-label = Show vessel
+iff-console-show-faction-tag-label = Show faction tag
 iff-console-designation-label = Designation
 iff-console-designation-other = None
 iff-console-designation-ship = Ship


### PR DESCRIPTION
ADDS:

New Faction Tag system which is definable within the Faction Modification Computer. Faction Tags are for the purposes of identifying which faction someone is part of.

Let's say that John Doe is part of the Jumping Jimmies faction, and is a Bartender. By default, Jumping Jimmies would have a Faction Tag of [JJ] (it defaults to the first letter of each word in the faction name), but they changed it to [JJs].
When John Doe's ID is examined, it should read 'John Doe - [JJs] Bartender'.

Grids claimed to factions will also by default have their Faction Tag displayed on their IFF. (This can be toggled in the IFF console)

Duplicate faction tags are disallowed, and any cancelled faction tag save causes the tag to go to its fallback value



!!DISCLAIMER!!

AI was used for the purposes of debugging, diagnosing build errors and suggesting alternative solutions, including determining which components needed adjustments for a clean implementation