### PR TITLE
Organs can go on custom tacos and burgers

### DIFF
--- a/Content.Shared/Nutrition/EntitySystems/FoodSequenceSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/FoodSequenceSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared.Nutrition.Prototypes;
 using Content.Shared.Popups;
 using Content.Shared.Storage.Components;
 using Content.Shared.Tag;
+using Content.Shared._Persistence14.Nutrition;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using System.Numerics;
@@ -105,14 +106,14 @@ public sealed class FoodSequenceSystem : SharedFoodSequenceSystem
         MergeTags(start, result);
     }
 
-    private bool TryAddFoodElement(Entity<FoodSequenceStartPointComponent> start, Entity<FoodSequenceElementComponent, EdibleComponent?> element, EntityUid? user = null)
+    private bool TryAddFoodElement(Entity<FoodSequenceStartPointComponent> start, Entity<FoodSequenceElementComponent, EdibleComponent?, InedibleFoodSequenceElementComponent?> element, EntityUid? user = null) // Persistence 14: InedibleFoodSequenceElementComponent added
     {
-        // we can't add a live mouse to a burger.
-        if (!Resolve(element, ref element.Comp2, false))
-            return false;
-
-        if (element.Comp2.RequireDead && _mobState.IsAlive(element))
-            return false;
+        // we can't add a live mouse to a burger. Modified in persistence 14 to not return false if there's no EdibleComponent
+        if (Resolve(element, ref element.Comp2, false))
+        {
+            if (element.Comp2.RequireDead && _mobState.IsAlive(element))
+                return false;
+        }
 
         //looking for a suitable FoodSequence prototype
         if (!element.Comp1.Entries.TryGetValue(start.Comp.Key, out var elementProto))
@@ -154,6 +155,7 @@ public sealed class FoodSequenceSystem : SharedFoodSequenceSystem
 
         UpdateFoodName(start);
         MergeFoodSolutions(start.Owner, element.Owner);
+        MergeInedibleFoodSolutions(start.Owner, element.Owner); // Persistence
         MergeFlavorProfiles(start, element);
         MergeTrash(start.Owner, element.Owner);
         MergeTags(start, element);
@@ -222,6 +224,24 @@ public sealed class FoodSequenceSystem : SharedFoodSequenceSystem
 
         startSolution.MaxVolume += elementSolution.MaxVolume;
         _solutionContainer.TryAddSolution(startSolutionEntity.Value, elementSolution);
+    }
+
+    private void MergeInedibleFoodSolutions(Entity<EdibleComponent?> start, Entity<InedibleFoodSequenceElementComponent?> element) // Persistence 14
+    {
+        if (!Resolve(start, ref start.Comp, false))
+            return;
+
+        if (!Resolve(element, ref element.Comp, false))
+            return;
+
+        if (!_solutionContainer.TryGetSolution(start.Owner, start.Comp.Solution, out var startSolutionEntity, out var startSolution))
+            return;
+
+        startSolution.MaxVolume += element.Comp.Volume;
+        foreach (var reagentQuantity in element.Comp.Contents)
+        {
+            startSolution.AddReagent(reagentQuantity);
+        }
     }
 
     private void MergeFlavorProfiles(EntityUid start, EntityUid element)

--- a/Content.Shared/_Persistence14/Nutrition/InedibleFoodSequenceElementComponent.cs
+++ b/Content.Shared/_Persistence14/Nutrition/InedibleFoodSequenceElementComponent.cs
@@ -1,0 +1,18 @@
+using Robust.Shared.GameStates;
+using Content.Shared.Chemistry.Reagent;
+using Content.Shared.FixedPoint;
+
+namespace Content.Shared._Persistence14.Nutrition;
+
+/// <summary>
+/// Contains network state for InedibleFoodSequenceElementComponent.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class InedibleFoodSequenceElementComponent : Component
+{
+    [DataField("reagents")]
+    public List<ReagentQuantity> Contents;
+
+    [DataField("volume")]
+    public FixedPoint2 Volume;
+}

--- a/Resources/Locale/en-US/_Persistence14/food_sequence.ftl
+++ b/Resources/Locale/en-US/_Persistence14/food_sequence.ftl
@@ -1,9 +1,5 @@
 food-sequence-content-eye = eye
-food-sequence-content-tongue = tongue
 food-sequence-content-appendix = appendix
-food-sequence-content-ears = ear
 food-sequence-content-lungs = lung
 food-sequence-content-heart = heart
-food-sequence-content-stomach = stomach
-food-sequence-content-liver = liver
 food-sequence-content-kidneys = kidney

--- a/Resources/Locale/en-US/_Persistence14/food_sequence.ftl
+++ b/Resources/Locale/en-US/_Persistence14/food_sequence.ftl
@@ -1,0 +1,9 @@
+food-sequence-content-eye = eye
+food-sequence-content-tongue = tongue
+food-sequence-content-appendix = appendix
+food-sequence-content-ears = ear
+food-sequence-content-lungs = lung
+food-sequence-content-heart = heart
+food-sequence-content-stomach = stomach
+food-sequence-content-liver = liver
+food-sequence-content-kidneys = kidney

--- a/Resources/Prototypes/Body/base_organs.yml
+++ b/Resources/Prototypes/Body/base_organs.yml
@@ -21,6 +21,11 @@
   parent: BaseItem
   components:
   - type: Organ
+  - type: InedibleFoodSequenceElement # Persistence 14
+    volume: 5
+    reagents:
+    - ReagentId: UncookedAnimalProteins
+      Quantity: 5
 
 - type: entity
   parent: OrganBase
@@ -259,6 +264,11 @@
     entries:
       Burger: Brain
       Taco: Brain
+  - type: InedibleFoodSequenceElement # Persistence 14
+    volume: 5
+    reagents:
+    - ReagentId: GreyMatter
+      Quantity: 5
 
 - type: entity
   parent: OrganBase
@@ -282,6 +292,10 @@
     markingData:
       layers:
       - Eyes
+  - type: FoodSequenceElement # Persistence 14
+    entries:
+      Burger: Eyes
+      Taco: Eyes
 
 - type: entity
   parent: OrganBase
@@ -295,6 +309,10 @@
   - type: Sprite
     layers:
     - state: tongue
+  - type: FoodSequenceElement # Persistence 14
+    entries:
+      Burger: Tongue
+      Taco: Tongue
 
 - type: entity
   parent: OrganBase
@@ -308,6 +326,10 @@
   - type: Sprite
     layers:
     - state: appendix
+  - type: FoodSequenceElement # Persistence 14
+    entries:
+      Burger: Appendix
+      Taco: Appendix
 
 - type: entity
   parent: OrganBase
@@ -321,6 +343,10 @@
   - type: Sprite
     layers:
     - state: ears
+  - type: FoodSequenceElement # Persistence 14
+    entries:
+      Burger: Ears
+      Taco: Ears
 
 - type: entity
   parent: OrganBase
@@ -345,6 +371,10 @@
     - state: lung-r
   - type: Item
     heldPrefix: lungs
+  - type: FoodSequenceElement # Persistence 14
+    entries:
+      Burger: Lungs
+      Taco: Lungs
 
 - type: entity
   parent: OrganBase
@@ -361,6 +391,10 @@
   - type: Metabolizer
     maxReagents: 2
     stages: [ Bloodstream ]
+  - type: FoodSequenceElement # Persistence 14
+    entries:
+      Burger: Heart
+      Taco: Heart
 
 - type: entity
   parent: OrganBase
@@ -384,6 +418,10 @@
     - state: stomach
   - type: Item
     heldPrefix: stomach
+  - type: FoodSequenceElement # Persistence 14
+    entries:
+      Burger: Stomach
+      Taco: Stomach
 
 - type: entity
   parent: OrganBase
@@ -402,6 +440,10 @@
   - type: Metabolizer
     maxReagents: 1
     stages: [ Metabolites ]
+  - type: FoodSequenceElement # Persistence 14
+    entries:
+      Burger: Liver
+      Taco: Liver
 
 - type: entity
   parent: OrganBase
@@ -420,6 +462,10 @@
     heldPrefix: kidneys
   - type: Metabolizer
     maxReagents: 5
+  - type: FoodSequenceElement # Persistence 14
+    entries:
+      Burger: Kidneys
+      Taco: Kidneys
 
 - type: entity
   id: OrganSpriteHumanInternal

--- a/Resources/Prototypes/_Persistence14/Recipes/Cooking/food_sequence_element.yml
+++ b/Resources/Prototypes/_Persistence14/Recipes/Cooking/food_sequence_element.yml
@@ -1,0 +1,86 @@
+- type: foodSequenceElement
+  id: Eyes
+  name: food-sequence-content-eye
+  sprites:
+  - sprite: Mobs/Species/Human/organs.rsi
+    state: eyeball-l
+  - sprite: Mobs/Species/Human/organs.rsi
+    state: eyeball-r
+  tags:
+  - Raw
+
+- type: foodSequenceElement
+  id: Tongue
+  name: food-sequence-content-tongue
+  sprites:
+  - sprite: Mobs/Species/Human/organs.rsi
+    state: tongue
+  tags:
+  - Raw
+
+- type: foodSequenceElement
+  id: Appendix
+  name: food-sequence-content-appendix
+  sprites:
+  - sprite: Mobs/Species/Human/organs.rsi
+    state: appendix
+  tags:
+  - Raw
+
+- type: foodSequenceElement
+  id: Ears
+  name: food-sequence-content-ears
+  sprites:
+  - sprite: Mobs/Species/Human/organs.rsi
+    state: ears
+  tags:
+  - Raw
+
+- type: foodSequenceElement
+  id: Lungs
+  name: food-sequence-content-lungs
+  sprites:
+  - sprite: Mobs/Species/Human/organs.rsi
+    state: lung-l
+  - sprite: Mobs/Species/Human/organs.rsi
+    state: lung-r
+  tags:
+  - Raw
+
+- type: foodSequenceElement
+  id: Heart
+  name: food-sequence-content-heart
+  sprites:
+  - sprite: Mobs/Species/Human/organs.rsi
+    state: heart-on
+  tags:
+  - Raw
+
+- type: foodSequenceElement
+  id: Stomach
+  name: food-sequence-content-stomach
+  sprites:
+  - sprite: Mobs/Species/Human/organs.rsi
+    state: stomach
+  tags:
+  - Raw
+
+- type: foodSequenceElement
+  id: Liver
+  name: food-sequence-content-liver
+  sprites:
+  - sprite: Mobs/Species/Human/organs.rsi
+    state: liver
+  tags:
+  - Raw
+
+- type: foodSequenceElement
+  id: Kidneys
+  name: food-sequence-content-kidneys
+  sprites:
+  - sprite: Mobs/Species/Human/organs.rsi
+    state: kidney-l
+  - sprite: Mobs/Species/Human/organs.rsi
+    state: kidney-r
+  tags:
+  - Raw


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Organs can now be put on custom burgers and tacos, adding 5 units of uncooked animal protein or grey matter per organ.

## Why / Balance
More uses for the random organs that are everywhere.

## Technical details
Adds a new component that stores a list of ReagentQuantities, without actually containing those reagents.
Modified FoodSequenceSystem to use the new component.
Various YAML changes.

## Media
[Screencast_20260813_213848.webm](https://github.com/user-attachments/assets/75a3a845-6c51-462f-91fc-efcb44baf5e8)
[Screencast_20260813_213917.webm](https://github.com/user-attachments/assets/21978227-3875-4f79-8536-6b917ba4c9a7)


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
- tweak: All organs can now be put on custom burgers and tacos.
