### PR TITLE
Fix a bug that would leave a permanent emote effect on

### DIFF
--- a/Content.Server/Chat/Systems/AutoEmoteSystem.cs
+++ b/Content.Server/Chat/Systems/AutoEmoteSystem.cs
@@ -108,6 +108,10 @@ public sealed class AutoEmoteSystem : EntitySystem
 
         DebugTools.Assert(_prototypeManager.HasIndex<AutoEmotePrototype>(autoEmotePrototypeId), "Prototype not found. Did you make a typo?");
 
+        // Keep Emotes and EmoteTimers in sync. AddEmote early-returns when Emotes already contains the
+        // id, so leaving a stale entry here would silently prevent the emote from ever being re-added.
+        autoEmote.Emotes.Remove(autoEmotePrototypeId);
+
         if (!autoEmote.EmoteTimers.Remove(autoEmotePrototypeId))
             return false;
 

--- a/Content.Server/_Persistence14/Xenoarchaeology/Artifact/XAE/Components/ForcedEmoteFitComponent.cs
+++ b/Content.Server/_Persistence14/Xenoarchaeology/Artifact/XAE/Components/ForcedEmoteFitComponent.cs
@@ -5,21 +5,18 @@ using Robust.Shared.Prototypes;
 namespace Content.Server.Xenoarchaeology.Artifact.XAE.Components;
 
 /// <summary>
-/// Tracks an ongoing forced-emote "fit" applied by <see cref="XAEForcedEmoteComponent"/>. Holds the
-/// AutoEmote to stop and when the fit ends, at which point both are removed as they are pointless.
+/// Tracks the ongoing forced-emote "fits" applied to a mob by <see cref="XAEForcedEmoteComponent"/>.
+/// A mob can be hit by several different forced emotes at once (e.g. from separate artifact nodes),
+/// so each auto-emote is tracked with its own end time and removed independently. Storing only a
+/// single emote would let a second fit overwrite the first, orphaning it so it never stops. The
+/// component is removed once no fits remain.
 /// </summary>
 [RegisterComponent, Access(typeof(XAEForcedEmoteSystem))]
 public sealed partial class ForcedEmoteFitComponent : Component
 {
     /// <summary>
-    /// The auto-emote to remove when the fit ends.
+    /// The active forced emotes and the time each one ends, keyed by the AutoEmote to remove.
     /// </summary>
     [DataField]
-    public ProtoId<AutoEmotePrototype> AutoEmote;
-
-    /// <summary>
-    /// When the fit ends and the mob stops emoting.
-    /// </summary>
-    [DataField]
-    public TimeSpan EndTime;
+    public Dictionary<ProtoId<AutoEmotePrototype>, TimeSpan> EndTimes = new();
 }

--- a/Content.Server/_Persistence14/Xenoarchaeology/Artifact/XAE/Components/XAEForcedEmoteComponent.cs
+++ b/Content.Server/_Persistence14/Xenoarchaeology/Artifact/XAE/Components/XAEForcedEmoteComponent.cs
@@ -30,5 +30,5 @@ public sealed partial class XAEForcedEmoteComponent : Component
     /// How long the fit lasts. AutoEmote has no lifetime of its own, so this system times it out.
     /// </summary>
     [DataField]
-    public TimeSpan Duration = TimeSpan.FromSeconds(20);
+    public TimeSpan Duration = TimeSpan.FromSeconds(10);
 }

--- a/Content.Server/_Persistence14/Xenoarchaeology/Artifact/XAE/XAEForcedEmoteSystem.cs
+++ b/Content.Server/_Persistence14/Xenoarchaeology/Artifact/XAE/XAEForcedEmoteSystem.cs
@@ -5,6 +5,7 @@ using Content.Shared.Mobs.Systems;
 using Content.Shared.Xenoarchaeology.Artifact;
 using Content.Shared.Xenoarchaeology.Artifact.XAE;
 using Robust.Shared.Timing;
+using System.Linq;
 
 namespace Content.Server.Xenoarchaeology.Artifact.XAE;
 
@@ -44,10 +45,11 @@ public sealed class XAEForcedEmoteSystem : BaseXAESystem<XAEForcedEmoteComponent
             EnsureComp<AutoEmoteComponent>(mob);
             _autoEmote.AddEmote(mob, comp.AutoEmote);
 
-            // AutoEmote has no lifetime of its own, so we time the fit out ourselves.
+            // AutoEmote has no lifetime of its own, so we time the fit out ourselves. A mob can be
+            // under several different forced emotes at once, so each is tracked separately;
+            // re-triggering the same emote just refreshes its end time.
             var fit = EnsureComp<ForcedEmoteFitComponent>(mob);
-            fit.AutoEmote = comp.AutoEmote;
-            fit.EndTime = endTime; // re-triggering refreshes the fit
+            fit.EndTimes[comp.AutoEmote] = endTime;
         }
     }
 
@@ -59,13 +61,21 @@ public sealed class XAEForcedEmoteSystem : BaseXAESystem<XAEForcedEmoteComponent
         var query = EntityQueryEnumerator<ForcedEmoteFitComponent>();
         while (query.MoveNext(out var uid, out var fit))
         {
-            if (now < fit.EndTime)
-                continue;
+            // Snapshot the keys so we can mutate the dictionary while iterating.
+            foreach (var autoEmote in fit.EndTimes.Keys.ToArray())
+            {
+                if (now < fit.EndTimes[autoEmote])
+                    continue;
 
-            // removeEmpty (default true) also drops the AutoEmoteComponent, unless the mob has other
-            // auto-emotes of its own (e.g. a cluwne), which are left untouched.
-            _autoEmote.RemoveEmote(uid, fit.AutoEmote);
-            RemCompDeferred<ForcedEmoteFitComponent>(uid);
+                // removeEmpty (default true) also drops the AutoEmoteComponent once no auto-emotes
+                // remain, unless the mob has other auto-emotes of its own (e.g. a cluwne), which are
+                // left untouched.
+                _autoEmote.RemoveEmote(uid, autoEmote);
+                fit.EndTimes.Remove(autoEmote);
+            }
+
+            if (fit.EndTimes.Count == 0)
+                RemCompDeferred<ForcedEmoteFitComponent>(uid);
         }
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed a bug that a emote effect from an artifact would become permanent when spammed

## Why / Balance
It's annoying an not intentional :D

## Technical details
We now use a dictionary to better track. Old system meant that adding a new emote effect would overwrite, so when it came down to deleting, we just deleted the new one and never the old one.


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).


## Breaking changes
Self contained in the emote effect system

**Changelog**
:cl:
- Fixed infinite emote effect bug
