### PR TITLE
Reduce minimum size for grids to show on radars, make small grids not show their IFF label.

### DIFF
--- a/Content.Shared/Shuttles/Systems/SharedShuttleSystem.IFF.cs
+++ b/Content.Shared/Shuttles/Systems/SharedShuttleSystem.IFF.cs
@@ -2,6 +2,8 @@ using System.Linq;
 using Content.Shared.Station.Components;
 using Content.Shared.Shuttles.Components;
 using JetBrains.Annotations;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Components;
 
 namespace Content.Shared.Shuttles.Systems;
 
@@ -37,6 +39,11 @@ public abstract partial class SharedShuttleSystem
         Resolve(gridUid, ref component, false);
 
         if (!self && component != null && (component.Flags & (IFFFlags.HideLabel | IFFFlags.Hide)) != 0x0)
+        {
+            return null;
+        }
+
+        if (component == null && TryComp(gridUid, out PhysicsComponent? physics) && physics.BodyType == BodyType.Dynamic && physics.Mass < 10f) // Persistence 14
         {
             return null;
         }

--- a/Content.Shared/Shuttles/Systems/SharedShuttleSystem.cs
+++ b/Content.Shared/Shuttles/Systems/SharedShuttleSystem.cs
@@ -143,7 +143,7 @@ public abstract partial class SharedShuttleSystem : EntitySystem
         if (!Resolve(gridUid, ref physics))
             return true;
 
-        if (physics.BodyType != BodyType.Static && physics.Mass < 10f)
+        if (physics.BodyType != BodyType.Static && physics.Mass < 2f) //Persistence 14: Reduced minimum mass to show on IFF consoles from 10 to 2.
         {
             return false;
         }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The minimum size required for a grid to show up on mass scanners has been reduced from 21 tiles to 5.

Grids smaller than 21 tiles will not show their name on mass scanners, unless they have been modified with an IFF console.

## Why / Balance
Makes it much harder to create shuttles that are invisible on radars, without cluttering mass scanners with labels for every single piece of space junk.

## Technical details
8 total lines of code changed.

## Media
[Screencast_20260811_231153.webm](https://github.com/user-attachments/assets/3d599ecc-7261-4361-9400-b90fb7db94ff)


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: The minimum size required for a grid to show up on mass scanners has been reduced from 21 tiles to 5.
- tweak: Grids smaller than 21 tiles will not show their names on mass scanners unless they were modified with an IFF console.
