### PR TITLE
Lathe prices test, fix existing price arbitrage recipes

### DIFF
--- a/Content.IntegrationTests/Tests/Lathe/LatheRecipeCostTest.cs
+++ b/Content.IntegrationTests/Tests/Lathe/LatheRecipeCostTest.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
 using Content.Server.Cargo.Systems;
+using Content.Shared.CCVar;
 using Content.Shared.Research.Prototypes;
+using Robust.Shared.Configuration;
 
 namespace Content.IntegrationTests.Tests.Lathe;
 
@@ -20,6 +22,7 @@ public sealed class LatheRecipeCostTest
         var proto = server.ProtoMan;
         var entMan = server.EntMan;
         var priceSystem = entMan.System<PricingSystem>();
+        var configMan = server.Resolve<IConfigurationManager>();
 
         var fails = new List<string>();
 
@@ -38,7 +41,7 @@ public sealed class LatheRecipeCostTest
                     if (material.IgnoreArbitrage)
                         ignoreRecipe = true;
 
-                    matPrice += material.Price * count;
+                    matPrice += material.Price * count * configMan.GetCVar(CCVars.PriceMult);
                 }
 
                 if (ignoreRecipe)
@@ -58,5 +61,7 @@ public sealed class LatheRecipeCostTest
             var msg = string.Join("\n", fails) + "\n" + "Following RecipePrototypes are giving Arbitrage when printed!";
             Assert.Fail(msg);
         }
+
+        await pair.CleanReturnAsync();
     }
 }

--- a/Content.IntegrationTests/Tests/Lathe/LatheRecipeCostTest.cs
+++ b/Content.IntegrationTests/Tests/Lathe/LatheRecipeCostTest.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using Content.Server.Cargo.Systems;
+using Content.Shared.Research.Prototypes;
+
+namespace Content.IntegrationTests.Tests.Lathe;
+
+[TestFixture]
+public sealed class LatheRecipeCostTest
+{
+    // This controls the limit of how much price arbitrage can be tolerated to not cause a test fail.
+    // Any lower than 10 is usually not worth enough to even print at all.
+    private const double Tolerance = 10;
+
+    [Test]
+    public async Task LatheRecipesNoArbitrageTest()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+
+        var server = pair.Server;
+        var proto = server.ProtoMan;
+        var entMan = server.EntMan;
+        var priceSystem = entMan.System<PricingSystem>();
+
+        var fails = new List<string>();
+
+        await server.WaitAssertion(() =>
+        {
+            var recipes = proto.EnumeratePrototypes<LatheRecipePrototype>();
+            foreach (var recipe in recipes)
+            {
+                var resultPrice = Math.Round(priceSystem.GetLatheRecipePrice(recipe));
+                var matPrice = 0.0;
+                bool ignoreRecipe = false;
+                foreach (var (materialId, count) in recipe.Materials)
+                {
+                    var material = proto.Index(materialId);
+
+                    if (material.IgnoreArbitrage)
+                        ignoreRecipe = true;
+
+                    matPrice += material.Price * count;
+                }
+
+                if (ignoreRecipe)
+                    continue;
+
+                matPrice = Math.Round(matPrice);
+
+                if (resultPrice > matPrice + Tolerance)
+                {
+                    fails.Add($"ID: {recipe.ID} Materials: {matPrice} Result: {resultPrice} Dif: {resultPrice - matPrice}");
+                }
+            }
+        });
+
+        if (fails.Count > 0)
+        {
+            var msg = string.Join("\n", fails) + "\n" + "Following RecipePrototypes are giving Arbitrage when printed!";
+            Assert.Fail(msg);
+        }
+    }
+}

--- a/Content.Shared/Materials/MaterialPrototype.cs
+++ b/Content.Shared/Materials/MaterialPrototype.cs
@@ -56,5 +56,14 @@ namespace Content.Shared.Materials
         /// </summary>
         [DataField(required: true)]
         public double Price = 0;
+
+        /// <summary>
+        /// Persistence Edit
+        /// If true, this material will be excluded from the LatheRecipeCostTest,
+        /// meaning the recipe can give price arbitrage when printed compared to the required materials.
+        /// Use this only for materials that can't be simply ordered in cargo (for example ore).
+        /// </summary>
+        [DataField]
+        public bool IgnoreArbitrage;
     }
 }

--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -291,7 +291,7 @@
   - type: ExplosionResistance
     damageCoefficient: 0.1
   - type: StaticPrice
-    price: 1000
+    price: 600
 
 #Special
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/backpacks.yml
@@ -291,7 +291,7 @@
   - type: ExplosionResistance
     damageCoefficient: 0.1
   - type: StaticPrice
-    price: 600
+    price: 150
 
 #Special
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpskirts.yml
@@ -521,8 +521,6 @@
     sprite: Clothing/Uniforms/Jumpskirt/operative_s.rsi
   - type: Clothing
     sprite: Clothing/Uniforms/Jumpskirt/operative_s.rsi
-  - type: StaticPrice
-    price: 500
 
 - type: entity
   parent: ClothingUniformSkirtBase

--- a/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -922,8 +922,6 @@
     sprite: Clothing/Uniforms/Jumpsuit/operative.rsi
   - type: Clothing
     sprite: Clothing/Uniforms/Jumpsuit/operative.rsi
-  - type: StaticPrice
-    price: 500
 
 - type: entity
   parent: ClothingUniformBase

--- a/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chemistry-vials.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chemistry-vials.yml
@@ -42,7 +42,7 @@
   - type: SolutionTransfer
     maxTransferAmount: 30
   - type: StaticPrice
-    price: 100
+    price: 40
   - type: Destructible
     thresholds:
     - trigger: &DamageTrigger100
@@ -88,7 +88,7 @@
   - type: SolutionTransfer
     maxTransferAmount: 10
   - type: StaticPrice
-    price: 50
+    price: 30
   - type: PhysicalComposition
     materialComposition:
       Glass: 10

--- a/Resources/Prototypes/Entities/Objects/Tools/pka_upgrade.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/pka_upgrade.yml
@@ -11,7 +11,7 @@
     size: Small
   - type: GunUpgrade
   - type: StaticPrice
-    price: 750
+    price: 700
   - type: Tag
     tags:
     - PKAUpgrade

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -460,6 +460,8 @@
     - type: Battery
       maxCharge: 10000
       startingCharge: 10000
+    - type: StaticPrice
+      price: 250
 
 - type: entity
   name: x-ray cannon

--- a/Resources/Prototypes/Reagents/Materials/glass.yml
+++ b/Resources/Prototypes/Reagents/Materials/glass.yml
@@ -52,7 +52,7 @@
   name: materials-reinforced-uranium-glass
   icon: { sprite: Objects/Materials/Sheets/glass.rsi, state: ruglass }
   color: "#2d872a"
-  price: 1.2 # $120 per. 2-2-1 mix of uranium, glass, and metal.
+  price: 1.1 # $110 per. 2-2-1 mix of uranium, glass, and metal.
 
 - type: material
   id: PhoronGlass

--- a/Resources/Prototypes/Reagents/Materials/glass.yml
+++ b/Resources/Prototypes/Reagents/Materials/glass.yml
@@ -52,7 +52,7 @@
   name: materials-reinforced-uranium-glass
   icon: { sprite: Objects/Materials/Sheets/glass.rsi, state: ruglass }
   color: "#2d872a"
-  price: 2.45 # $295 per. 2-2-1 mix of uranium, glass, and metal.
+  price: 1.2 # $120 per. 2-2-1 mix of uranium, glass, and metal.
 
 - type: material
   id: PhoronGlass

--- a/Resources/Prototypes/Reagents/Materials/materials.yml
+++ b/Resources/Prototypes/Reagents/Materials/materials.yml
@@ -32,7 +32,7 @@
   unit: materials-unit-sheet
   icon: { sprite: /Textures/Objects/Materials/materials.rsi, state: durathread }
   color: "#8291a1"
-  price: 0.6 # 1-1 mix of plastic and cloth.
+  price: 0.3 # 1-1 mix of plastic and cloth.
 
 - type: material
   id: Paper
@@ -107,7 +107,7 @@
   icon: { sprite: Objects/Materials/materials.rsi, state: cotton }
   color: "#cccccc"
   price: 0.02 #Who knew cotton was infinitely more valuable than silk
-  
+
 - type: material
   id: Pyrotton
   name: materials-pyrotton

--- a/Resources/Prototypes/Reagents/Materials/ores.yml
+++ b/Resources/Prototypes/Reagents/Materials/ores.yml
@@ -5,6 +5,7 @@
   unit: materials-unit-chunk
   icon: { sprite: Objects/Materials/ore.rsi, state: iron }
   price: 0.05
+  ignoreArbitrage: true
 
 - type: material
   id: RawQuartz
@@ -14,6 +15,7 @@
   icon: { sprite: Objects/Materials/ore.rsi, state: spacequartz }
   color: "#a8ccd7"
   price: 0.075
+  ignoreArbitrage: true
 
 - type: material
   id: RawGold
@@ -23,6 +25,7 @@
   icon: { sprite: Objects/Materials/ore.rsi, state: gold }
   color: "#FFD700"
   price: 0.2
+  ignoreArbitrage: true
 
 - type: material
   id: RawDiamond
@@ -32,6 +35,7 @@
   icon: { sprite: Objects/Materials/ore.rsi, state: diamond }
   color: "#C9D8F2"
   price: 0.5
+  ignoreArbitrage: true
 
 - type: material
   id: RawSilver
@@ -41,6 +45,7 @@
   icon: { sprite: Objects/Materials/ore.rsi, state: silver }
   color: "#C0C0C0"
   price: 0.15
+  ignoreArbitrage: true
 
 - type: material
   id: RawPlasma
@@ -50,6 +55,7 @@
   icon: { sprite: Objects/Materials/ore.rsi, state: plasma }
   color: "#7e009e"
   price: 0.2
+  ignoreArbitrage: true
 
 - type: material
   id: RawUranium
@@ -59,6 +65,7 @@
   icon: { sprite: Objects/Materials/ore.rsi, state: uranium }
   color: "#32a852"
   price: 0.2
+  ignoreArbitrage: true
 
 - type: material
   id: RawBananium
@@ -68,6 +75,7 @@
   icon: { sprite: Objects/Materials/ore.rsi, state: bananium }
   color: "#32a852"
   price: 0.2
+  ignoreArbitrage: true
 
 - type: material
   id: RawSalt
@@ -77,6 +85,7 @@
   icon: { sprite: Objects/Materials/ore.rsi, state: salt }
   color: "#f5e7d7"
   price: 0.075
+  ignoreArbitrage: true
 
 - type: material
   id: RawAluminum
@@ -86,6 +95,7 @@
   icon: { sprite: Objects/Materials/ore.rsi, state: aluminum }
   color: "#cfd8e3"
   price: 0.08
+  ignoreArbitrage: true
 
 - type: material
   id: RawCopper
@@ -95,6 +105,7 @@
   icon: { sprite: Objects/Materials/ore.rsi, state: copper }
   color: "#b87333"
   price: 0.09
+  ignoreArbitrage: true
 
 - type: material
   id: RawTin
@@ -104,6 +115,7 @@
   icon: { sprite: Objects/Materials/ore.rsi, state: tin }
   color: "#b0b8c6"
   price: 0.07
+  ignoreArbitrage: true
 
 - type: material
   id: RawTitanium
@@ -113,4 +125,4 @@
   icon: { sprite: Objects/Materials/ore.rsi, state: titanium }
   color: "#9aa7b1"
   price: 0.2
-
+  ignoreArbitrage: true


### PR DESCRIPTION
## About the PR
Added an integration test to detect lathe recipes that produce an item that costs more than the materials it is made out of.

## Why / Balance
Lathe printing is not an intended way of getting money. Also it's an objectively bad way of getting money from a gameplay perspective, since it doesn't reward the players with actual gameplay, but instead forces them to buy-print-sell on a constant loop without any risks or interesting interactions, which basically defines this tactic of getting money as Meta.

## Technical details
The test calculates the cost of the actual lathe recipe using the API method, and then sums the price of each material that is required to make the item. Any arbitrage lower than 10 credits is tolerated (you need insane dedication to make money off of this).
The test doesn't account for the price of the resulting reagents, because there are no recipes that use that feature yet.
Ore materials are ignored from the test because they can only be mined and can't be mass produced.

## Media
Nothing to show

**Changelog**
:cl: Rouden
- fix: Fixed some lathe recipies making items that cost more than the materials they are made out of. Lathe printing with materials that can be ordered from cargo is no longer profitable.