### PR TITLE
Hellspawn Artifact Fragment Fix

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/hellspawn.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/hellspawn.yml
@@ -82,7 +82,7 @@
       450: Dead
   - type: Butcherable
     spawned:
-      - id: ArtifactFragment
+      - id: ArtifactFragment1
         amount: 4
   - type: MeleeWeapon
     attackRate: 0.6


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changed Hellspawn from dropping four artifact fragment stacks to four artifact fragments, singular.

## Why / Balance
Hellspawn were dropping thirty times the artifact fragments as intended. This is an obvious issue.

## Technical details
Changed the line from Hellspawn items from "ArtifactFragment" to "ArtifactFragment1".

## Media
<img width="605" height="290" alt="image" src="https://github.com/user-attachments/assets/4cc76b60-99ec-4389-895d-dd67332024b7" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None that I'm aware of.

**Changelog**
:cl:
- fix: Hellspawn no longer drop 120 Artifact Fragments, and now only drop 4 Artifact Fragments. Who knew a single 1 was so important?

