### PR TITLE
(feat) display bloodstream contents in health analyzer

### DIFF
--- a/Content.Client/HealthAnalyzer/UI/HealthAnalyzerControl.xaml
+++ b/Content.Client/HealthAnalyzer/UI/HealthAnalyzerControl.xaml
@@ -36,6 +36,19 @@
         </GridContainer>
     </BoxContainer>
 
+    <!-- Start Persistence: Display bloodstream contents in health analyzers -->
+    <PanelContainer StyleClasses="LowDivider" />
+
+    <Label Name="BloodstreamContentsHeaderText" Text="{Loc 'health-analyzer-window-entity-bloodstream-contents-header'}" Visible="False"/>
+    <Label Name="BloodstreamNotFoundText" Text="{Loc 'health-analyzer-window-entity-bloodstream-not-found'}" Visible="False"/>
+
+    <GridContainer
+        Name="BloodstreamContainer"
+        Margin="0 0 0 5"
+        Columns="2">
+    </GridContainer>
+    <!-- End Persistence -->
+
     <PanelContainer Name="AlertsDivider" Visible="False" StyleClasses="LowDivider" />
 
     <BoxContainer Name="AlertsContainer" Visible="False" Margin="0 5" Orientation="Vertical" HorizontalAlignment="Center">

--- a/Content.Client/HealthAnalyzer/UI/HealthAnalyzerControl.xaml
+++ b/Content.Client/HealthAnalyzer/UI/HealthAnalyzerControl.xaml
@@ -44,7 +44,7 @@
 
     <GridContainer
         Name="BloodstreamContainer"
-        Margin="0 0 0 5"
+        Margin="5 0 0 5"
         Columns="2">
     </GridContainer>
     <!-- End Persistence -->

--- a/Content.Client/HealthAnalyzer/UI/HealthAnalyzerControl.xaml.cs
+++ b/Content.Client/HealthAnalyzer/UI/HealthAnalyzerControl.xaml.cs
@@ -18,6 +18,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 using System.Linq;
 using System.Numerics;
+using Content.Shared.Chemistry.Reagent; // Persistence: Display bloodstream contents in health analyzers
 namespace Content.Client.HealthAnalyzer.UI;
 
 // Health analyzer UI is split from its window because it's used by both the
@@ -141,6 +142,8 @@ public sealed partial class HealthAnalyzerControl : BoxContainer
         var damagePerType = _damageable.GetAllDamage(target.Value).DamageDict;
 
         DrawDiagnosticGroups(damageSortedGroups, damagePerType);
+
+        DrawBloodstreamContents(state.BloodContents); // Persistence: Display bloodstream contents in health analyzers
     }
 
     private static string GetStatus(MobState mobState)
@@ -199,6 +202,44 @@ public sealed partial class HealthAnalyzerControl : BoxContainer
             }
         }
     }
+
+    // Start Persistence: Display bloodstream contents in health analyzers
+    private void DrawBloodstreamContents(List<ReagentQuantity>? bloodContents)
+    {
+        BloodstreamContainer.RemoveAllChildren();
+
+        if (bloodContents is null)
+        {
+            BloodstreamNotFoundText.Visible = true;
+            return;
+        }
+
+        BloodstreamContentsHeaderText.Visible = true;
+
+        foreach (var (reagent, quantity) in bloodContents)
+        {
+            var reagentId = reagent;
+            _prototypes.TryIndex(reagentId.Prototype, out ReagentPrototype? proto);
+            var name = proto?.LocalizedName ?? Loc.GetString("chem-master-window-unknown-reagent-text");
+            var reagentColor = proto?.SubstanceColor ?? default(Color);
+            var reagentText = new Label();
+            reagentText.Text = name + ": " + quantity.ToString();
+            var reagentColorSwatch = new PanelContainer
+            {
+                Name = "colorPanel",
+                VerticalExpand = true,
+                MinWidth = 4,
+                PanelOverride = new StyleBoxFlat
+                {
+                    BackgroundColor = reagentColor
+                },
+                Margin = new Thickness(0, 1)
+            };
+            BloodstreamContainer.AddChild(reagentColorSwatch);
+            BloodstreamContainer.AddChild(reagentText);
+        }
+    }
+    // End Persistence
 
     private Texture GetTexture(string texture)
     {

--- a/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml
+++ b/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml
@@ -2,8 +2,8 @@
     xmlns="https://spacestation14.io"
     xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
     xmlns:ui="clr-namespace:Content.Client.HealthAnalyzer.UI"
-    MaxHeight="525"
-    MinWidth="300">
+    MaxHeight="800"
+    MinWidth="300"> <!-- Persistence: MaxHeight 525 < 800 -->
     <ScrollContainer
         Margin="5 5 5 5"
         ReturnMeasure="True"

--- a/Content.Server/Medical/HealthAnalyzerSystem.cs
+++ b/Content.Server/Medical/HealthAnalyzerSystem.cs
@@ -2,6 +2,7 @@ using Content.Server.Body.Systems;
 using Content.Server.Medical.Components;
 using Content.Shared.Body.Components;
 using Content.Shared.Chemistry.EntitySystems;
+using Content.Shared.Chemistry.Reagent; // Persistence: Display bloodstream contents in health analyzers
 using Content.Shared.Damage.Components;
 using Content.Shared.DoAfter;
 using Content.Shared.Hands.Components;
@@ -246,11 +247,13 @@ public sealed class HealthAnalyzerSystem : EntitySystem
         var bloodAmount = float.NaN;
         var bleeding = false;
         var unrevivable = false;
+        var bloodContents = new List<ReagentQuantity>(); // Persistence: Display bloodstream contents in health analyzers
 
         if (TryComp<BloodstreamComponent>(entity, out var bloodstream) &&
             _solutionContainerSystem.ResolveSolution(entity, bloodstream.BloodSolutionName,
                 ref bloodstream.BloodSolution, out var bloodSolution))
         {
+            bloodContents = bloodSolution.Contents; // Persistence: Display bloodstream contents in health analyzers
             bloodAmount = _bloodstreamSystem.GetBloodLevel(entity);
             bleeding = bloodstream.BleedAmount > 0;
         }
@@ -264,7 +267,8 @@ public sealed class HealthAnalyzerSystem : EntitySystem
             bloodAmount,
             null,
             bleeding,
-            unrevivable
+            unrevivable,
+            bloodContents // Persistence: Display bloodstream contents in health analyzers
         );
     }
 }

--- a/Content.Shared/MedicalScanner/HealthAnalyzerScannedUserMessage.cs
+++ b/Content.Shared/MedicalScanner/HealthAnalyzerScannedUserMessage.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Chemistry.Reagent; // Persistence: Display bloodstream contents in health analyzers
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.MedicalScanner;
@@ -28,10 +29,11 @@ public struct HealthAnalyzerUiState
     public bool? ScanMode;
     public bool? Bleeding;
     public bool? Unrevivable;
+    public List<ReagentQuantity>? BloodContents; // Persistence: Display bloodstream contents in health analyzers
 
     public HealthAnalyzerUiState() { }
 
-    public HealthAnalyzerUiState(NetEntity? targetEntity, float temperature, float bloodLevel, bool? scanMode, bool? bleeding, bool? unrevivable)
+    public HealthAnalyzerUiState(NetEntity? targetEntity, float temperature, float bloodLevel, bool? scanMode, bool? bleeding, bool? unrevivable, List<ReagentQuantity>? bloodContents) // Persistence: add List<ReagentQuantity>? bloodContents
     {
         TargetEntity = targetEntity;
         Temperature = temperature;
@@ -39,5 +41,6 @@ public struct HealthAnalyzerUiState
         ScanMode = scanMode;
         Bleeding = bleeding;
         Unrevivable = unrevivable;
+        BloodContents = bloodContents; // Persistence: Display bloodstream contents in health analyzers
     }
 }

--- a/Resources/Locale/en-US/_Persistence14/medical/components/health-analyzer-component.ftl
+++ b/Resources/Locale/en-US/_Persistence14/medical/components/health-analyzer-component.ftl
@@ -1,0 +1,2 @@
+health-analyzer-window-entity-bloodstream-contents-header = Bloodstream Contents:
+health-analyzer-window-entity-bloodstream-not-found = Bloodstream not found


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Health analyzers (including MedTek PDA cartridge and cryopod) now display the contents of a mob's bloodstream.

## Why / Balance
#563 slowed metabolism drastically, and folks suspect that providing visibility into bloodstream contents will help with alleviating some of the pains from this change.

## Technical details
I ripped some code from the cryopod & chemmaster implementations & stuffed it into the health analyzer. In particular:
- `Content.Client/HealthAnalyzer/UI/HealthAnalyzerControl.xaml.cs` is doing the bulk of the work. `DrawBloodstreamContents` processes the contents of the bloodstream (a nullable `List<ReagentQuantity>`), grabs the localized name & reagent color for each reagent, and adds UI elements containing the helpful values (name, quantity, color)
- `Content.Client/HealthAnalyzer/UI/HealthAnalyzerControl.xaml` Just reuses some of the other conventions in this file to create a new container for the information to live in within the UI
- `Content.Server/Medical/HealthAnalyzerSystem.cs` Now passes the contents of the mob's bloodstream from server-> client. It was actually surprisingly simple to grab the bloodstream, since the health scanner already checks overall blood-level
- `Content.Shared/MedicalScanner/HealthAnalyzerScannedUserMessage.cs` Added a parameter for the bloodstream's contents (a nullable `List<ReagentQuantity>`)
- `Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml` Adjusted the maximum height of the health analyzer window to account for the increased information.
- `Resources/Locale/en-US/_Persistence14/medical/components/health-analyzer-component.ftl` Added localizations for this feature

## Media
<img width="314" height="736" alt="image" src="https://github.com/user-attachments/assets/6104f2ab-ac4c-41d6-b632-42101793fb1f" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Shouldn't be any. The parameters that were added to existing bits of code are nullable & there are null checks on the receiving side

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Health analyzer UI (and by extension, MedTek & cryopod UI) now shows the contents of the target's bloodstream
