### PR TITLE
Revision: Balancing Modular HUDs for Persistence

### DIFF
--- a/Resources/Prototypes/_Moffstation/Recipes/Lathes/modular_hud_modules.yml
+++ b/Resources/Prototypes/_Moffstation/Recipes/Lathes/modular_hud_modules.yml
@@ -10,6 +10,7 @@
     Steel: 200
     Glass: 100
     Plastic: 50
+  unlockUses: 2
 
 - type: latheRecipe
   parent: BaseModularHudModuleT1Recipe
@@ -20,6 +21,8 @@
     Glass: 100
     Plastic: 50
     Silver: 50
+  unlockUses: 2
+
 
 # Tier 1
 
@@ -59,6 +62,7 @@
     Steel: 200
     Glass: 100
     Silver: 100 # Eye protection uses silver as a lens filter... or something
+  unlockUses: 2
 
 - type: latheRecipe
   parent: BaseModularHudModuleT2Recipe

--- a/Resources/Prototypes/_Moffstation/Research/arsenal.yml
+++ b/Resources/Prototypes/_Moffstation/Research/arsenal.yml
@@ -27,7 +27,7 @@
     entity: HudModuleFlashImmunity
   discipline: Arsenal
   tier: 2
-  cost: 4000
+  cost: 20000 # Price changed for Persistence14
   technologyPrerequisites:
   - ModularHudFrames
   recipeUnlocks:

--- a/Resources/Prototypes/_Moffstation/Research/civilianservices.yml
+++ b/Resources/Prototypes/_Moffstation/Research/civilianservices.yml
@@ -23,7 +23,7 @@
     entity: HudModuleShowCriminalRecordIcons
   discipline: CivilianServices
   tier: 2
-  cost: 3500
+  cost: 17500 # Price changed for Persistence14
   technologyPrerequisites:
   - ModularHudFrames
   - ModularHudModulesCivilianT1
@@ -39,7 +39,7 @@
     entity: HudModuleShowMedicalIcons
   discipline: CivilianServices
   tier: 2
-  cost: 3500
+  cost: 17500 # Price changed for Persistence14
   technologyPrerequisites:
   - ModularHudFrames
   - ModularHudModulesCivilianT1

--- a/Resources/Prototypes/_Moffstation/Research/experimental.yml
+++ b/Resources/Prototypes/_Moffstation/Research/experimental.yml
@@ -23,7 +23,7 @@
     entity: HudModuleSolutionScanner
   discipline: Experimental
   tier: 2
-  cost: 2000
+  cost: 10000 # Price changed for Persistence14
   technologyPrerequisites:
   - ModularHudFrames
   - ModularHudModulesExperimentalT1

--- a/Resources/Prototypes/_Moffstation/Research/industrial.yml
+++ b/Resources/Prototypes/_Moffstation/Research/industrial.yml
@@ -1,5 +1,7 @@
+
 # Tier 1
 
+# Removed for Persistence14
 #- type: technology
 #  id: ModularHudModulesIndustrialT1
 #  name: research-technology-modular-hud-modules-industrial-t1
@@ -22,7 +24,7 @@
     entity: HudModuleEyeProtection
   discipline: Industrial
   tier: 2
-  cost: 3500
+  cost: 17500 # Price changed for Persistence14
   technologyPrerequisites:
   - ModularHudFrames
 #  - ModularHudModulesIndustrialT1

--- a/Resources/Prototypes/_Persistence14/Recipes/Lathe/modular_hud_frames.yml
+++ b/Resources/Prototypes/_Persistence14/Recipes/Lathe/modular_hud_frames.yml
@@ -8,6 +8,7 @@
     Steel: 100
     Glass: 200
     Plastic: 100
+  unlockUses: 2
 
 - type: latheRecipe
   parent: BaseModularHudFrameRecipe


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Updates a few of the modular hud recipes and whatnot to match persistence standards. Mainly adding unlock uses to the recipes and increasing the research cost of Tier 2 modules.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This keeps recent changes in line with general standards for recipes and science.

## Technical details
<!-- Summary of code changes for easier review. -->
* Increased cost of all T2 modular hud researches by 5x, same as previous T2 research change for other items.
* Added unlockUses: 2 to all modules and hud frames.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
No known breaking changes.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Increase research cost of T2 hud research
- tweak: Increase unlock count for hud recipes from 1 to 2 across the board

