### PR TITLE
feat: Gas Geysers Randomized Weights

### DIFF
--- a/Content.Server/_Persistence14/Atmos/Geyser/GasGeyserSystem.cs
+++ b/Content.Server/_Persistence14/Atmos/Geyser/GasGeyserSystem.cs
@@ -38,7 +38,21 @@ public sealed partial class GasGeyserSystem : EntitySystem
     /// </summary>
     public void Errupt(Entity<GasGeyserComponent> geyser, GasMixture environment)
     {
-        var merger = new GasMixture(geyser.Comp.Moles, 1);
+        var moles = (float[]) geyser.Comp.Moles.Clone();
+
+        foreach (var fluidEntry in geyser.Comp.VariableMoles)
+        {
+            if (fluidEntry.Value.Moles <= 0 || fluidEntry.Value.Probability <= 0)
+                continue;
+
+            if (_random.Prob(fluidEntry.Value.Probability))
+                moles[(int) fluidEntry.Key] += fluidEntry.Value.Moles;
+        }
+
+        var merger = new GasMixture(moles, 1)
+        {
+            Temperature = geyser.Comp.SpawnTemperature,
+        };
         _atmos.Merge(environment, merger);
 
         var delay = _random.NextFloat() * (geyser.Comp.MaxEruptionDelay - geyser.Comp.MinEruptionDelay) + geyser.Comp.MinEruptionDelay;

--- a/Content.Shared/_Persistence14/Atmos/Geyser/GasGeyserComponent.cs
+++ b/Content.Shared/_Persistence14/Atmos/Geyser/GasGeyserComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Atmos;
+using Content.Shared.MiningFluid.Components;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared._Persistence14.Atmos.Geyser;
@@ -31,13 +32,20 @@ public sealed partial class GasGeyserComponent : Component
     public TimeSpan EruptionRangeDeltaNegative = TimeSpan.FromSeconds(0);
 
     public TimeSpan MaxEruptionDelay => EruptionDelay + EruptionRangeDeltaPositive;
-    public TimeSpan MinEruptionDelay => EruptionDelay + EruptionRangeDeltaNegative;
+    public TimeSpan MinEruptionDelay => EruptionDelay - EruptionRangeDeltaNegative;
 
     /// <summary>
     /// Gases released into the atmosphere when the geyser erupts.
     /// </summary>
     [DataField(required: true, customTypeSerializer: typeof(GasArraySerializer)), AutoNetworkedField]
     public float[] Moles = new float[Atmospherics.AdjustedNumberOfGases];
+
+    /// <summary>
+    /// Optional weighted gas additions applied independently each eruption.
+    /// Mirrors TrappedFluid's variableMixture behavior (per-gas prob + moles).
+    /// </summary>
+    [DataField("variableMoles")]
+    public Dictionary<Gas, VariableFluidDefinition> VariableMoles = new();
 
     /// <summary>
     /// When external gas mixture exceeds this amount of moles, geysers cannot errupt.

--- a/Resources/Prototypes/_Persistence14/Entities/Atmos/geyser.yml
+++ b/Resources/Prototypes/_Persistence14/Entities/Atmos/geyser.yml
@@ -24,6 +24,7 @@
     eruptionDelay: 5m
     eruptionRangeDeltaPositive: 2m
     eruptionRangeDeltaNegative: 2m
+    spawnTemperature: 235
 
 
 - type: entity
@@ -32,6 +33,332 @@
   suffix: plasma
   components:
   - type: GasGeyser
-    eruptionDelay: 10
+    eruptionDelay: 2m
+    eruptionRangeDeltaPositive: 30s
+    eruptionRangeDeltaNegative: 30s
+    spawnTemperature: 780
     moles: 
-      Plasma: 100
+      Plasma: 1200
+    variableMoles:
+      Plasma:
+        moles: 300
+        prob: 0.5
+      Tritium:
+        moles: 300
+        prob: 0.2
+      Hydrogen:
+        moles: 300
+        prob: 0.2
+
+
+- type: entity
+  id: GeyserChlorine
+  parent: GeyserBase
+  suffix: chlorine
+  components:
+  - type: GasGeyser
+    eruptionDelay: 2m
+    eruptionRangeDeltaPositive: 30s
+    eruptionRangeDeltaNegative: 30s
+    spawnTemperature: 260
+    moles:
+      Chlorine: 1200
+
+
+- type: entity
+  id: GeyserFluorine
+  parent: GeyserBase
+  suffix: fluorine
+  components:
+  - type: GasGeyser
+    eruptionDelay: 2m
+    eruptionRangeDeltaPositive: 30s
+    eruptionRangeDeltaNegative: 30s
+    spawnTemperature: 250
+    moles:
+      Fluorine: 1200
+
+
+- type: entity
+  id: GeyserMethane
+  parent: GeyserBase
+  suffix: methane
+  components:
+  - type: GasGeyser
+    eruptionDelay: 2m
+    eruptionRangeDeltaPositive: 30s
+    eruptionRangeDeltaNegative: 30s
+    spawnTemperature: 340
+    moles:
+      Methane: 1200
+
+
+- type: entity
+  id: GeyserOxygen
+  parent: GeyserBase
+  suffix: oxygen
+  components:
+  - type: GasGeyser
+    eruptionDelay: 2m
+    eruptionRangeDeltaPositive: 30s
+    eruptionRangeDeltaNegative: 30s
+    spawnTemperature: 255
+    moles:
+      Oxygen: 1200
+
+
+- type: entity
+  id: GeyserHydrogen
+  parent: GeyserBase
+  suffix: hydrogen
+  components:
+  - type: GasGeyser
+    eruptionDelay: 2m
+    eruptionRangeDeltaPositive: 30s
+    eruptionRangeDeltaNegative: 30s
+    spawnTemperature: 70
+    moles:
+      Hydrogen: 1200
+
+
+- type: entity
+  id: GeyserWaterVapor
+  parent: GeyserBase
+  suffix: water vapor
+  components:
+  - type: GasGeyser
+    eruptionDelay: 2m
+    eruptionRangeDeltaPositive: 30s
+    eruptionRangeDeltaNegative: 30s
+    spawnTemperature: 275
+    moles:
+      WaterVapor: 1200
+
+
+- type: entity
+  id: GeyserNitrogen
+  parent: GeyserBase
+  suffix: nitrogen
+  components:
+  - type: GasGeyser
+    eruptionDelay: 2m
+    eruptionRangeDeltaPositive: 30s
+    eruptionRangeDeltaNegative: 30s
+    spawnTemperature: 210
+    moles:
+      Nitrogen: 1200
+
+
+- type: entity
+  id: GeyserAmmonia
+  parent: GeyserBase
+  suffix: ammonia
+  components:
+  - type: GasGeyser
+    eruptionDelay: 2m
+    eruptionRangeDeltaPositive: 30s
+    eruptionRangeDeltaNegative: 30s
+    spawnTemperature: 285
+    moles:
+      Ammonia: 1200
+
+
+- type: entity
+  id: GeyserCarbonDioxide
+  parent: GeyserBase
+  suffix: carbon dioxide
+  components:
+  - type: GasGeyser
+    eruptionDelay: 2m
+    eruptionRangeDeltaPositive: 30s
+    eruptionRangeDeltaNegative: 30s
+    spawnTemperature: 300
+    moles:
+      CarbonDioxide: 1200
+
+
+- type: entity
+  id: GeyserPlasmaUnstable
+  parent: GeyserPlasma
+  suffix: plasma, unstable
+  components:
+  - type: GasGeyser
+    spawnTemperature: 980
+    variableMoles:
+      Tritium:
+        moles: 400
+        prob: 0.35
+      Hydrogen:
+        moles: 300
+        prob: 0.35
+      ChlorineTrifluoride:
+        moles: 120
+        prob: 0.08
+
+
+- type: entity
+  id: GeyserChlorineCorrosive
+  parent: GeyserChlorine
+  suffix: chlorine, corrosive
+  components:
+  - type: GasGeyser
+    spawnTemperature: 305
+    variableMoles:
+      Fluorine:
+        moles: 300
+        prob: 0.35
+      Oxygen:
+        moles: 200
+        prob: 0.25
+
+
+- type: entity
+  id: GeyserFluorineReactive
+  parent: GeyserFluorine
+  suffix: fluorine, reactive
+  components:
+  - type: GasGeyser
+    spawnTemperature: 315
+    variableMoles:
+      Chlorine:
+        moles: 280
+        prob: 0.35
+      Hydrogen:
+        moles: 220
+        prob: 0.2
+      Oxygen:
+        moles: 140
+        prob: 0.15
+
+
+- type: entity
+  id: GeyserMethaneVolatile
+  parent: GeyserMethane
+  suffix: methane, volatile
+  components:
+  - type: GasGeyser
+    spawnTemperature: 420
+    variableMoles:
+      Hydrogen:
+        moles: 260
+        prob: 0.4
+      CarbonDioxide:
+        moles: 200
+        prob: 0.25
+      Oxygen:
+        moles: 120
+        prob: 0.15
+
+
+- type: entity
+  id: GeyserOxygenOxidizer
+  parent: GeyserOxygen
+  suffix: oxygen, oxidizer
+  components:
+  - type: GasGeyser
+    spawnTemperature: 290
+    variableMoles:
+      Nitrogen:
+        moles: 240
+        prob: 0.4
+      WaterVapor:
+        moles: 220
+        prob: 0.25
+      Plasma:
+        moles: 120
+        prob: 0.1
+
+
+- type: entity
+  id: GeyserHydrogenVolatile
+  parent: GeyserHydrogen
+  suffix: hydrogen, volatile
+  components:
+  - type: GasGeyser
+    spawnTemperature: 95
+    variableMoles:
+      Oxygen:
+        moles: 220
+        prob: 0.4
+      Plasma:
+        moles: 140
+        prob: 0.25
+      Tritium:
+        moles: 80
+        prob: 0.15
+
+
+- type: entity
+  id: GeyserWaterVaporSuperheated
+  parent: GeyserWaterVapor
+  suffix: water vapor, superheated
+  components:
+  - type: GasGeyser
+    spawnTemperature: 390
+    variableMoles:
+      Oxygen:
+        moles: 220
+        prob: 0.35
+      Hydrogen:
+        moles: 220
+        prob: 0.35
+      Ammonia:
+        moles: 120
+        prob: 0.15
+
+
+- type: entity
+  id: GeyserNitrogenCryogenic
+  parent: GeyserNitrogen
+  suffix: nitrogen, cryogenic
+  components:
+  - type: GasGeyser
+    spawnTemperature: 185
+    variableMoles:
+      Frezon:
+        moles: 180
+        prob: 0.18
+      WaterVapor:
+        moles: 220
+        prob: 0.25
+      Oxygen:
+        moles: 180
+        prob: 0.25
+
+
+- type: entity
+  id: GeyserAmmoniaCaustic
+  parent: GeyserAmmonia
+  suffix: ammonia, caustic
+  components:
+  - type: GasGeyser
+    spawnTemperature: 295
+    variableMoles:
+      Nitrogen:
+        moles: 280
+        prob: 0.4
+      WaterVapor:
+        moles: 240
+        prob: 0.3
+      Chlorine:
+        moles: 120
+        prob: 0.1
+
+
+- type: entity
+  id: GeyserCarbonDioxideVolcanic
+  parent: GeyserCarbonDioxide
+  suffix: carbon dioxide, volcanic
+  components:
+  - type: GasGeyser
+    spawnTemperature: 410
+    variableMoles:
+      Methane:
+        moles: 260
+        prob: 0.25
+      Plasma:
+        moles: 160
+        prob: 0.15
+      NitrousOxide:
+        moles: 200
+        prob: 0.2

--- a/Resources/Prototypes/_Persistence14/Entities/Atmos/geyser.yml
+++ b/Resources/Prototypes/_Persistence14/Entities/Atmos/geyser.yml
@@ -2,7 +2,7 @@
   id: GeyserBase
   abstract: true
   name: geyser
-  placement: 
+  placement:
     mode: SnapgridCenter
   description: A whole in the ground that goes way too deep. Don't stand too close!
   components:
@@ -24,37 +24,27 @@
     eruptionDelay: 5m
     eruptionRangeDeltaPositive: 2m
     eruptionRangeDeltaNegative: 2m
-    spawnTemperature: 235
+    spawnTemperature: 80
 
 
 - type: entity
   id: GeyserPlasma
   parent: GeyserBase
-  suffix: plasma
+  suffix: basalt, ironrock
   components:
   - type: GasGeyser
     eruptionDelay: 2m
     eruptionRangeDeltaPositive: 30s
     eruptionRangeDeltaNegative: 30s
-    spawnTemperature: 780
-    moles: 
-      Plasma: 1200
-    variableMoles:
-      Plasma:
-        moles: 300
-        prob: 0.5
-      Tritium:
-        moles: 300
-        prob: 0.2
-      Hydrogen:
-        moles: 300
-        prob: 0.2
+    spawnTemperature: 650
+    moles:
+      Plasma: 600
 
 
 - type: entity
   id: GeyserChlorine
   parent: GeyserBase
-  suffix: chlorine
+  suffix: chromite, conglomerate
   components:
   - type: GasGeyser
     eruptionDelay: 2m
@@ -62,13 +52,13 @@
     eruptionRangeDeltaNegative: 30s
     spawnTemperature: 260
     moles:
-      Chlorine: 1200
+      Chlorine: 600
 
 
 - type: entity
   id: GeyserFluorine
   parent: GeyserBase
-  suffix: fluorine
+  suffix: chromite, conglomerate
   components:
   - type: GasGeyser
     eruptionDelay: 2m
@@ -76,13 +66,13 @@
     eruptionRangeDeltaNegative: 30s
     spawnTemperature: 250
     moles:
-      Fluorine: 1200
+      Fluorine: 600
 
 
 - type: entity
   id: GeyserMethane
   parent: GeyserBase
-  suffix: methane
+  suffix: ironrock, andesite
   components:
   - type: GasGeyser
     eruptionDelay: 2m
@@ -90,13 +80,13 @@
     eruptionRangeDeltaNegative: 30s
     spawnTemperature: 340
     moles:
-      Methane: 1200
+      Methane: 600
 
 
 - type: entity
   id: GeyserOxygen
   parent: GeyserBase
-  suffix: oxygen
+  suffix: conglomerate, ice
   components:
   - type: GasGeyser
     eruptionDelay: 2m
@@ -104,27 +94,27 @@
     eruptionRangeDeltaNegative: 30s
     spawnTemperature: 255
     moles:
-      Oxygen: 1200
+      Oxygen: 600
 
 
 - type: entity
   id: GeyserHydrogen
   parent: GeyserBase
-  suffix: hydrogen
+  suffix: ice, ironrock
   components:
   - type: GasGeyser
     eruptionDelay: 2m
     eruptionRangeDeltaPositive: 30s
     eruptionRangeDeltaNegative: 30s
-    spawnTemperature: 70
+    spawnTemperature: 80
     moles:
-      Hydrogen: 1200
+      Hydrogen: 600
 
 
 - type: entity
   id: GeyserWaterVapor
   parent: GeyserBase
-  suffix: water vapor
+  suffix: andesite, ice
   components:
   - type: GasGeyser
     eruptionDelay: 2m
@@ -132,13 +122,13 @@
     eruptionRangeDeltaNegative: 30s
     spawnTemperature: 275
     moles:
-      WaterVapor: 1200
+      WaterVapor: 600
 
 
 - type: entity
   id: GeyserNitrogen
   parent: GeyserBase
-  suffix: nitrogen
+  suffix: conglomerate, ice
   components:
   - type: GasGeyser
     eruptionDelay: 2m
@@ -146,13 +136,13 @@
     eruptionRangeDeltaNegative: 30s
     spawnTemperature: 210
     moles:
-      Nitrogen: 1200
+      Nitrogen: 600
 
 
 - type: entity
   id: GeyserAmmonia
   parent: GeyserBase
-  suffix: ammonia
+  suffix: chromite, andesite
   components:
   - type: GasGeyser
     eruptionDelay: 2m
@@ -160,13 +150,13 @@
     eruptionRangeDeltaNegative: 30s
     spawnTemperature: 285
     moles:
-      Ammonia: 1200
+      Ammonia: 600
 
 
 - type: entity
   id: GeyserCarbonDioxide
   parent: GeyserBase
-  suffix: carbon dioxide
+  suffix: conglomerate, basalt
   components:
   - type: GasGeyser
     eruptionDelay: 2m
@@ -174,191 +164,381 @@
     eruptionRangeDeltaNegative: 30s
     spawnTemperature: 300
     moles:
-      CarbonDioxide: 1200
+      CarbonDioxide: 600
 
 
 - type: entity
   id: GeyserPlasmaUnstable
   parent: GeyserPlasma
-  suffix: plasma, unstable
+  suffix: ironrock, basalt, unstable
   components:
   - type: GasGeyser
-    spawnTemperature: 980
+    spawnTemperature: 700
     variableMoles:
       Tritium:
-        moles: 400
+        moles: 200
         prob: 0.35
       Hydrogen:
-        moles: 300
+        moles: 150
         prob: 0.35
-      ChlorineTrifluoride:
-        moles: 120
-        prob: 0.08
+      Oxygen:
+        moles: 80
+        prob: 0.15
+
+
+- type: entity
+  id: GeyserPlasmaVolcanic
+  parent: GeyserPlasma
+  suffix: basalt, andesite, volcanic
+  components:
+  - type: GasGeyser
+    spawnTemperature: 850
+    variableMoles:
+      CarbonDioxide:
+        moles: 160
+        prob: 0.4
+      Ammonia:
+        moles: 110
+        prob: 0.25
+      Methane:
+        moles: 60
+        prob: 0.1
 
 
 - type: entity
   id: GeyserChlorineCorrosive
   parent: GeyserChlorine
-  suffix: chlorine, corrosive
+  suffix: chromite, conglomerate, corrosive
   components:
   - type: GasGeyser
     spawnTemperature: 305
     variableMoles:
       Fluorine:
-        moles: 300
+        moles: 150
         prob: 0.35
       Oxygen:
-        moles: 200
+        moles: 100
         prob: 0.25
+
+
+- type: entity
+  id: GeyserChlorineToxic
+  parent: GeyserChlorine
+  suffix: chromite, conglomerate, toxic
+  components:
+  - type: GasGeyser
+    spawnTemperature: 295
+    variableMoles:
+      Hydrogen:
+        moles: 120
+        prob: 0.35
+      Ammonia:
+        moles: 90
+        prob: 0.2
+      ChlorineTrifluoride:
+        moles: 40
+        prob: 0.05
 
 
 - type: entity
   id: GeyserFluorineReactive
   parent: GeyserFluorine
-  suffix: fluorine, reactive
+  suffix: chromite, conglomerate, reactive
   components:
   - type: GasGeyser
     spawnTemperature: 315
     variableMoles:
       Chlorine:
-        moles: 280
+        moles: 140
         prob: 0.35
       Hydrogen:
-        moles: 220
+        moles: 110
         prob: 0.2
       Oxygen:
-        moles: 140
+        moles: 70
         prob: 0.15
+
+
+- type: entity
+  id: GeyserPlasmaCatalytic
+  parent: GeyserPlasma
+  suffix: chromite, basalt, catalytic
+  components:
+  - type: GasGeyser
+    spawnTemperature: 520
+    variableMoles:
+      Fluorine:
+        moles: 110
+        prob: 0.25
+      Chlorine:
+        moles: 70
+        prob: 0.2
+      ChlorineTrifluoride:
+        moles: 20
+        prob: 0.03
 
 
 - type: entity
   id: GeyserMethaneVolatile
   parent: GeyserMethane
-  suffix: methane, volatile
+  suffix: ironrock, basalt, volatile
   components:
   - type: GasGeyser
     spawnTemperature: 420
     variableMoles:
       Hydrogen:
-        moles: 260
+        moles: 130
         prob: 0.4
       CarbonDioxide:
-        moles: 200
+        moles: 100
         prob: 0.25
       Oxygen:
-        moles: 120
+        moles: 60
         prob: 0.15
+
+
+- type: entity
+  id: GeyserMethaneSeep
+  parent: GeyserMethane
+  suffix: ice, andesite, seep
+  components:
+  - type: GasGeyser
+    spawnTemperature: 285
+    variableMoles:
+      WaterVapor:
+        moles: 80
+        prob: 0.2
+      Hydrogen:
+        moles: 90
+        prob: 0.2
+      Frezon:
+        moles: 30
+        prob: 0.08
 
 
 - type: entity
   id: GeyserOxygenOxidizer
   parent: GeyserOxygen
-  suffix: oxygen, oxidizer
+  suffix: conglomerate, andesite, oxidizer
   components:
   - type: GasGeyser
     spawnTemperature: 290
     variableMoles:
       Nitrogen:
-        moles: 240
+        moles: 120
         prob: 0.4
       WaterVapor:
-        moles: 220
+        moles: 110
         prob: 0.25
-      Plasma:
-        moles: 120
+      CarbonDioxide:
+        moles: 60
+        prob: 0.1
+
+
+- type: entity
+  id: GeyserOxygenBreathable
+  parent: GeyserOxygen
+  suffix: conglomerate, ice, breathable
+  components:
+  - type: GasGeyser
+    spawnTemperature: 245
+    variableMoles:
+      Nitrogen:
+        moles: 140
+        prob: 0.45
+      CarbonDioxide:
+        moles: 60
+        prob: 0.15
+      WaterVapor:
+        moles: 40
         prob: 0.1
 
 
 - type: entity
   id: GeyserHydrogenVolatile
   parent: GeyserHydrogen
-  suffix: hydrogen, volatile
+  suffix: ironrock, ice, volatile
   components:
   - type: GasGeyser
     spawnTemperature: 95
     variableMoles:
       Oxygen:
-        moles: 220
+        moles: 110
         prob: 0.4
       Plasma:
-        moles: 140
+        moles: 70
         prob: 0.25
-      Tritium:
-        moles: 80
+      CarbonDioxide:
+        moles: 40
         prob: 0.15
+
+
+- type: entity
+  id: GeyserHydrogenCryo
+  parent: GeyserHydrogen
+  suffix: ice, conglomerate, cryo
+  components:
+  - type: GasGeyser
+    spawnTemperature: 80
+    variableMoles:
+      Frezon:
+        moles: 40
+        prob: 0.08
+      Nitrogen:
+        moles: 110
+        prob: 0.35
+      Oxygen:
+        moles: 70
+        prob: 0.2
 
 
 - type: entity
   id: GeyserWaterVaporSuperheated
   parent: GeyserWaterVapor
-  suffix: water vapor, superheated
+  suffix: andesite, basalt, superheated
   components:
   - type: GasGeyser
-    spawnTemperature: 390
+    spawnTemperature: 485
     variableMoles:
       Oxygen:
-        moles: 220
+        moles: 110
         prob: 0.35
-      Hydrogen:
-        moles: 220
+      Plasma:
+        moles: 110
         prob: 0.35
       Ammonia:
-        moles: 120
+        moles: 60
         prob: 0.15
+
+
+- type: entity
+  id: GeyserWaterVaporFrozen
+  parent: GeyserWaterVapor
+  suffix: ice, andesite, frozen
+  components:
+  - type: GasGeyser
+    spawnTemperature: 80
+    variableMoles:
+      Frezon:
+        moles: 30
+        prob: 0.06
+      Nitrogen:
+        moles: 90
+        prob: 0.25
+      Oxygen:
+        moles: 70
+        prob: 0.2
 
 
 - type: entity
   id: GeyserNitrogenCryogenic
   parent: GeyserNitrogen
-  suffix: nitrogen, cryogenic
+  suffix: ice, conglomerate, cryogenic
   components:
   - type: GasGeyser
-    spawnTemperature: 185
+    spawnTemperature: 80
     variableMoles:
       Frezon:
-        moles: 180
-        prob: 0.18
+        moles: 60
+        prob: 0.12
       WaterVapor:
-        moles: 220
+        moles: 110
         prob: 0.25
       Oxygen:
-        moles: 180
+        moles: 90
         prob: 0.25
+
+
+- type: entity
+  id: GeyserNitrogenInert
+  parent: GeyserNitrogen
+  suffix: conglomerate, andesite, inert
+  components:
+  - type: GasGeyser
+    spawnTemperature: 200
+    variableMoles:
+      Oxygen:
+        moles: 90
+        prob: 0.2
+      CarbonDioxide:
+        moles: 60
+        prob: 0.15
+      WaterVapor:
+        moles: 50
+        prob: 0.1
 
 
 - type: entity
   id: GeyserAmmoniaCaustic
   parent: GeyserAmmonia
-  suffix: ammonia, caustic
+  suffix: chromite, conglomerate, caustic
   components:
   - type: GasGeyser
     spawnTemperature: 295
     variableMoles:
       Nitrogen:
-        moles: 280
+        moles: 140
         prob: 0.4
-      WaterVapor:
-        moles: 240
-        prob: 0.3
       Chlorine:
-        moles: 120
+        moles: 60
         prob: 0.1
+      ChlorineTrifluoride:
+        moles: 30
+        prob: 0.05
+
+
+- type: entity
+  id: GeyserAmmoniaFertile
+  parent: GeyserAmmonia
+  suffix: conglomerate, andesite, fertile
+  components:
+  - type: GasGeyser
+    spawnTemperature: 270
+    variableMoles:
+      Nitrogen:
+        moles: 120
+        prob: 0.35
+      CarbonDioxide:
+        moles: 80
+        prob: 0.25
+      WaterVapor:
+        moles: 70
+        prob: 0.2
 
 
 - type: entity
   id: GeyserCarbonDioxideVolcanic
   parent: GeyserCarbonDioxide
-  suffix: carbon dioxide, volcanic
+  suffix: basalt, ironrock, volcanic
   components:
   - type: GasGeyser
     spawnTemperature: 410
     variableMoles:
       Methane:
-        moles: 260
+        moles: 130
         prob: 0.25
       Plasma:
-        moles: 160
+        moles: 80
         prob: 0.15
-      NitrousOxide:
-        moles: 200
+      Ammonia:
+        moles: 100
         prob: 0.2
+
+
+- type: entity
+  id: GeyserWaterVaporMisty
+  parent: GeyserWaterVapor
+  suffix: andesite, conglomerate, misty
+  components:
+  - type: GasGeyser
+    spawnTemperature: 285
+    variableMoles:
+      Ammonia:
+        moles: 110
+        prob: 0.35
+      Methane:
+        moles: 80
+        prob: 0.2
+      Oxygen:
+        moles: 60
+        prob: 0.15


### PR DESCRIPTION
Adds:

Randomized weights for gas geyser spouting (from the gas asteroid VariableFluid), allowing geysers to have probabilities weighted on their eruptions
Definable temperatures for expelled gas
A bunch of prototypes made for placement by admins sorted by suffix

Fixes:

Math was wrong for delta defs (both had a +, changed the negative to a -)