### PR TITLE
Made it so increments of 5u of artifixium will activate extra wildcards.

### DIFF
--- a/Content.Shared/EntityEffects/Effects/ArtifactEntityEffectsSystem.cs
+++ b/Content.Shared/EntityEffects/Effects/ArtifactEntityEffectsSystem.cs
@@ -35,19 +35,21 @@ public sealed partial class ArtifactUnlockEntityEffectSystem : EntityEffectSyste
 
     protected override void Effect(Entity<XenoArtifactComponent> entity, ref EntityEffectEvent<ArtifactUnlock> args)
     {
+        // Scale is the units of artifexium applied in this reaction.
+        var units = args.Scale;
+
         if (EnsureComp<XenoArtifactUnlockingComponent>(entity, out var unlocking))
         {
-            if (unlocking.ArtifexiumApplied)
-                return;
-
+            // Window already open: add to it and let the normal timer run out.
             _popup.PopupEntity(Loc.GetString("artifact-activation-artifexium"), entity, PopupType.Medium);
         }
         else
         {
-            _xenoArtifact.TriggerXenoArtifact(entity, null, force: true);
+            // Artifexium opened the window: resolve instantly.
+            _xenoArtifact.SetInstantUnlock((entity, unlocking));
         }
 
-        _xenoArtifact.SetArtifexiumApplied((entity, unlocking), true);
+        _xenoArtifact.AddArtifexiumScale((entity, unlocking), units);
     }
 }
 

--- a/Content.Shared/Xenoarchaeology/Artifact/Components/XenoArtifactComponent.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/Components/XenoArtifactComponent.cs
@@ -83,6 +83,13 @@ public sealed partial class XenoArtifactComponent : Component
     /// </summary>
     [DataField, AutoPausedField]
     public TimeSpan NextUnlockTime;
+
+    /// <summary>
+    /// Units of artifexium that substitute for one required node trigger. A node needing N triggers
+    /// unlocks with N * this many units. Keep in sync with the ArtifactUnlock effect's minScale.
+    /// </summary>
+    [DataField]
+    public float ArtifexiumCostPerTrigger = 5f;
     #endregion
 
     // NOTE: you should not be accessing any of these values directly. Use the methods in SharedXenoArtifactSystem.Graph

--- a/Content.Shared/Xenoarchaeology/Artifact/Components/XenoArtifactUnlockingComponent.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/Components/XenoArtifactUnlockingComponent.cs
@@ -22,10 +22,12 @@ public sealed partial class XenoArtifactUnlockingComponent : Component
     public TimeSpan EndTime;
 
     /// <summary>
-    /// Tracks if artifexium has been applied, which changes the unlock behavior slightly.
+    /// Total units of artifexium applied during this unlocking window. Every
+    /// <see cref="XenoArtifactComponent.ArtifexiumCostPerTrigger"/> units substitute for one required
+    /// node trigger when the window resolves. Zero means no artifexium is in effect.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public bool ArtifexiumApplied;
+    public float ArtifexiumScale;
 
     /// <summary>
     /// The sound that plays when an artifact finishes unlocking successfully (with node unlocked).

--- a/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Unlock.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Unlock.cs
@@ -124,9 +124,9 @@ public abstract partial class SharedXenoArtifactSystem
             var requiredIndices = GetPredecessorNodes((ent, artifactComponent), nodeIndex);
             requiredIndices.Add(nodeIndex);
 
-            if (!ent.Comp1.ArtifexiumApplied)
+            if (artifactUnlockingComponent.ArtifexiumScale <= 0f)
             {
-                // Make sure the two sets are identical
+                // No artifexium: triggered set must match the required set exactly.
                 if (requiredIndices.Count != artifactUnlockingComponent.TriggeredNodeIndexes.Count
                     || !artifactUnlockingComponent.TriggeredNodeIndexes.All(requiredIndices.Contains))
                     continue;
@@ -135,10 +135,14 @@ public abstract partial class SharedXenoArtifactSystem
                 return true; // exit early
             }
 
-            // If we apply artifexium, check that the sets are identical EXCEPT for one extra node.
-            // This node is a "wildcard" and we'll make a pool so we can pick one to actually unlock.
-            if (!artifactUnlockingComponent.TriggeredNodeIndexes.All(requiredIndices.Contains) ||
-                requiredIndices.Count - 1 != artifactUnlockingComponent.TriggeredNodeIndexes.Count)
+            // With artifexium: triggered set must be a subset of the required set, and artifexium must
+            // cover every trigger that wasn't performed manually (ArtifexiumCostPerTrigger units each).
+            if (!artifactUnlockingComponent.TriggeredNodeIndexes.All(requiredIndices.Contains))
+                continue;
+
+            var missingTriggers = requiredIndices.Count - artifactUnlockingComponent.TriggeredNodeIndexes.Count;
+            var wildcardsAvailable = (int) (artifactUnlockingComponent.ArtifexiumScale / artifactComponent.ArtifexiumCostPerTrigger);
+            if (missingTriggers > wildcardsAvailable)
                 continue;
 
             potentialNodes.Add(curNode);

--- a/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.XAT.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.XAT.cs
@@ -94,9 +94,21 @@ public abstract partial class SharedXenoArtifactSystem
         }
     }
 
-    public void SetArtifexiumApplied(Entity<XenoArtifactUnlockingComponent> ent, bool val)
+    /// <summary>
+    /// Adds units of applied artifexium to the current unlocking window.
+    /// </summary>
+    public void AddArtifexiumScale(Entity<XenoArtifactUnlockingComponent> ent, float amount)
     {
-        ent.Comp.ArtifexiumApplied = val;
+        ent.Comp.ArtifexiumScale += amount;
+        Dirty(ent);
+    }
+
+    /// <summary>
+    /// Sets the window to resolve on the next update tick instead of waiting out the timer.
+    /// </summary>
+    public void SetInstantUnlock(Entity<XenoArtifactUnlockingComponent> ent)
+    {
+        ent.Comp.EndTime = _timing.CurTime;
         Dirty(ent);
     }
 }


### PR DESCRIPTION
## About the PR
Reworks how Artifexium unlocks artifact nodes.

Previously Artifexium could only ever replace a **single** node trigger (one "wildcard"), so it was hard-capped to helping with one missing trigger per unlock. Now it scales with how much you apply: every 5u of Artifexium substitutes for one required trigger. With enough of it you can brute-force nodes open with no manual triggering at all, and — over many applications — fully unlock an entire artifact.

Behaviour:
- **Applying Artifexium to an artifact that has no unlock window open** starts the window and resolves it instantly.
- **Applying it after a tool has already opened the window** adds to it and respects the normal unlock timer, so tool triggers and Artifexium stack.
- A node needing N triggers costs **N × 5u** to unlock via Artifexium (e.g. 10u opens a node that needs 2 triggers).
- When multiple nodes are affordable, which one unlocks is still **random**.

## Why / Balance
Artifexium was previously a niche one-trigger assist. This turns it into a full "brute-force" path: dump enough reagent and you can crack an artifact without solving its triggers, at the cost of destroying artifacts to make the reagent. In other words, a proper incentive for artifact fragment dump that feels good and worth it to use. Trading resources for convenience and speed

Rough economy (server defaults): one crushed + ground artifact yields ~20–40u of Artifexium (2–4 fragments × 10u), and fully unlocking a typical handheld artifact costs on the order of ~30–40 trigger-activations. At 5u per trigger that's roughly **5–8 crushed artifacts to fully brute-force one** — a deliberate net-negative sink so brute-forcing stays a last resort rather than a shortcut. The cost is exposed as a tunable (`ArtifexiumCostPerTrigger`, default 5) so it can be raised if in-game testing shows it's too cheap.

Another thing to keep in mind is that using this means you don't know what this will unlock. Players will need to be aware of it and be smart or risk triggering deadly effects so spamming this without a thought is sure to lead to unforeseen consequences (Seriously... all it takes is a lizard polymorph followed by a pyro and you are dead). 

## Technical details
- `XenoArtifactUnlockingComponent`: replaced `bool ArtifexiumApplied` with `float ArtifexiumScale` (total units applied during the window).
- `XenoArtifactComponent`: added `ArtifexiumCostPerTrigger` (default 5) — units of Artifexium per substituted trigger.
- `SharedXenoArtifactSystem`: `SetArtifexiumApplied` → `AddArtifexiumScale` (accumulates units); added `SetInstantUnlock` (resolves the window on the next tick).
- `TryGetNodeFromUnlockState`: with Artifexium applied, a node qualifies when the triggered set is a subset of its required set and `missingTriggers ≤ floor(ArtifexiumScale / ArtifexiumCostPerTrigger)`. All qualifying nodes are pooled and one is picked at random.
- `ArtifactUnlockEntityEffectSystem`: now reads the reagent quantity (`args.Scale`) and accumulates it instead of setting a flag; re-application stacks.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
`XenoArtifactUnlockingComponent.ArtifexiumApplied` (bool) was removed and replaced with `ArtifexiumScale` (float). `SharedXenoArtifactSystem.SetArtifexiumApplied` was removed; use `AddArtifexiumScale` instead.

:cl:
- tweak: Artifexium now scales with how much you apply — every 5u substitutes for one artifact node trigger, so with enough of it you can brute-force nodes (and eventually whole artifacts) open.