### PR TITLE
fix: admin-related chat channels no longer stack

### DIFF
--- a/Content.Client/_RMC14/Chat/CMChatSystem.cs
+++ b/Content.Client/_RMC14/Chat/CMChatSystem.cs
@@ -24,6 +24,9 @@ public sealed class CMChatSystem : EntitySystem // Persistence: SharedCMChatSyst
 
     public bool TryRepetition(ChatBox chat, OutputPanel contents, FormattedMessage message, NetEntity sender, string unwrapped, ChatChannel channel, bool repeatCheckSender)
     {
+        if (ChatChannel.AdminRelated.HasFlag(channel)) // Persistence: don't stack anything that's admin-chat related
+            return false;
+
         var repeated = false;
         foreach (var old in chat.RepeatQueue)
         {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Client-side chat stacking code now breaks early if the message is received on any admin-related channel

## Why / Balance
Because admin chats probably don't need to be stacked & this was an issue:
<img width="422" height="227" alt="image" src="https://github.com/user-attachments/assets/293bb991-cd42-4b5c-bbd0-d1dd3c9acbea" />

## Technical details
- `TryRepetition()` in `CMChatSystem.cs` now returns false if the channel passed is any admin related channel

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
