### PR TITLE
add colorful costumes to Uniform Lathe

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/clothing.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/clothing.yml
@@ -47,6 +47,8 @@
   - ClothingUniformJumpskirtRedStripedDress
   - ClothingShoesBootsPerformer
   - ClothingShoesBootsLaceup
+  - ClothingUniformRandomStandard
+  - ClothingUniformRandomBra
   - ClothingShoesFlippers
   - ClothingShoesLeather
   - ClothingShoesSlippers

--- a/Resources/Prototypes/Recipes/Lathes/clothing.yml
+++ b/Resources/Prototypes/Recipes/Lathes/clothing.yml
@@ -1205,6 +1205,16 @@
   parent: BaseJumpsuitRecipe
   id: ClothingUniformGenericTurtleNeckAndJeans
   result: ClothingUniformGenericTurtleNeckAndJeans
+  
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformRandomStandard
+  result: ClothingUniformRandomStandard
+  
+- type: latheRecipe
+  parent: BaseJumpsuitRecipe
+  id: ClothingUniformRandomBra
+  result: ClothingUniformRandomBra
 
 - type: latheRecipe
   parent: BaseJumpsuitRecipe


### PR DESCRIPTION
This PR is to add 'Colorful Costumes' to the uniform lathe, which was only obtainable via the clothesdrobe, let the stations be fashionable. 