### PR TITLE
Bugfix: Anomaly Generator Spawn Targeting

### DIFF
--- a/Content.Server/Anomaly/AnomalySystem.Generator.cs
+++ b/Content.Server/Anomaly/AnomalySystem.Generator.cs
@@ -161,14 +161,8 @@ public sealed partial class AnomalySystem
     private void OnGeneratingFinished(EntityUid uid, AnomalyGeneratorComponent component)
     {
         var xform = Transform(uid);
-
-        if (_station.GetStationInMap(xform.MapID) is not { } station ||
-            _station.GetLargestGrid(station) is not { } grid)
-        {
-            if (xform.GridUid == null)
-                return;
-            grid = xform.GridUid.Value;
-        }
+        if (xform.GridUid is not { } grid)
+            return;
 
         SpawnOnRandomGridLocation(grid, component.SpawnerPrototype);
         RemComp<GeneratingAnomalyGeneratorComponent>(uid);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Ensures that all anomalies created by an anomaly generator are generated on the grid containing the anomaly.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It's a tad baffling this wasn't the case before...

## Technical details
<!-- Summary of code changes for easier review. -->
Removed station/largest grid checks overwriting the generator's grid target.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
no known breaking changes

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Anomalies now properly generate on the generator's grid.
