### PR TITLE
Hotfix: Removes Tech Disk Terminal UI

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/techdiskterminal.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/techdiskterminal.yml
@@ -14,15 +14,6 @@
       state: unshaded
   - type: DiskConsole
   - type: ResearchClient
-  - type: ActivatableUI
-    key: enum.DiskConsoleUiKey.Key
-  - type: ActivatableUIRequiresPower
-  - type: UserInterface
-    interfaces:
-      enum.DiskConsoleUiKey.Key:
-        type: DiskConsoleBoundUserInterface
-      enum.ResearchClientUiKey.Key:
-        type: ResearchClientBoundUserInterface
   - type: ExtensionCableReceiver
   - type: Computer
     board: TechDiskComputerCircuitboard


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Disables the UI on the tech disk terminal

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Currently the gambling on tech disks breaks the big balance changes we made to research costs. When a T3 tech costs 100k research points, the 1k cost of a tech disk is trivial.

A larger rework of the tech disk terminal is coming to replace this functionality with something new. This is an intermediate measure.

## Technical details
<!-- Summary of code changes for easier review. -->
* Removes the activatable UI and UI components from the TechDiskTerminal entity prototype.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
No known breaking changes.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- remove: Tech disk terminal is now purely decorative (for now).
