### PR TITLE
Added emote triggers and effects

### DIFF
--- a/Content.Server/_Persistence14/Xenoarchaeology/Artifact/XAE/Components/ForcedEmoteFitComponent.cs
+++ b/Content.Server/_Persistence14/Xenoarchaeology/Artifact/XAE/Components/ForcedEmoteFitComponent.cs
@@ -1,0 +1,25 @@
+using Content.Server.Xenoarchaeology.Artifact.XAE;
+using Content.Shared.Chat.Prototypes;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.Xenoarchaeology.Artifact.XAE.Components;
+
+/// <summary>
+/// Tracks an ongoing forced-emote "fit" applied by <see cref="XAEForcedEmoteComponent"/>. Holds the
+/// AutoEmote to stop and when the fit ends, at which point both are removed.
+/// </summary>
+[RegisterComponent, Access(typeof(XAEForcedEmoteSystem))]
+public sealed partial class ForcedEmoteFitComponent : Component
+{
+    /// <summary>
+    /// The auto-emote to remove when the fit ends.
+    /// </summary>
+    [DataField]
+    public ProtoId<AutoEmotePrototype> AutoEmote;
+
+    /// <summary>
+    /// When the fit ends and the mob stops emoting.
+    /// </summary>
+    [DataField]
+    public TimeSpan EndTime;
+}

--- a/Content.Server/_Persistence14/Xenoarchaeology/Artifact/XAE/Components/ForcedEmoteFitComponent.cs
+++ b/Content.Server/_Persistence14/Xenoarchaeology/Artifact/XAE/Components/ForcedEmoteFitComponent.cs
@@ -6,7 +6,7 @@ namespace Content.Server.Xenoarchaeology.Artifact.XAE.Components;
 
 /// <summary>
 /// Tracks an ongoing forced-emote "fit" applied by <see cref="XAEForcedEmoteComponent"/>. Holds the
-/// AutoEmote to stop and when the fit ends, at which point both are removed.
+/// AutoEmote to stop and when the fit ends, at which point both are removed as they are pointless.
 /// </summary>
 [RegisterComponent, Access(typeof(XAEForcedEmoteSystem))]
 public sealed partial class ForcedEmoteFitComponent : Component

--- a/Content.Server/_Persistence14/Xenoarchaeology/Artifact/XAE/Components/XAEForcedEmoteComponent.cs
+++ b/Content.Server/_Persistence14/Xenoarchaeology/Artifact/XAE/Components/XAEForcedEmoteComponent.cs
@@ -1,0 +1,34 @@
+using Content.Server.Xenoarchaeology.Artifact.XAE;
+using Content.Shared.Chat.Prototypes;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.Xenoarchaeology.Artifact.XAE.Components;
+
+/// <summary>
+/// Xeno artifact effect: forces every alive mob within <see cref="Radius"/> into a repeated emote
+/// "fit" (e.g. uncontrollable laughter) for <see cref="Duration"/>. Line of sight is not required.
+/// The repeat interval and per-tick probability come from the referenced <see cref="AutoEmote"/>
+/// prototype, reusing the game's AutoEmote machinery (as used by cluwnes/zombies/etc.).
+/// </summary>
+[RegisterComponent, Access(typeof(XAEForcedEmoteSystem))]
+public sealed partial class XAEForcedEmoteComponent : Component
+{
+    /// <summary>
+    /// The auto-emote forced onto affected mobs. It defines which emote, the interval, and the
+    /// per-interval probability. Keep its `force` false so only mobs able to perform the emote do.
+    /// </summary>
+    [DataField(required: true)]
+    public ProtoId<AutoEmotePrototype> AutoEmote;
+
+    /// <summary>
+    /// Radius (in tiles) around the artifact within which mobs are affected. Line of sight is ignored.
+    /// </summary>
+    [DataField]
+    public float Radius = 5f;
+
+    /// <summary>
+    /// How long the fit lasts. AutoEmote has no lifetime of its own, so this system times it out.
+    /// </summary>
+    [DataField]
+    public TimeSpan Duration = TimeSpan.FromSeconds(20);
+}

--- a/Content.Server/_Persistence14/Xenoarchaeology/Artifact/XAE/XAEForcedEmoteSystem.cs
+++ b/Content.Server/_Persistence14/Xenoarchaeology/Artifact/XAE/XAEForcedEmoteSystem.cs
@@ -1,0 +1,71 @@
+using Content.Server.Chat;
+using Content.Server.Chat.Systems;
+using Content.Server.Xenoarchaeology.Artifact.XAE.Components;
+using Content.Shared.Mobs.Systems;
+using Content.Shared.Xenoarchaeology.Artifact;
+using Content.Shared.Xenoarchaeology.Artifact.XAE;
+using Robust.Shared.Timing;
+
+namespace Content.Server.Xenoarchaeology.Artifact.XAE;
+
+/// <summary>
+/// System for a xeno artifact effect that forces nearby mobs into a repeated emote "fit"
+/// (e.g. uncontrollable laughter) for a fixed duration. Line of sight is ignored. The repeat itself
+/// (interval + probability) is driven by the game's AutoEmote machinery; this system only applies
+/// the auto-emote to living mobs in range and removes it again once the duration elapses.
+/// </summary>
+public sealed class XAEForcedEmoteSystem : BaseXAESystem<XAEForcedEmoteComponent>
+{
+    [Dependency] private readonly EntityLookupSystem _lookup = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly AutoEmoteSystem _autoEmote = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
+
+    /// <summary> Pre-allocated and re-used collection. </summary>
+    private readonly HashSet<EntityUid> _entities = new();
+
+    /// <inheritdoc/>
+    protected override void OnActivated(Entity<XAEForcedEmoteComponent> ent, ref XenoArtifactNodeActivatedEvent args)
+    {
+        var comp = ent.Comp;
+        var endTime = _timing.CurTime + comp.Duration;
+
+        _entities.Clear();
+        _lookup.GetEntitiesInRange(args.Coordinates, comp.Radius, _entities);
+        foreach (var mob in _entities)
+        {
+            // Only living mobs are affected.
+            if (!_mobState.IsAlive(mob))
+                continue;
+
+            // Reuse the game's AutoEmote timer to drive the repeat. Because the AutoEmote prototype is
+            // non-forced, only mobs that can actually perform the emote will - anything that can't
+            // (wrong species, muzzled, etc.) is silently skipped, matching how weh / laughing gas act.
+            EnsureComp<AutoEmoteComponent>(mob);
+            _autoEmote.AddEmote(mob, comp.AutoEmote);
+
+            // AutoEmote has no lifetime of its own, so we time the fit out ourselves.
+            var fit = EnsureComp<ForcedEmoteFitComponent>(mob);
+            fit.AutoEmote = comp.AutoEmote;
+            fit.EndTime = endTime; // re-triggering refreshes the fit
+        }
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var now = _timing.CurTime;
+        var query = EntityQueryEnumerator<ForcedEmoteFitComponent>();
+        while (query.MoveNext(out var uid, out var fit))
+        {
+            if (now < fit.EndTime)
+                continue;
+
+            // removeEmpty (default true) also drops the AutoEmoteComponent, unless the mob has other
+            // auto-emotes of its own (e.g. a cluwne), which are left untouched.
+            _autoEmote.RemoveEmote(uid, fit.AutoEmote);
+            RemCompDeferred<ForcedEmoteFitComponent>(uid);
+        }
+    }
+}

--- a/Content.Shared/_Persistence14/Xenoarchaeology/Artifact/XAT/Components/XATEmoteComponent.cs
+++ b/Content.Shared/_Persistence14/Xenoarchaeology/Artifact/XAT/Components/XATEmoteComponent.cs
@@ -1,0 +1,25 @@
+using Content.Shared.Chat.Prototypes;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared.Xenoarchaeology.Artifact.XAT.Components;
+
+/// <summary>
+/// This is used for a xenoarch trigger that activates when a mob performs an emote nearby
+/// (e.g. laughing, sighing, sneezing).
+/// </summary>
+[RegisterComponent, NetworkedComponent, Access(typeof(XATEmoteSystem)), AutoGenerateComponentState]
+public sealed partial class XATEmoteComponent : Component
+{
+    /// <summary>
+    /// Range within which the artifact listens for emotes.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float Range = 5;
+
+    /// <summary>
+    /// Emotes that can activate this trigger. If empty, any emote works.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public HashSet<ProtoId<EmotePrototype>> Emotes = new();
+}

--- a/Content.Shared/_Persistence14/Xenoarchaeology/Artifact/XAT/XATEmoteSystem.cs
+++ b/Content.Shared/_Persistence14/Xenoarchaeology/Artifact/XAT/XATEmoteSystem.cs
@@ -1,0 +1,54 @@
+using Content.Shared.Chat;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Xenoarchaeology.Artifact.Components;
+using Content.Shared.Xenoarchaeology.Artifact.XAT.Components;
+
+namespace Content.Shared.Xenoarchaeology.Artifact.XAT;
+
+/// <summary>
+/// System for a xeno artifact trigger that requires a mob to perform an emote near the artifact.
+/// </summary>
+public sealed class XATEmoteSystem : BaseXATSystem<XATEmoteComponent>
+{
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+
+    private EntityQuery<XenoArtifactComponent> _xenoArtifactQuery;
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _xenoArtifactQuery = GetEntityQuery<XenoArtifactComponent>();
+
+        // EmoteEvent is raised (directed) on the emoting entity, not on the artifact, so we can't use
+        // the artifact event-relay here. Every mob has MobStateComponent, so a directed subscription
+        // on it catches any mob's emote and hands us the emoter directly.
+        SubscribeLocalEvent<MobStateComponent, EmoteEvent>(OnEmote);
+    }
+
+    private void OnEmote(Entity<MobStateComponent> ent, ref EmoteEvent args)
+    {
+        var emoterCoords = Transform(ent).Coordinates;
+
+        var query = EntityQueryEnumerator<XATEmoteComponent, XenoArtifactNodeComponent>();
+        while (query.MoveNext(out var uid, out var comp, out var node))
+        {
+            if (node.Attached == null)
+                continue;
+
+            // An empty Emotes set means any emote triggers it; otherwise only the listed emotes count.
+            if (comp.Emotes.Count > 0 && !comp.Emotes.Contains(args.Emote.ID))
+                continue;
+
+            var artifact = _xenoArtifactQuery.Get(node.Attached.Value);
+
+            if (!CanTrigger(artifact, (uid, node)))
+                continue;
+
+            var artifactCoords = Transform(artifact).Coordinates;
+            if (_transform.InRange(emoterCoords, artifactCoords, comp.Range))
+                Trigger(artifact, (uid, comp, node));
+        }
+    }
+}

--- a/Resources/Locale/en-US/xenoarchaeology/artifact-hints.ftl
+++ b/Resources/Locale/en-US/xenoarchaeology/artifact-hints.ftl
@@ -68,6 +68,17 @@ xenoarch-trigger-tip-blood = Blood
 xenoarch-trigger-tip-throw = Being thrown
 xenoarch-trigger-tip-death = Death
 xenoarch-trigger-tip-magnet = Magnetic waves
+# _Persistence14 content: emote trigger tips
+xenoarch-trigger-tip-laugh = Laughter
+xenoarch-trigger-tip-sigh = A weary sigh
+xenoarch-trigger-tip-sneeze = A sneeze
+xenoarch-trigger-tip-cough = A cough
+xenoarch-trigger-tip-whistle = Whistling
+xenoarch-trigger-tip-cry = Tears
+xenoarch-trigger-tip-clap = Applause
+xenoarch-trigger-tip-yawn = A yawn
+xenoarch-trigger-tip-scream = A scream
+# end _Persistence14 content
 
 ### Description hints
 xenoarch-trigger-examine-wrenching = There's a loose bit spinning around.

--- a/Resources/Prototypes/XenoArch/effect_tables.yml
+++ b/Resources/Prototypes/XenoArch/effect_tables.yml
@@ -4,7 +4,7 @@
     children:
     - !type:NestedSelector
       tableId: XenoArtifactEffectsRoot
-      weight: 403.0 # Total weights of the table so distribution remains even
+      weight: 483.0 # Total weights of the table so distribution remains even
     # Eventually full size only artifact effects will go here
 
 - type: entityTable
@@ -13,7 +13,7 @@
     children:
     - !type:NestedSelector
       tableId: XenoArtifactEffectsMain
-      weight: 425.0 # Total weights of the table so distribution remains even
+      weight: 505.0 # Total weights of the table so distribution remains even
     # Eventually full size only artifact effects will go here
 
 - type: entityTable
@@ -22,7 +22,7 @@
     children:
     - !type:NestedSelector
       tableId: XenoArtifactEffectsDeep
-      weight: 337.0 # Total weights of the table so distribution remains even
+      weight: 417.0 # Total weights of the table so distribution remains even
     # Eventually full size only artifact effects will go here
 
 - type: entityTable
@@ -31,7 +31,7 @@
     children:
     - !type:NestedSelector
       tableId: XenoArtifactEffectsRoot
-      weight: 403.0 # Total weights of the table so distribution remains even
+      weight: 483.0 # Total weights of the table so distribution remains even
     - !type:NestedSelector
       tableId: XenoArtifactEffectsRootHandheldOnly
       weight: 54.0 # Total weights of the table so distribution remains even
@@ -42,7 +42,7 @@
     children:
     - !type:NestedSelector
       tableId: XenoArtifactEffectsMain
-      weight: 425.0 # Total weights of the table so distribution remains even
+      weight: 505.0 # Total weights of the table so distribution remains even
     - !type:NestedSelector
       tableId: XenoArtifactEffectsMainHandheldOnly
       weight: 37.0 # Total weights of the table so distribution remains even
@@ -53,7 +53,7 @@
     children:
     - !type:NestedSelector
       tableId: XenoArtifactEffectsDeep
-      weight: 337.0 # Total weights of the table so distribution remains even
+      weight: 417.0 # Total weights of the table so distribution remains even
     - !type:NestedSelector
       tableId: XenoArtifactEffectsDeepHandheldOnly
       weight: 30.0 # Total weights of the table so distribution remains even
@@ -62,6 +62,24 @@
   id: XenoArtifactEffectsRoot
   table: !type:GroupSelector
     children:
+    # _Persistence14 content: forced-emote effects (common tier, weight 10 like most effects)
+    - id: XenoArtifactEffectLaughingFit
+      weight: 10.0
+    - id: XenoArtifactEffectSighingFit
+      weight: 10.0
+    - id: XenoArtifactEffectSneezingFit
+      weight: 10.0
+    - id: XenoArtifactEffectCoughingFit
+      weight: 10.0
+    - id: XenoArtifactEffectWhistlingFit
+      weight: 10.0
+    - id: XenoArtifactEffectCryingFit
+      weight: 10.0
+    - id: XenoArtifactEffectYawningFit
+      weight: 10.0
+    - id: XenoArtifactEffectScreamingFit
+      weight: 10.0
+    # end _Persistence14 content
     - id: XenoArtifactAnomalySpawn
       weight: 1.0
     - id: XenoArtifactArtifactSpawn
@@ -209,7 +227,7 @@
     - id: XenoArtifactRawMaterialSpawnUraniumFew
       weight: 10.0
     - id: XenoArtifactRawMaterialSpawnUraniumMore
-      weight: 1.0 
+      weight: 1.0
     - id: XenoArtifactRawMaterialSpawnUraniumMany
       weight: 0.0 # Here for parity
     - id: XenoArtifactStealth
@@ -225,6 +243,24 @@
   id: XenoArtifactEffectsMain
   table: !type:GroupSelector
     children:
+    # _Persistence14 content: forced-emote effects
+    - id: XenoArtifactEffectLaughingFit
+      weight: 7.0
+    - id: XenoArtifactEffectSighingFit
+      weight: 7.0
+    - id: XenoArtifactEffectSneezingFit
+      weight: 7.0
+    - id: XenoArtifactEffectCoughingFit
+      weight: 7.0
+    - id: XenoArtifactEffectWhistlingFit
+      weight: 7.0
+    - id: XenoArtifactEffectCryingFit
+      weight: 7.0
+    - id: XenoArtifactEffectYawningFit
+      weight: 7.0
+    - id: XenoArtifactEffectScreamingFit
+      weight: 7.0
+    # end _Persistence14 content
     - id: XenoArtifactAnomalySpawn
       weight: 1.0
     - id: XenoArtifactArtifactSpawn
@@ -388,6 +424,24 @@
   id: XenoArtifactEffectsDeep
   table: !type:GroupSelector
     children:
+    # _Persistence14 content: forced-emote effects (common tier, weight 10 like most effects)
+    - id: XenoArtifactEffectLaughingFit
+      weight: 4.0
+    - id: XenoArtifactEffectSighingFit
+      weight: 4.0
+    - id: XenoArtifactEffectSneezingFit
+      weight: 4.0
+    - id: XenoArtifactEffectCoughingFit
+      weight: 4.0
+    - id: XenoArtifactEffectWhistlingFit
+      weight: 4.0
+    - id: XenoArtifactEffectCryingFit
+      weight: 4.0
+    - id: XenoArtifactEffectYawningFit
+      weight: 4.0
+    - id: XenoArtifactEffectScreamingFit
+      weight: 4.0
+    # end _Persistence14 content
     - id: XenoArtifactAnomalySpawn
       weight: 3.0
     - id: XenoArtifactArtifactSpawn

--- a/Resources/Prototypes/XenoArch/effects.yml
+++ b/Resources/Prototypes/XenoArch/effects.yml
@@ -239,7 +239,7 @@
       - Prying
       speedModifier: 2 # Very powerful to balance out the desire to sell or scrap for points
       useSound: /Audio/Items/crowbar.ogg
-    
+
 
 - type: entity
   id: XenoArtifactToolScrewdriver
@@ -404,6 +404,92 @@
       - behavior: Pulsing
         changeSound:
           path: /Audio/Items/change_drill.ogg
+
+# _Persistence14 content
+# Forced-emote effects: on activation, every living mob within `radius` (line of sight ignored) that
+# can perform the emote is made to repeat it for `duration` seconds. The repeat cadence/probability
+# come from the referenced AutoEmote prototype (see _Persistence14/Voice/auto_emotes.yml).
+# To add another, pair a new autoEmote prototype with a copy of one of these (new id + autoEmote).
+- type: entity
+  id: XenoArtifactEffectLaughingFit
+  parent: BaseXenoArtifactEffect
+  description: Induces uncontrollable laughter in nearby minds
+  components:
+  - type: XAEForcedEmote
+    autoEmote: XenoArchForcedLaugh
+    radius: 5
+    duration: 10
+
+- type: entity
+  id: XenoArtifactEffectSighingFit
+  parent: BaseXenoArtifactEffect
+  description: Induces uncontrollable sighing in nearby minds
+  components:
+  - type: XAEForcedEmote
+    autoEmote: XenoArchForcedSigh
+    radius: 5
+    duration: 10
+
+- type: entity
+  id: XenoArtifactEffectSneezingFit
+  parent: BaseXenoArtifactEffect
+  description: Induces uncontrollable sneezing in nearby minds
+  components:
+  - type: XAEForcedEmote
+    autoEmote: XenoArchForcedSneeze
+    radius: 5
+    duration: 10
+
+- type: entity
+  id: XenoArtifactEffectCoughingFit
+  parent: BaseXenoArtifactEffect
+  description: Induces uncontrollable coughing in nearby minds
+  components:
+  - type: XAEForcedEmote
+    autoEmote: XenoArchForcedCough
+    radius: 5
+    duration: 10
+
+- type: entity
+  id: XenoArtifactEffectWhistlingFit
+  parent: BaseXenoArtifactEffect
+  description: Induces uncontrollable whistling in nearby minds
+  components:
+  - type: XAEForcedEmote
+    autoEmote: XenoArchForcedWhistle
+    radius: 5
+    duration: 10
+
+- type: entity
+  id: XenoArtifactEffectCryingFit
+  parent: BaseXenoArtifactEffect
+  description: Induces uncontrollable crying in nearby minds
+  components:
+  - type: XAEForcedEmote
+    autoEmote: XenoArchForcedCry
+    radius: 5
+    duration: 10
+
+- type: entity
+  id: XenoArtifactEffectYawningFit
+  parent: BaseXenoArtifactEffect
+  description: Induces uncontrollable yawning in nearby minds
+  components:
+  - type: XAEForcedEmote
+    autoEmote: XenoArchForcedYawn
+    radius: 5
+    duration: 10
+
+- type: entity
+  id: XenoArtifactEffectScreamingFit
+  parent: BaseXenoArtifactEffect
+  description: Induces uncontrollable screaming in nearby minds
+  components:
+  - type: XAEForcedEmote
+    autoEmote: XenoArchForcedScream
+    radius: 5
+    duration: 10
+# end _Persistence14 content
 
 - type: entity
   id: XenoArtifactEffectBadFeeling
@@ -1377,7 +1463,7 @@
           range: 3, 8
         children:
         - id: SheetGlass1
-  
+
 - type: entity
   id: XenoArtifactMaterialSpawnGlassMany
   parent: BaseXenoArtifactEffect
@@ -1432,7 +1518,7 @@
           range: 3, 8
         children:
         - id: SheetSteel1
-  
+
 - type: entity
   id: XenoArtifactMaterialSpawnSteelMany
   parent: BaseXenoArtifactEffect
@@ -1487,7 +1573,7 @@
           range: 3, 8
         children:
         - id: SheetPlastic1
-  
+
 - type: entity
   id: XenoArtifactMaterialSpawnPlasticMany
   parent: BaseXenoArtifactEffect
@@ -1597,7 +1683,7 @@
         Heat: -50
         Cold: -50
         Shock: -50
-  
+
 - type: entity
   id: XenoArtifactHealRare
   parent: BaseXenoArtifactEffect

--- a/Resources/Prototypes/XenoArch/triggers.yml
+++ b/Resources/Prototypes/XenoArch/triggers.yml
@@ -16,6 +16,17 @@
     TriggerPressureHigh: 0.5
     TriggerPressureLow: 1
     TriggerExamine: 1
+    # _Persistence14 content: emote triggers (common tier, weight 1 like most triggers)
+    TriggerLaugh: 1
+    TriggerSigh: 1
+    TriggerSneeze: 1
+    TriggerCough: 1
+    TriggerWhistle: 1
+    TriggerCry: 1
+    TriggerClap: 1
+    TriggerYawn: 1
+    TriggerScream: 1
+    # end _Persistence14 content
     TriggerBluntDamage: 1
     TriggerPierceDamage: 1
     TriggerWrenching: 0.5
@@ -184,6 +195,82 @@
   components:
   - type: XATExamine
 
+# _Persistence14 content
+# Emote triggers. Each is its own trigger keyed to a single emote via XATEmote's `emotes` list.
+# To add another, copy one of these with a new id + emote + a matching tip loc string.
+- type: xenoArchTrigger
+  id: TriggerLaugh
+  tip: xenoarch-trigger-tip-laugh
+  components:
+  - type: XATEmote
+    emotes:
+    - Laugh
+
+- type: xenoArchTrigger
+  id: TriggerSigh
+  tip: xenoarch-trigger-tip-sigh
+  components:
+  - type: XATEmote
+    emotes:
+    - Sigh
+
+- type: xenoArchTrigger
+  id: TriggerSneeze
+  tip: xenoarch-trigger-tip-sneeze
+  components:
+  - type: XATEmote
+    emotes:
+    - Sneeze
+
+- type: xenoArchTrigger
+  id: TriggerCough
+  tip: xenoarch-trigger-tip-cough
+  components:
+  - type: XATEmote
+    emotes:
+    - Cough
+
+- type: xenoArchTrigger
+  id: TriggerWhistle
+  tip: xenoarch-trigger-tip-whistle
+  components:
+  - type: XATEmote
+    emotes:
+    - Whistle
+
+- type: xenoArchTrigger
+  id: TriggerCry
+  tip: xenoarch-trigger-tip-cry
+  components:
+  - type: XATEmote
+    emotes:
+    - Crying
+
+- type: xenoArchTrigger
+  id: TriggerClap
+  tip: xenoarch-trigger-tip-clap
+  components:
+  - type: XATEmote
+    emotes:
+    - Clap
+
+- type: xenoArchTrigger
+  id: TriggerYawn
+  tip: xenoarch-trigger-tip-yawn
+  components:
+  - type: XATEmote
+    emotes:
+    - Yawn
+
+- type: xenoArchTrigger
+  id: TriggerScream
+  tip: xenoarch-trigger-tip-scream
+  components:
+  - type: XATEmote
+    emotes:
+    - Scream
+# end _Persistence14 content
+
 - type: xenoArchTrigger
   id: TriggerBruteDamage
   tip: xenoarch-trigger-tip-blunt-damage
@@ -262,7 +349,7 @@
       Slash: 20
   - type: XATExaminableText
     examineText: xenoarch-trigger-examine-slicing
-  
+
 - type: xenoArchTrigger
   id: TriggerCutting
   tip: xenoarch-trigger-tip-cutting
@@ -274,7 +361,7 @@
       Slash: 20
   - type: XATExaminableText
     examineText: xenoarch-trigger-examine-cutting
-  
+
 - type: xenoArchTrigger
   id: TriggerRolling
   tip: xenoarch-trigger-tip-rolling

--- a/Resources/Prototypes/_Persistence14/Voice/auto_emotes.yml
+++ b/Resources/Prototypes/_Persistence14/Voice/auto_emotes.yml
@@ -1,0 +1,52 @@
+# _Persistence14 content
+# AutoEmote prototypes that drive the artifact forced-emote effects (XAEForcedEmote).
+# Each affected mob attempts this emote every `interval` seconds with `chance` probability of it
+# firing. `force` is left default (false), so a mob that cannot perform the emote is skipped.
+# Add a new forced-emote effect by pairing a new entry here with an effect entity in effects.yml.
+- type: autoEmote
+  id: XenoArchForcedLaugh
+  emote: Laugh
+  interval: 0.2
+  chance: 0.3
+
+- type: autoEmote
+  id: XenoArchForcedSigh
+  emote: Sigh
+  interval: 0.2
+  chance: 0.3
+
+- type: autoEmote
+  id: XenoArchForcedSneeze
+  emote: Sneeze
+  interval: 0.2
+  chance: 0.3
+
+- type: autoEmote
+  id: XenoArchForcedCough
+  emote: Cough
+  interval: 0.2
+  chance: 0.3
+
+- type: autoEmote
+  id: XenoArchForcedWhistle
+  emote: Whistle
+  interval: 0.2
+  chance: 0.3
+
+- type: autoEmote
+  id: XenoArchForcedCry
+  emote: Crying
+  interval: 0.2
+  chance: 0.3
+
+- type: autoEmote
+  id: XenoArchForcedYawn
+  emote: Yawn
+  interval: 0.2
+  chance: 0.3
+
+- type: autoEmote
+  id: XenoArchForcedScream
+  emote: Scream
+  interval: 0.2
+  chance: 0.3


### PR DESCRIPTION
## About the PR
Adds a new **emote** category to xenoarchaeology artifacts, on both sides of the loop:

- **Triggers** — performing one of the common, everyone-has-them emotes near an artifact triggers its node. Nine are included: laugh, sigh, sneeze, cough, whistle, cry, clap, yawn, and scream. Each is its own trigger.
- **Effects** — activating a node forces every living person in range (line of sight not required) into an uncontrollable emote "fit" for a few seconds. Eight are included, matching the triggers minus clap: laughing, sighing, sneezing, coughing, whistling, crying, yawning, and screaming fits.

## Why / Balance
Xenoarch is about discovering an artifact's triggers, but almost every existing trigger needs a tool, chemical, gas, or environmental setup. Emotes add an approachable, roleplay-flavored category that anyone can attempt with no equipment, which is nice for early exploration and for non-scientists poking at artifacts. Both the triggers and the effects sit at the **common** weight tier (triggers weight 1, effects weight 10), so they're a normal part of the pool rather than rare or dominant.

The effects are purely comedic/social — they deal no damage and only make people emote — so they're a low-risk "annoyance" effect in the same spirit as the existing telepathic/shuffle effects. Only mobs that can actually perform the emote are affected, and the fit is short (10s) and self-clears.

Also, we need common/bloat triggers so not everything needs to give materials or polymorph you. It feels like that is all you get now a days x-x

## Technical details
Both features reuse existing framework rather than adding new plumbing:

- **`XATEmote` (trigger)** — shared component (`Range` + optional `emotes` allowlist) + `XATEmoteSystem : BaseXATSystem<XATEmoteComponent>`. Emotes are raised on the emoter, not the artifact, so instead of the artifact event-relay the system takes a directed `EmoteEvent` subscription (via `MobStateComponent`), then does a proximity check against artifact nodes — modeled on `XATDeathSystem`. One trigger prototype per emote keys off the `emotes` list.
- **`XAEForcedEmote` (effect)** — server component (`AutoEmote` proto ref + `Radius` + `Duration`) + `XAEForcedEmoteSystem : BaseXAESystem<XAEForcedEmoteComponent>`. On node activation it does an `EntityLookupSystem` range query and, for each living mob, drives the repeated emote through the existing **`AutoEmote`** system (`AutoEmoteSystem.AddEmote`) — reusing its interval + probability, the same machinery cluwnes/zombies use. A small `ForcedEmoteFitComponent` tracks the end time and removes the auto-emote when the duration elapses; re-triggering refreshes it. Non-forced auto-emotes mean species that can't perform the emote are skipped.
- New `autoEmote` prototypes drive cadence/probability (`interval: 0.2`, `chance: 0.3`, `duration: 10` → ~15 emotes/fit on average).
- Triggers and effects are registered in the existing weighted trigger/effect tables; hint tips added to `artifact-hints.ftl`.
- All fork-specific C# and the new `autoEmote` prototypes live under `_Persistence14/` paths.

Files:
- `Content.Shared/_Persistence14/Xenoarchaeology/Artifact/XAT/` — `XATEmoteComponent`, `XATEmoteSystem`
- `Content.Server/_Persistence14/Xenoarchaeology/Artifact/XAE/` — `XAEForcedEmoteComponent`, `ForcedEmoteFitComponent`, `XAEForcedEmoteSystem`
- `Resources/Prototypes/XenoArch/{triggers,effects,effect_tables}.yml`, `Resources/Prototypes/_Persistence14/Voice/auto_emotes.yml`, `Resources/Locale/en-US/xenoarchaeology/artifact-hints.ftl`

## Media
<!-- TODO: attach a clip of (1) an artifact unlocking from an emote trigger, and (2) a node activating a laughing/screaming fit on nearby players. -->

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an in-game showcase.

## Breaking changes
None. All added types are new (`XATEmote*`, `XAEForcedEmote*`, `ForcedEmoteFitComponent`); no existing components, prototypes, or APIs were renamed or removed.

:cl: Sendir
- add: Some artifacts can now be triggered by emoting near them (laugh, sigh, sneeze, cough, whistle, cry, clap, yawn, scream).
- add: Some artifacts can now afflict everyone nearby with an uncontrollable emote fit (laughing, sighing, sneezing, coughing, whistling, crying, yawning, or screaming).

## DISCLAIMER
AI was used for the following:
- Learning about existing systems
- Braindstorming the best approach
- Code comment
- PR writting

All things the AI did were checked and tested by me to make sure nothing out of the ordinary happened and to keep it within scope