### PR TITLE
Fix flatpacked subfloor gyroscopes

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
@@ -497,7 +497,7 @@
   - type: SubFloorHide
   - type: CollideOnAnchor
   - type: Transform
-    anchored: false
+    anchored: true
   - type: BlockAnchorOn
     blacklist:
       components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Subfloor gyroscopes are now properly anchored when built from a flatpack, instead of being in a glitched state of counting as unanchored, but unable to move.

## Technical details
Single line YAML change