### PR TITLE
sound and outline for the storage counter

### DIFF
--- a/Resources/Prototypes/_Persistence14/Entities/Structures/Storage/storage_counter.yml
+++ b/Resources/Prototypes/_Persistence14/Entities/Structures/Storage/storage_counter.yml
@@ -18,6 +18,8 @@
     - 0,0,5,5
     - 7,0,12,5
     maxItemSize: Huge
+    storageOpenSound: /Audio/Effects/closetopen.ogg
+    storageCloseSound: /Audio/Effects/closetclose.ogg
   - type: UserInterface
     interfaces:
       enum.StorageUiKey.Key:
@@ -35,6 +37,7 @@
   - type: Construction
     graph: StorageCounterGraph
     node: storagecounter
+  - type: InteractionOutline
 
 - type: entity
   id: StorageCounterFrame


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

simple change for the storage counters, now they play sound every time you open them annnnd gives them an interaction outline,  bc when you put stuff on top of it it makes it a lil difficult to open them

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
