### PR TITLE
Revision: Removes default weld and flash protection from sunglasses.

### DIFF
--- a/Resources/Prototypes/_Moffstation/Entities/Clothing/Eyes/eyewear.yml
+++ b/Resources/Prototypes/_Moffstation/Entities/Clothing/Eyes/eyewear.yml
@@ -96,10 +96,8 @@
       specular:
         color: "#FFFFFF10"
         priority: 1000
-  - type: EyeProtection
   - type: IdentityBlocker
     coverage: EYES
-  - type: FlashImmunity
 
 - type: entity
   parent: ClothingEyesModularHudGlasses


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
As the title says. Removes the default weld and flash protection from sunglasses.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
With the modhud update, this basically gave sunglasses a free two modules. Now which hud you choose to wear is 80% style points.

## Technical details
<!-- Summary of code changes for easier review. -->
* Removed EyeProtection component from ClothingEyesModularHudSunglasses
* Removed FlashImmunity component from ClothingEyesModularHudSunglasses

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
For some unknown reason, sec eyepatches are still just normal sec eyepatches... couldn't tell you why.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Sunglasses no longer give weld and flash protection without modules.
