### PR TITLE
Recyclerhitbox2

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/recycler.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/recycler.yml
@@ -18,14 +18,14 @@
       brrt:
         shape:
           !type:PhysShapeAabb
-          bounds: "-0.15,-0.15,0.15,0.15"
+          bounds: "-0.32,-0.32,0.32,0"
         hard: false
         layer:
         - FullTileLayer
       collision:
         shape:
           !type:PhysShapeAabb
-          bounds: "-0.49,-0.49,0.49,0.49"
+          bounds: "-0.49,-0.31,0.49,0.49"
         hard: true
         mask:
         - MachineMask


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Follow-up to PR#487
Adjusted the hitboxes so the destruction hitbox is roughly aligned with the "roller" on the sprite, pulled back the collision hitbox to expose it.

## Why / Balance
The previous PR broke the recyler's ability to recycle large entities such as destroyed generators. This restores that (although only when processing in one direction, IMO it makes sense that only the end with the crushing wheel should be able to take large machines)

## Technical details
Hitbox adjustments

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="412" height="403" alt="image" src="https://github.com/user-attachments/assets/1844113f-ae64-4543-9835-2753c59b76dd" />


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed recycler being unable to process generators
