### PR TITLE
Add Grid Config to Autolathe

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_shuttle.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_shuttle.yml
@@ -19,16 +19,6 @@
   group: market
 
 - type: cargoProduct
-  id: GridConfigurator
-  icon:
-    sprite: Objects/Tools/access_configurator.rsi
-    state: icon
-  product: GridConfigurator
-  cost: 5000
-  category: cargoproduct-category-name-shuttle
-  group: market
-
-- type: cargoProduct
   id: ComputerStationModificationFlatpack
   icon:
     sprite: Objects/Devices/flatpack.rsi

--- a/Resources/Prototypes/Recipes/Lathes/Packs/engineering.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/engineering.yml
@@ -24,6 +24,7 @@
   - ClothingHeadHatCone
   - ClothingHeadHatHardhatYellowEmpty
   - AccessConfigurator
+  - GridConfigurator
   - ToolboxMechanical
   - VoiceSensorCopper
   - SignallerCopper

--- a/Resources/Prototypes/Recipes/Lathes/tools.yml
+++ b/Resources/Prototypes/Recipes/Lathes/tools.yml
@@ -55,6 +55,16 @@
 
 - type: latheRecipe
   parent: BaseToolRecipe
+  id: GridConfigurator
+  result: GridConfigurator
+  completetime: 2
+  materials:
+    Steel: 600
+    Plastic: 800
+    Glass: 400
+
+- type: latheRecipe
+  parent: BaseToolRecipe
   id: Wrench
   result: Wrench
   materials:


### PR DESCRIPTION
Title.

This PR removes the Grid config from the cargo market, and puts it into the autolathe.

