### PR TITLE
Re-implement changed metabolism rates for Psicodine and Ethylredoxrazine

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -107,6 +107,7 @@
   flavor: medicine
   color: "#2d5708"
   metabolisms:
+    metabolismRate: 0.1
     Bloodstream:
       effects:
       - !type:ModifyStatusEffect
@@ -856,7 +857,7 @@
         conditions:
         - !type:TemperatureCondition
         #Minimum added so it can't work in space atmos
-          min: 50.0 
+          min: 50.0
           max: 180.0
         damage:
           Burn: -2
@@ -1367,6 +1368,7 @@
   color: "#07E79E"
   metabolisms:
     Bloodstream:
+      metabolismRate: 0.3
       effects:
       - !type:HealthChange
         conditions:

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -107,8 +107,8 @@
   flavor: medicine
   color: "#2d5708"
   metabolisms:
-    metabolismRate: 0.1
     Bloodstream:
+      metabolismRate: 0.1
       effects:
       - !type:ModifyStatusEffect
         effectProto: StatusEffectDrunk


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The changes to the metabolism rates of these reagents made in #264 were accidentally reverted during an upstream merge.

## Technical details
YAML only
