### PR TITLE
Add solar starter kit crate

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_engines.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_engines.yml
@@ -68,6 +68,16 @@
   category: cargoproduct-category-name-engineering
   group: market
 
+- type: cargoProduct
+  id: EngineSolarStarter
+  icon:
+    sprite: Objects/Devices/flatpack.rsi
+    state: solar-assembly-part
+  product: CrateEngineeringSolarStarter
+  cost: 2200
+  category: cargoproduct-category-name-engineering
+  group: market
+
 #- type: cargoProduct
 #  id: EngineTeslaGenerator
 #  icon:

--- a/Resources/Prototypes/Catalog/Cargo/engineermarket.yml
+++ b/Resources/Prototypes/Catalog/Cargo/engineermarket.yml
@@ -258,6 +258,16 @@
   category: cargoproduct-category-name-engineering
   group: engineermarket
 
+- type: cargoProduct
+  id: EngineSolarStarterETS
+  icon:
+    sprite: Objects/Devices/flatpack.rsi
+    state: solar-assembly-part
+  product: CrateEngineeringSolarStarter
+  cost: 2200
+  category: cargoproduct-category-name-engineering
+  group: engineermarket
+
 #- type: cargoProduct
 #  id: EngineTeslaGeneratorETS
 #  icon:

--- a/Resources/Prototypes/Catalog/Fills/Crates/engines.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/engines.yml
@@ -143,6 +143,25 @@
           amount: 2
 
 - type: entity
+  parent: CrateEngineering
+  id: CrateEngineeringSolarStarter
+  name: solar starter kit crate
+  description: A kit with solar flatpacks and glass to construct ten solar panels. Comes with boards for a solar tracker and solar control console.
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:AllSelector
+        children:
+        - id: SolarAssemblyFlatpack
+          amount: 10
+        - id: SheetGlass10
+          amount: 2
+        - id: SolarTrackerElectronics
+          amount: 1
+        - id: SolarControlComputerCircuitboard
+          amount: 1
+
+- type: entity
   parent: CrateEngineeringSecure
   id: CrateEngineeringShuttle
   name: shuttle powering crate


### PR DESCRIPTION
## About the PR
Add a crate containing the same as a regular solar crate, but also the boards for a tracker and control computer. Base price is 2200 spesos, available at regular ATS and engi ATS.

## Technical details
Just yaml

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
- add: Added solar starter kit crate, containing 10 solar assemblies, the glass for them, a solar tracker board and a solar control computer board.