### PR TITLE
Revision: Modified Bluespace Tech to require Phoron

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/chemistry.yml
+++ b/Resources/Prototypes/Recipes/Lathes/chemistry.yml
@@ -52,6 +52,7 @@
     Steel: 500
     Plastic: 500
     Plasma: 150
+    Phoron: 100
     Silver: 50
 
 - type: latheRecipe
@@ -62,6 +63,7 @@
     Steel: 500
     Plastic: 500
     Plasma: 150
+    Phoron: 100
     Silver: 50
 
 - type: latheRecipe
@@ -73,6 +75,7 @@
     Plastic: 150
     Glass: 250
     Plasma: 100
+    Phoron: 100
     Silver: 50
 
 - type: latheRecipe

--- a/Resources/Prototypes/Recipes/Lathes/devices.yml
+++ b/Resources/Prototypes/Recipes/Lathes/devices.yml
@@ -151,6 +151,7 @@
     Silver: 750
     Plasma: 1500
     Uranium: 150
+    Phoron: 500
 
 - type: latheRecipe
   parent: ClothingBackpackHolding
@@ -167,6 +168,12 @@
   id: OreBagOfHolding
   result: OreBagOfHolding
   unlockUses: 3
+  materials:
+    Steel: 2000
+    Silver: 750
+    Plasma: 1500
+    Uranium: 150
+    Phoron: 300
 
 - type: latheRecipe
   id: ClothingMaskWeldingGas

--- a/Resources/Prototypes/Recipes/Lathes/powercells.yml
+++ b/Resources/Prototypes/Recipes/Lathes/powercells.yml
@@ -64,6 +64,7 @@
     Glass: 400
     Uranium: 200
     Gold: 100
+    Phoron: 200
   unlockUses: 2
 
 # Power cages

--- a/Resources/Prototypes/Recipes/Lathes/salvage.yml
+++ b/Resources/Prototypes/Recipes/Lathes/salvage.yml
@@ -40,6 +40,7 @@
   materials:
     Steel: 1000
     Glass: 500
+    Phoron: 50
     # If they get spammed make it cost silver.
 
 - type: latheRecipe


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
All bluespace and other high-tech items now require phoron as part of their recipe. Effected items:
* Bags of Holding - 5 Phoron
* Ore Bag of Holding - 3 Phoron
* Bluespace Jug/Beaker/Syringe - 1 Phoron
* Fulton Beacon - .5 Phoron
* Microreactor - 2 Phoron

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Currently these incredibly high tier items are undervalued and basically guarenteed to be everywhere sooner than later. Adding a phoron cost both increases the value of these items and incentivises the gathering of phoron which helps increase its availability for its other uses (anomaly generation and solar panels for example).

## Technical details
<!-- Summary of code changes for easier review. -->
* Added phoron to the lathe recipe of all listed items.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
No known breaking changes.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: High tech items now cost phoron to make.
