### PR TITLE
Makes Laser Shield Researchable and Craftable in a Sec Fab

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
@@ -27,13 +27,13 @@
   - ClothingBeltMilitaryWebbing
   - ClothingShoesBootsJack
   - ClothingShoesBootsCombat
-  - ClothingShoesHighheelBoots 
-  - ClothingShoesBootsMerc 
+  - ClothingShoesHighheelBoots
+  - ClothingShoesBootsMerc
   - ClothingShoesBootsWinterSec
-  - ClothingShoesBootsCowboyBrown 
-  - ClothingShoesBootsCowboyBlack 
-  - ClothingShoesBootsCowboyWhite 
-  - ClothingShoesBootsCowboyFancy 
+  - ClothingShoesBootsCowboyBrown
+  - ClothingShoesBootsCowboyBlack
+  - ClothingShoesBootsCowboyWhite
+  - ClothingShoesBootsCowboyFancy
 
 # Practice ammo/mags and practice weapons
 - type: latheRecipePack
@@ -160,6 +160,8 @@
   - WeaponLaserCarbine
   - WeaponXrayCannon
   - WeaponTemperatureGun
+  - RiotLaserShield
+
 
 - type: latheRecipePack
   id: SecurityDisablers

--- a/Resources/Prototypes/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/security.yml
@@ -127,6 +127,17 @@
     Glass: 800
   unlockUses: 4
 
+- type: latheRecipe
+  parent: BaseShieldRecipe
+  id: RiotLaserShield
+  result: RiotLaserShield
+  materials:
+    Steel: 300
+    Glass: 400
+  unlockUses: 4
+
+
+
 # Targets
 - type: latheRecipe
   parent: BaseTargetRecipe
@@ -393,48 +404,48 @@
 
 - type: latheRecipe
   parent: BaseGlovesClothingRecipeInsulated
-  id: ClothingHandsGlovesCombat 
-  result: ClothingHandsGlovesCombat 
+  id: ClothingHandsGlovesCombat
+  result: ClothingHandsGlovesCombat
   unlockUses: 4
 
 - type: latheRecipe
   parent: BaseBeltsClothingRecipe
-  id: ClothingBeltSecurity 
-  result: ClothingBeltSecurity 
+  id: ClothingBeltSecurity
+  result: ClothingBeltSecurity
   materials:
     Cloth: 400
     Durathread: 100
 
 - type: latheRecipe
   parent: BaseBeltsClothingRecipe
-  id: ClothingBeltHolster 
-  result: ClothingBeltHolster 
+  id: ClothingBeltHolster
+  result: ClothingBeltHolster
 
 - type: latheRecipe
   parent: BaseBeltsClothingRecipe
-  id: ClothingBeltBandolier 
-  result: ClothingBeltBandolier 
+  id: ClothingBeltBandolier
+  result: ClothingBeltBandolier
 
 - type: latheRecipe
   parent: BaseBeltsClothingRecipe
-  id: ClothingBeltSecurityWebbing 
-  result: ClothingBeltSecurityWebbing 
+  id: ClothingBeltSecurityWebbing
+  result: ClothingBeltSecurityWebbing
   materials:
     Cloth: 400
     Durathread: 300
 
 - type: latheRecipe
   parent: BaseBeltsClothingRecipe
-  id: ClothingBeltMercWebbing 
-  result: ClothingBeltMercWebbing 
+  id: ClothingBeltMercWebbing
+  result: ClothingBeltMercWebbing
   materials:
     Cloth: 400
     Durathread: 300
 
 - type: latheRecipe
   parent: BaseBeltsClothingRecipe
-  id: ClothingBeltMilitaryWebbing 
-  result: ClothingBeltMilitaryWebbing 
+  id: ClothingBeltMilitaryWebbing
+  result: ClothingBeltMilitaryWebbing
   materials:
     Cloth: 400
     Durathread: 300
@@ -501,4 +512,3 @@
   parent: BaseShoesClothingRecipeSecurity
   id: ClothingShoesBootsCowboyFancy
   result: ClothingShoesBootsCowboyFancy
-

--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -47,6 +47,7 @@
   cost: 7500
   recipeUnlocks:
   - WeaponLaserCarbine
+  - RiotLaserShield
 
 - type: technology
   id: NonlethalAmmunition


### PR DESCRIPTION
## About the PR
I took the existing Laser Riot Shield from upstream Space Station 14 and attached it to the Weaponized Laser Manipulation technology from the arsenal discipline. Each research of said tech now grants 4 prints of the laser shield. It costs 3 Steel and 4 glass for a shield. 

## Why / Balance
Overall this won't impact the game's balance much. The Laser Riot Shield is a bit of a niche use case, but from a story perspective with the discovery of Xenoborgs in the Threshold the potential stockpiling of equipment specifically designed to counteract known Xenoborg weaponry I think would be a good addition to the player's arsenal of tools. 
## Technical details
In Resources>Prototypes>Research>arsenal.yml added "-RiotLaserShield" to line 50 under "WeaponizedLaserManipulation"
In Resources>Prototypes>Recipes>Lathes>Packs>security.yml added "-RiotShieldLaser" to the Security Weapons dynamic pack on line 163. 
In Resources>Prototypes>Recipes>Lathes>security.yml added 
"- type: latheRecipe
  parent: BaseShieldRecipe
  id: RiotLaserShield
  result: RiotLaserShield
  materials:
    Steel: 300
    Glass: 400
  unlockUses: 4" from line 130-137 under the #Shields section. 
Of course as a result several other lines of code got bumped down to different lines, but remain unchanged.
## Media
<img width="891" height="670" alt="example" src="https://github.com/user-attachments/assets/c4944f9a-81d1-4c44-93e6-1698fac2fa4c" />
 adding an item to the secfab. 
<img width="1204" height="643" alt="example2" src="https://github.com/user-attachments/assets/c11afb5a-5777-4942-b3b8-004702852e31" />
<img width="1103" height="723" alt="example3" src="https://github.com/user-attachments/assets/595ae9db-2f34-4ff1-8a25-96502c490103" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
I don't think anything is breaking with this. I'm just adding a shield that already exists to the sec fab. 

**Changelog**
:cl:
- tweak: Added Laser Shield to Weaponized Laser Weaponry tech
- add: Added Laser Shield to SecFab
-->
