### PR TITLE
Mega spray pickable amount

### DIFF
--- a/Content.Server/Fluids/EntitySystems/SpraySystem.cs
+++ b/Content.Server/Fluids/EntitySystems/SpraySystem.cs
@@ -3,6 +3,7 @@ using Content.Server.Chemistry.EntitySystems;
 using Content.Server.Gravity;
 using Content.Server.Popups;
 using Content.Shared.CCVar;
+using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.FixedPoint;
 using Content.Shared.Fluids;
@@ -134,7 +135,13 @@ public sealed class SpraySystem : SharedSpraySystem
         var threeQuarters = diffNorm * 0.75f;
         var quarter = diffNorm * 0.25f;
 
-        var amount = Math.Max(Math.Min((solution.Volume / entity.Comp.TransferAmount).Int(), entity.Comp.VaporAmount), 1);
+        // When opted in, the amount sprayed per use is player-configurable via the SolutionTransfer
+        // ("set transfer amount" context verb); otherwise it uses the SprayComponent's fixed amount.
+        var transferAmount = entity.Comp.TransferAmount;
+        if (entity.Comp.UseSolutionTransferAmount && TryComp<SolutionTransferComponent>(entity, out var solutionTransfer))
+            transferAmount = solutionTransfer.TransferAmount;
+
+        var amount = Math.Max(Math.Min((solution.Volume / transferAmount).Int(), entity.Comp.VaporAmount), 1);
         var spread = entity.Comp.VaporSpread / amount;
 
         for (var i = 0; i < amount; i++)
@@ -150,7 +157,7 @@ public sealed class SpraySystem : SharedSpraySystem
             if (distance > entity.Comp.SprayDistance)
                 target = sprayerMapPos.Offset(diffNorm * entity.Comp.SprayDistance);
 
-            var adjustedSolutionAmount = entity.Comp.TransferAmount / entity.Comp.VaporAmount;
+            var adjustedSolutionAmount = transferAmount / entity.Comp.VaporAmount;
             var newSolution = _solutionContainer.SplitSolution(soln.Value, adjustedSolutionAmount);
 
             if (newSolution.Volume <= FixedPoint2.Zero)

--- a/Content.Server/Fluids/EntitySystems/SpraySystem.cs
+++ b/Content.Server/Fluids/EntitySystems/SpraySystem.cs
@@ -3,7 +3,6 @@ using Content.Server.Chemistry.EntitySystems;
 using Content.Server.Gravity;
 using Content.Server.Popups;
 using Content.Shared.CCVar;
-using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.FixedPoint;
 using Content.Shared.Fluids;
@@ -135,13 +134,7 @@ public sealed class SpraySystem : SharedSpraySystem
         var threeQuarters = diffNorm * 0.75f;
         var quarter = diffNorm * 0.25f;
 
-        // When opted in, the amount sprayed per use is player-configurable via the SolutionTransfer
-        // ("set transfer amount" context verb); otherwise it uses the SprayComponent's fixed amount.
-        var transferAmount = entity.Comp.TransferAmount;
-        if (entity.Comp.UseSolutionTransferAmount && TryComp<SolutionTransferComponent>(entity, out var solutionTransfer))
-            transferAmount = solutionTransfer.TransferAmount;
-
-        var amount = Math.Max(Math.Min((solution.Volume / transferAmount).Int(), entity.Comp.VaporAmount), 1);
+        var amount = Math.Max(Math.Min((solution.Volume / entity.Comp.TransferAmount).Int(), entity.Comp.VaporAmount), 1);
         var spread = entity.Comp.VaporSpread / amount;
 
         for (var i = 0; i < amount; i++)
@@ -157,7 +150,7 @@ public sealed class SpraySystem : SharedSpraySystem
             if (distance > entity.Comp.SprayDistance)
                 target = sprayerMapPos.Offset(diffNorm * entity.Comp.SprayDistance);
 
-            var adjustedSolutionAmount = transferAmount / entity.Comp.VaporAmount;
+            var adjustedSolutionAmount = entity.Comp.TransferAmount / entity.Comp.VaporAmount;
             var newSolution = _solutionContainer.SplitSolution(soln.Value, adjustedSolutionAmount);
 
             if (newSolution.Volume <= FixedPoint2.Zero)

--- a/Content.Shared/Chemistry/EntitySystems/SolutionTransferSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SolutionTransferSystem.cs
@@ -65,14 +65,28 @@ public sealed class SolutionTransferSystem : EntitySystem
             Priority = 1
         });
 
+        // Build the clickable amounts: the standard presets within the container's range, plus the
+        // container's own min and max so the exact bounds are always selectable even when they aren't
+        // one of the standard presets (e.g. a 40u cap that sits between the 25 and 50 presets).
+        var amounts = new List<FixedPoint2>();
+        foreach (var amount in DefaultTransferAmounts)
+        {
+            if (amount >= ent.Comp.MinimumTransferAmount && amount <= ent.Comp.MaximumTransferAmount)
+                amounts.Add(amount);
+        }
+
+        if (!amounts.Contains(ent.Comp.MinimumTransferAmount))
+            amounts.Add(ent.Comp.MinimumTransferAmount);
+        if (!amounts.Contains(ent.Comp.MaximumTransferAmount))
+            amounts.Add(ent.Comp.MaximumTransferAmount);
+
+        amounts.Sort((a, b) => a > b ? 1 : a < b ? -1 : 0);
+
         // Add specific transfer verbs according to the container's size
         var priority = 0;
         var user = args.User;
-        foreach (var amount in DefaultTransferAmounts)
+        foreach (var amount in amounts)
         {
-            if (amount < ent.Comp.MinimumTransferAmount || amount > ent.Comp.MaximumTransferAmount)
-                continue;
-
             AlternativeVerb verb = new();
             verb.Text = Loc.GetString("comp-solution-transfer-verb-amount", ("amount", amount));
             verb.Category = VerbCategory.SetTransferAmount;

--- a/Content.Shared/Chemistry/EntitySystems/SolutionTransferSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SolutionTransferSystem.cs
@@ -65,28 +65,14 @@ public sealed class SolutionTransferSystem : EntitySystem
             Priority = 1
         });
 
-        // Build the clickable amounts: the standard presets within the container's range, plus the
-        // container's own min and max so the exact bounds are always selectable even when they aren't
-        // one of the standard presets (e.g. a 40u cap that sits between the 25 and 50 presets).
-        var amounts = new List<FixedPoint2>();
-        foreach (var amount in DefaultTransferAmounts)
-        {
-            if (amount >= ent.Comp.MinimumTransferAmount && amount <= ent.Comp.MaximumTransferAmount)
-                amounts.Add(amount);
-        }
-
-        if (!amounts.Contains(ent.Comp.MinimumTransferAmount))
-            amounts.Add(ent.Comp.MinimumTransferAmount);
-        if (!amounts.Contains(ent.Comp.MaximumTransferAmount))
-            amounts.Add(ent.Comp.MaximumTransferAmount);
-
-        amounts.Sort((a, b) => a > b ? 1 : a < b ? -1 : 0);
-
         // Add specific transfer verbs according to the container's size
         var priority = 0;
         var user = args.User;
-        foreach (var amount in amounts)
+        foreach (var amount in DefaultTransferAmounts)
         {
+            if (amount < ent.Comp.MinimumTransferAmount || amount > ent.Comp.MaximumTransferAmount)
+                continue;
+
             AlternativeVerb verb = new();
             verb.Text = Loc.GetString("comp-solution-transfer-verb-amount", ("amount", amount));
             verb.Category = VerbCategory.SetTransferAmount;

--- a/Content.Shared/Fluids/Components/SprayComponent.cs
+++ b/Content.Shared/Fluids/Components/SprayComponent.cs
@@ -15,6 +15,14 @@ public sealed partial class SprayComponent : Component
     [DataField]
     public FixedPoint2 TransferAmount = 10;
 
+    /// <summary>
+    /// If true, the amount sprayed per use is taken from this entity's <c>SolutionTransfer</c> component
+    /// (letting the player pick it via the "set transfer amount" context verb) instead of the fixed
+    /// <see cref="TransferAmount"/> above. Has no effect if the entity has no SolutionTransfer component.
+    /// </summary>
+    [DataField]
+    public bool UseSolutionTransferAmount;
+
     [DataField]
     public float SprayDistance = 3.5f;
 

--- a/Content.Shared/Fluids/Components/SprayComponent.cs
+++ b/Content.Shared/Fluids/Components/SprayComponent.cs
@@ -15,14 +15,6 @@ public sealed partial class SprayComponent : Component
     [DataField]
     public FixedPoint2 TransferAmount = 10;
 
-    /// <summary>
-    /// If true, the amount sprayed per use is taken from this entity's <c>SolutionTransfer</c> component
-    /// (letting the player pick it via the "set transfer amount" context verb) instead of the fixed
-    /// <see cref="TransferAmount"/> above. Has no effect if the entity has no SolutionTransfer component.
-    /// </summary>
-    [DataField]
-    public bool UseSolutionTransferAmount;
-
     [DataField]
     public float SprayDistance = 3.5f;
 

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
@@ -80,6 +80,14 @@
     sprayDistance: 4.5
     spraySound:
       path: /Audio/Effects/spray2.ogg
+    # The mega spray bottle's spray amount is player-selectable via the "set transfer amount"
+    # context verb (SolutionTransfer below).
+    useSolutionTransferAmount: true
+  - type: SolutionTransfer
+    transferAmount: 15
+    minTransferAmount: 5
+    maxTransferAmount: 40
+    canChangeTransferAmount: true
 
 - type: entity
   parent: SprayBottle

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/spray.yml
@@ -80,14 +80,6 @@
     sprayDistance: 4.5
     spraySound:
       path: /Audio/Effects/spray2.ogg
-    # The mega spray bottle's spray amount is player-selectable via the "set transfer amount"
-    # context verb (SolutionTransfer below).
-    useSolutionTransferAmount: true
-  - type: SolutionTransfer
-    transferAmount: 15
-    minTransferAmount: 5
-    maxTransferAmount: 40
-    canChangeTransferAmount: true
 
 - type: entity
   parent: SprayBottle


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Gave the unique ability to the Mega Sprayer to pick the amount it sprays (up to a cap)

## Why / Balance
Wanted to give it a unique ability as it's the "mega" version but mostly since some aspects of the game benefit from the player fine tuning the spray

## Technical details
- Mega spray can now pick the units in it's spray
- Change the "pick solution amount" in context menu (prob not the correct name for what it is) to now show the min and max in case it wasn't on the pre-defined list of options


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an in-game showcase.

**Changelog**
:cl:
- Tweaked the context menu to now show min and max (if it wouldn't show before)
- Mega Spray can now pick the units it sprays


## DISCLAIMER
AI was used for the following
- Debug
- Learning the system
- Code comments