### PR TITLE
Add Basic Survival gas masks to autolathe

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -142,6 +142,7 @@
     - CassetteTape
     - ReligionStatic
     - HydroponicsStatic
+    - GasMasksStatic # Persi14
   - type: EmagLatheRecipes
     emagStaticPacks:
     - SecurityAmmoStatic

--- a/Resources/Prototypes/_Persistence14/Recipes/Lathe/Packs/engineering.yml
+++ b/Resources/Prototypes/_Persistence14/Recipes/Lathe/Packs/engineering.yml
@@ -1,0 +1,5 @@
+- type: latheRecipePack
+  id: ToolsStatic
+  recipes:
+  - ClothingMaskGas
+  - ClothingMaskBreath

--- a/Resources/Prototypes/_Persistence14/Recipes/Lathe/Packs/engineering.yml
+++ b/Resources/Prototypes/_Persistence14/Recipes/Lathe/Packs/engineering.yml
@@ -1,5 +1,7 @@
+## Static
+
 - type: latheRecipePack
-  id: ToolsStatic
+  id: GasMasksStatic
   recipes:
   - ClothingMaskGas
   - ClothingMaskBreath

--- a/Resources/Prototypes/_Persistence14/Recipes/Lathe/misc.yml
+++ b/Resources/Prototypes/_Persistence14/Recipes/Lathe/misc.yml
@@ -1,0 +1,9 @@
+- type: latheRecipe
+  parent: BaseMaskRecipe
+  id: ClothingMaskGas
+  result: ClothingMaskGas
+
+- type: latheRecipe
+  parent: BaseMaskRecipe
+  id: ClothingMaskBreath
+  result: ClothingMaskBreath


### PR DESCRIPTION


<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
This adds gas masks, and survival gas masks into the autolathe
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I wanted players to be able to print gas masks incase someone doesnt have any internals.
## Technical details
<!-- Summary of code changes for easier review. -->
YML changes. 
## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
None needed.
## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
No Game breaking changes.
