### PR TITLE
Chemical crate rebalance

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_medical.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_medical.yml
@@ -119,32 +119,22 @@
   group: market
 
 - type: cargoProduct
-  id: ChemistryP
+  id: ChemistryMetals
   icon:
     sprite: Structures/Storage/Crates/chemcrate_secure.rsi
     state: icon
-  product: CrateChemistryP
+  product: CrateChemistryMetals
   cost: 850
   category: cargoproduct-category-name-medical
   group: market
 
 - type: cargoProduct
-  id: ChemistryS
+  id: ChemistryNonMetals
   icon:
     sprite: Structures/Storage/Crates/chemcrate_secure.rsi
     state: icon
-  product: CrateChemistryS
-  cost: 750
-  category: cargoproduct-category-name-medical
-  group: market
-
-- type: cargoProduct
-  id: CrateChemistryD
-  icon:
-    sprite: Structures/Storage/Crates/chemcrate_secure.rsi
-    state: icon
-  product: CrateChemistryD
-  cost: 750
+  product: CrateChemistryNonMetals
+  cost: 850
   category: cargoproduct-category-name-medical
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/sciencemarket.yml
+++ b/Resources/Prototypes/Catalog/Cargo/sciencemarket.yml
@@ -1,30 +1,20 @@
 - type: cargoProduct
-  id: ChemistryPSTS
+  id: ChemistryMetalsSTS
   icon:
     sprite: Structures/Storage/Crates/chemcrate_secure.rsi
     state: icon
-  product: CrateChemistryP
+  product: CrateChemistryMetals
   cost: 1250
   category: cargoproduct-category-name-medical
   group: sciencemarket
 
 - type: cargoProduct
-  id: ChemistrySSTS
+  id: ChemistryNonMetalsSTS
   icon:
     sprite: Structures/Storage/Crates/chemcrate_secure.rsi
     state: icon
-  product: CrateChemistryS
-  cost: 1000
-  category: cargoproduct-category-name-medical
-  group: sciencemarket
-
-- type: cargoProduct
-  id: CrateChemistryDSTS
-  icon:
-    sprite: Structures/Storage/Crates/chemcrate_secure.rsi
-    state: icon
-  product: CrateChemistryD
-  cost: 1000
+  product: CrateChemistryNonMetals
+  cost: 1250
   category: cargoproduct-category-name-medical
   group: sciencemarket
 

--- a/Resources/Prototypes/Catalog/Fills/Crates/chemistry.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/chemistry.yml
@@ -62,3 +62,43 @@
       entity_storage:
         id: JugPlantBGone
         amount: 5
+
+- type: entity # Persistence
+  parent: CrateChemistrySecure
+  id: CrateChemistryMetals
+  name: metal chemicals crate
+  description: Contains useful metal and metalloid elements. Requires Chemistry access to open.
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:AllSelector
+        children:
+        - id: JugAluminium
+        - id: JugLithium
+        - id: JugSodium
+        - id: JugPotassium
+        - id: JugRadium
+        - id: JugIron
+        - id: JugCopper
+        - id: JugMercury
+        - id: JugSilicon
+
+- type: entity # Persistence
+  parent: CrateChemistrySecure
+  id: CrateChemistryNonMetals
+  name: nonmetal chemicals crate
+  description: Contains useful non-metal elements. Requires Chemistry access to open.
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:AllSelector
+        children:
+        - id: JugCarbon
+        - id: JugChlorine
+        - id: JugFluorine
+        - id: JugIodine
+        - id: JugPhosphorus
+        - id: JugSulfur
+        - id: JugOxygen
+        - id: JugNitrogen
+        - id: JugHydrogen


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Replaces chemicals crate (S), chemicals crate (S), and chemicals crate (D) with the metal chemicals crate, and nonmetal chemicals crate. These two crates combined contain all of the reagents the previous crates contained, except for gold and silver, and each cost the same amount as chemicals crate (P),

## Why / Balance
Turning the gold and silver from chemicals crate (D) into bars using frost oil results in 20 bars of gold and silver per $750 crate, which is several times cheaper than directly purchasing gold and silver crates.

Just removing those two reagents from chemicals crate (D) would result in it only containing 3 jugs. 

Gold and silver are also not used in the recipes for any other reagents.