### PR TITLE
More Radium Jugs

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
@@ -17,7 +17,7 @@
     JugOxygen: 3
     JugPhosphorus: 1
     JugPotassium: 2
-    JugRadium: 1
+    JugRadium: 2
     JugSilicon: 2
     JugSodium: 2
     JugSugar: 3


### PR DESCRIPTION
added one more radium jug per restock

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added 1 more radium jug to the restock.
A total of two radium!
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Radium is a pain to get for the chemist players.
## Technical details
<!-- Summary of code changes for easier review. -->
Turned that one to a two
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
Add: 1 Radium Jug extra to restock