### PR TITLE
Fixed hitbox on recycler

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/recycler.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/recycler.yml
@@ -28,9 +28,10 @@
           bounds: "-0.49,-0.49,0.49,0.49"
         hard: true
         mask:
-        - Impassable
+        - MachineMask
         layer:
         - Opaque
+        - MidImpassable
         - BulletImpassable
       conveyor:
         shape: !type:PolygonShape


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed the hitbox of the recycler

## Why / Balance
Despite being a very bulky machine that takes up a full tile, the recycler does not collide with player mobs, which is very strange and has been broken for years. This fixes that, while preserving its functionality

## Technical details
Changed fixture mask and added a layer to one of its hitboxes

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Recycler is no longer intangible