### PR TITLE
Humanoids who have not accepted death cannot be gibbed or cremated.

### DIFF
--- a/Content.Server/Anomaly/Effects/InnerBodyAnomalySystem.cs
+++ b/Content.Server/Anomaly/Effects/InnerBodyAnomalySystem.cs
@@ -8,6 +8,8 @@ using Content.Shared.Anomaly.Components;
 using Content.Shared.Anomaly.Effects;
 using Content.Shared.Chat;
 using Content.Shared.Database;
+using Content.Shared.Damage; // Persistence 14: Deal damage to entities which cannot be gibbed.
+using Content.Shared.Damage.Systems; // Persistence 14: Deal damage to entities which cannot be gibbed.
 using Content.Shared.Gibbing;
 using Content.Shared.Mobs;
 using Content.Shared.Popups;
@@ -33,6 +35,7 @@ public sealed class InnerBodyAnomalySystem : SharedInnerBodyAnomalySystem
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly StunSystem _stun = default!;
+    [Dependency] private readonly DamageableSystem _damage = default!; // Persistence 14: Deal damage to entities which cannot be gibbed.
 
     private readonly Color _messageColor = Color.FromSrgb(new Color(201, 22, 94));
 
@@ -130,6 +133,7 @@ public sealed class InnerBodyAnomalySystem : SharedInnerBodyAnomalySystem
 
     private void OnAnomalySupercritical(Entity<InnerBodyAnomalyComponent> ent, ref AnomalySupercriticalEvent args)
     {
+        _damage.TryChangeDamage(ent.Owner, ent.Comp.SupercriticalDamage, true); // Persistence 14: Deal damage to entities which cannot be gibbed.
         _gibbing.Gib(ent.Owner);
     }
 

--- a/Content.Server/Mobs/CritMobActionsSystem.cs
+++ b/Content.Server/Mobs/CritMobActionsSystem.cs
@@ -15,11 +15,13 @@ using Content.Shared.Mobs.Systems;
 using Content.Shared.Players;
 using Content.Shared.Preferences;
 using Content.Shared.Speech.Muting;
+using Content.Shared.Tag;
 using Robust.Server.Console;
 using Robust.Server.GameObjects;
 using Robust.Shared.Configuration;
 using Robust.Shared.Player;
 using Robust.Shared.Timing;
+using Robust.Shared.Prototypes;
 
 namespace Content.Server.Mobs;
 
@@ -41,7 +43,9 @@ public sealed class CritMobActionsSystem : EntitySystem
     [Dependency] private readonly RadioSystem _radio = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
     [Dependency] private readonly IConfigurationManager _configurationManager = default!;
+    [Dependency] private readonly TagSystem _tag = default!;
     private const int MaxLastWordsLength = 30;
+    private static readonly ProtoId<TagPrototype> NoGibTag = "NoGib";
 
     public override void Initialize()
     {
@@ -225,6 +229,8 @@ public sealed class CritMobActionsSystem : EntitySystem
                         foundSlot = pair.Key;
                     }
                 }
+
+                _tag.RemoveTag(uid, NoGibTag);
                 _prefsManager.DeleteCharacter(foundSlot, actor.PlayerSession.UserId, actor.PlayerSession);
                 _ticker.Respawn(actor.PlayerSession);
             });

--- a/Content.Shared/Anomaly/Components/InnerBodyAnomalyComponent.cs
+++ b/Content.Shared/Anomaly/Components/InnerBodyAnomalyComponent.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Anomaly.Effects;
+using Content.Shared.Damage;
 using Content.Shared.Humanoid.Prototypes;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
@@ -69,6 +70,17 @@ public sealed partial class InnerBodyAnomalyComponent : Component
     /// </summary>
     [DataField]
     public string LayerMap = "inner_anomaly_layer";
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public DamageSpecifier SupercriticalDamage = new DamageSpecifier()// Persistence 14: Deal damage to entities which cannot be gibbed.
+    {
+        DamageDict = new()
+        {
+            {"Blunt", 400},
+            {"Cellular", 150},
+            {"Radiation", 450}
+        }
+    };
 }
 
 /// <summary>

--- a/Content.Shared/Gibbing/GibbingSystem.cs
+++ b/Content.Shared/Gibbing/GibbingSystem.cs
@@ -4,6 +4,8 @@ using Robust.Shared.Audio.Systems;
 using Robust.Shared.Network;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Random;
+using Robust.Shared.Prototypes; // Persistence 14: NoGibTag
+using Content.Shared.Tag; // Persistence 14: NoGibTag
 
 namespace Content.Shared.Gibbing;
 
@@ -15,8 +17,10 @@ public sealed class GibbingSystem : EntitySystem
     [Dependency] private readonly SharedDestructibleSystem _destructible = default!;
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly TagSystem _tag = default!; // Persistence 14: NoGibTag
 
     private static readonly SoundSpecifier? GibSound = new SoundCollectionSpecifier("gib", AudioParams.Default.WithVariation(0.025f));
+    private static readonly ProtoId<TagPrototype> NoGibTag = "NoGib"; // Persistence 14: NoGibTag
 
     /// <summary>
     /// Gibs an entity.
@@ -32,6 +36,9 @@ public sealed class GibbingSystem : EntitySystem
         // BodySystem handles prediction rather poorly and causes client-sided bugs when we gib on the client
         // This guard can be removed once it is gone and replaced by a prediction-safe system.
         if (!_net.IsServer)
+            return new();
+
+        if (_tag.HasTag(ent, NoGibTag)) // Persistence 14: NoGibTag
             return new();
 
         if (!_destructible.DestroyEntity(ent))

--- a/Content.Shared/Morgue/Components/CrematoriumComponent.cs
+++ b/Content.Shared/Morgue/Components/CrematoriumComponent.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Damage;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
@@ -39,4 +40,13 @@ public sealed partial class CrematoriumComponent : Component
 
     [DataField]
     public SoundSpecifier CremateFinishSound = new SoundPathSpecifier("/Audio/Machines/ding.ogg");
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public DamageSpecifier CremateDamage = new DamageSpecifier()// Persistence 14: Deal damage to entities which cannot be ashed.
+    {
+        DamageDict = new()
+        {
+            {"Heat", 400},
+        }
+    };
 }

--- a/Content.Shared/Morgue/SharedCrematoriumSystem.cs
+++ b/Content.Shared/Morgue/SharedCrematoriumSystem.cs
@@ -7,11 +7,15 @@ using Content.Shared.Standing;
 using Content.Shared.Storage;
 using Content.Shared.Storage.Components;
 using Content.Shared.Storage.EntitySystems;
+using Content.Shared.Tag; // Persistence 14: NoGibTag
 using Content.Shared.Verbs;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Network;
 using Robust.Shared.Timing;
+using Robust.Shared.Prototypes; // Persistence 14: NoGibTag
+using Content.Shared.Damage; // Persistence 14: Deal damage to entities which cannot be ashed.
+using Content.Shared.Damage.Systems; // Persistence 14: Deal damage to entities which cannot be ashed.
 
 namespace Content.Shared.Morgue;
 
@@ -26,6 +30,10 @@ public abstract class SharedCrematoriumSystem : EntitySystem
     [Dependency] private readonly SharedAudioSystem _audio = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly SharedContainerSystem _container = default!;
+    [Dependency] private readonly TagSystem _tag = default!; // Persistence 14: NoGibTag
+    [Dependency] private readonly DamageableSystem _damage = default!; // Persistence 14: Deal damage to entities which cannot be ashed.
+
+    private static readonly ProtoId<TagPrototype> NoGibTag = "NoGib"; // Persistence 14: NoGibTag
 
     public override void Initialize()
     {
@@ -138,13 +146,21 @@ public abstract class SharedCrematoriumSystem : EntitySystem
 
         if (ent.Comp2.Contents.ContainedEntities.Count > 0)
         {
+            var spawnAsh = true;
             for (var i = ent.Comp2.Contents.ContainedEntities.Count - 1; i >= 0; i--)
             {
                 var item = ent.Comp2.Contents.ContainedEntities[i];
+                if (_tag.HasTag(item, NoGibTag))
+                {
+                    spawnAsh = false;
+                    _damage.TryChangeDamage(item, ent.Comp1.CremateDamage); // Persistence 14: Deal damage to entities which cannot be ashed.
+                    continue;
+                }
                 _container.Remove(item, ent.Comp2.Contents);
                 PredictedDel(item);
             }
-            PredictedTrySpawnInContainer(ent.Comp1.LeftOverProtoId, ent.Owner, ent.Comp2.Contents.ID, out _);
+            if (spawnAsh)
+                PredictedTrySpawnInContainer(ent.Comp1.LeftOverProtoId, ent.Owner, ent.Comp2.Contents.ID, out _);
         }
 
         EntityStorage.OpenStorage(ent.Owner, ent.Comp2);

--- a/Resources/Prototypes/Body/Species/vox.yml
+++ b/Resources/Prototypes/Body/Species/vox.yml
@@ -180,29 +180,7 @@
     spawned:
     - id: FoodMeatChicken
       amount: 5
-  - type: Destructible
-    thresholds:
-    - trigger:
-        !type:DamageTypeTrigger
-        damageType: Blunt
-        damage: 400
-      behaviors:
-      - !type:GibBehavior { }
-    - trigger:
-        !type:DamageTypeTrigger
-        damageType: Radiation
-        damage: 15
-      behaviors:
-      - !type:PopupBehavior
-        popup: mouth-taste-metal
-        popupType: LargeCaution
-        targetOnly: true
-    - trigger:
-        !type:DamageTypeTrigger
-        damageType: Radiation
-        damage: 40
-      behaviors:
-      - !type:VomitBehavior
+    # Persistence 14: Removed destructable component override for turning into roast chicken when ashed, due to ashing not existing.
   - type: PassiveDamage
     # Augment normal health regen to be able to tank some Poison damage
     # This allows Vox to take their mask off temporarily to eat something without needing a trip to medbay afterwards.

--- a/Resources/Prototypes/Body/species_base.yml
+++ b/Resources/Prototypes/Body/species_base.yml
@@ -163,6 +163,24 @@
     - FootstepSound
     - DoorBumpOpener
     - AnomalyHost
+    - NoGib
+  - type: Destructible # Persistence 14: Overwrite blunt gibbing behaviour
+    thresholds:
+    - trigger:
+        !type:DamageTypeTrigger
+        damageType: Radiation
+        damage: 15
+      behaviors:
+      - !type:PopupBehavior
+        popup: mouth-taste-metal
+        popupType: LargeCaution
+        targetOnly: true
+    - trigger:
+        !type:DamageTypeTrigger
+        damageType: Radiation
+        damage: 40
+      behaviors:
+      - !type:VomitBehavior
 
 - type: entity
   save: true

--- a/Resources/Prototypes/Entities/Structures/Storage/morgue.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/morgue.yml
@@ -80,7 +80,7 @@
 - type: entity
   id: MorgueAssembly
   name: morgue assembly
-  description: Used to store bodies once completed. 
+  description: Used to store bodies once completed.
   placement:
     mode: SnapgridCenter
   components:

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -35,7 +35,7 @@
 
 - type: Tag
   id: ApcElectronics # ConstructionGraph
-  
+
 - type: Tag
   id: Apron # ConstructionGraph: scraparmor
 
@@ -1025,6 +1025,9 @@
 
 - type: Tag
   id: NoConsoleSound # Blacklist on BaseComputer, StationMap. Tagged entity will not make sound when opening the UI.
+
+- type: Tag
+  id: NoGib # Persistence 14: Prevents anything this is put on from being gibbed. Temporary solution to gibbing related glitches.
 
 - type: Tag
   id: NotGhostnadoWarpable # Prevents the entity from being selected via "Warp to most followed" ghost warp


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

Player species are now unable to be gibbed or turned into ash by any means, unless they chose to accept death in the death network menu.

Anomalous infections deal 400 blunt, 150 cellular, and 450 radiation damage to their host when they go supercritical.
Cremators deal 400 points of heat damage when attempting to cremate a player who has not accepted death.

## Why / Balance
Gibbing and ashing cause issues with the current death system.

## Technical details
YAML changes to BaseSpeciesMob and MobVox
Added the NoGib tag.
Made GibbingSystem check for the NoGib tag, and fail to gib entities that have it.
Made crematoriums check for the NoGib tag in their contents. If the tag is found, the crematorium deals damage to the entity instead of deleting it, and does not spawn ash.

## Media
[Screencast_20260731_170615.webm](https://github.com/user-attachments/assets/c203b9a7-888f-416c-96d7-ac88ceb1ea0a)

[Screencast_20260731_170906.webm](https://github.com/user-attachments/assets/36b8fb9e-cfe0-4fb2-9574-f56f5ddc4d92)

[Screencast_20260731_175912.webm](https://github.com/user-attachments/assets/8a2023d7-554c-4f6d-9b46-2fe015b4bca4)

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Playable species can no longer be gibbed by blunt damage.
- tweak: Playable species can no longer be gibbed by other means, unless they have accepted death.
- tweak: Anomalous infections that have gone supercritical now deal massive amounts of cellular and radiation damage to their hosts.
- tweak: Playable species who have not accepted death take 400 points of heat damage when cremated, instead of turning into ash.