### PR TITLE
Tower-cap Sap

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -194,6 +194,13 @@
   id: Log
   parent: ProduceBase
   components:
+  # Persistence 14 - adds the ability to juice tower-cap logs for sap
+  - type: Extractable
+    juiceSolution:
+      reagents:
+      - ReagentId: Sap
+        Quantity: 1
+  # Persistence 14 - End
   - type: Sprite
     sprite: Objects/Specific/Hydroponics/towercap.rsi
   - type: Item


### PR DESCRIPTION
adds the ability to juice tower-cap logs into sap, since we don't have dionas

## About the PR
Tower-cap logs can be juiced into sap at a ratio of 1:1

## Why / Balance
No way to get sap

## Media
<img width="620" height="273" alt="Screenshot_29072026_031210" src="https://github.com/user-attachments/assets/9400552e-3a9c-4870-81c4-4b981880b2a6" />

## Breaking changes
None as far as i know

**Changelog**
added the ability to juice tower-cap logs into sap