### PR TITLE
Map Screen Waypoint fix

### DIFF
--- a/Content.Client/Shuttles/UI/MapScreen.xaml.cs
+++ b/Content.Client/Shuttles/UI/MapScreen.xaml.cs
@@ -116,23 +116,23 @@ public sealed partial class MapScreen : BoxContainer
             FilterMapObjects();
         };
 
-        WaypointCoordsX.OnTextEntered += args =>
-        {
-            if (int.TryParse(args.Text, out var amount))
-            {
-                UpdateWaypoint(new Vector2(amount, MapRadar.WaypointCoords?.Y ?? 0));
-            }
-        };
-        WaypointCoordsY.OnTextEntered += args =>
-        {
-            if (int.TryParse(args.Text, out var amount))
-            {
-                UpdateWaypoint(new Vector2(MapRadar.WaypointCoords?.X ?? 0, amount));
-            }
-        };
+        WaypointCoordsX.OnTextEntered += _ => UpdateWaypointEdits();
+        WaypointCoordsY.OnTextEntered += _ => UpdateWaypointEdits();
         WaypointButton.OnPressed += _ => UpdateWaypoint(null);
 
         SearchBar.OnTextChanged += _ => FilterMapObjects();
+    }
+
+    private void UpdateWaypointEdits()
+    {
+        UpdateWaypoint(new Vector2(
+            int.TryParse(WaypointCoordsX.Text, out var xAmount)
+                ? xAmount
+                : MapRadar.WaypointCoords?.X ?? 0,
+            int.TryParse(WaypointCoordsY.Text, out var yAmount)
+                ? yAmount
+                : MapRadar.WaypointCoords?.Y ?? 0
+        ));
     }
 
     public void UpdateState(ShuttleMapInterfaceState state)

--- a/Content.Client/Shuttles/UI/MapScreen.xaml.cs
+++ b/Content.Client/Shuttles/UI/MapScreen.xaml.cs
@@ -144,6 +144,13 @@ public sealed partial class MapScreen : BoxContainer
         _state = state.FTLState;
         _ftlTime = state.FTLTime;
         MapRadar.InFtl = true;
+
+        //Need this to initialize the value when first opening the gui if a waypoint exists, but updating it every frame causes unresponsive behavior.
+        if (MapRadar.WaypointCoords == null && state.Waypoint != null)
+        {
+            UpdateWaypoint(state.Waypoint);
+        }
+
         switch (_state)
         {
             case FTLState.Available:

--- a/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleConsoleSystem.cs
@@ -289,7 +289,7 @@ public sealed partial class ShuttleConsoleSystem : SharedShuttleConsoleSystem
         if (shuttleGridUid != null && entity != null)
         {
             navState = GetNavState(entity.Value, dockState.Docks);
-            mapState = GetMapState(shuttleGridUid.Value);
+            mapState = GetMapState(shuttleGridUid.Value, entity.Value);
         }
         else
         {
@@ -554,15 +554,21 @@ public sealed partial class ShuttleConsoleSystem : SharedShuttleConsoleSystem
     /// <summary>
     /// Specific to a particular shuttle.
     /// </summary>
-    public ShuttleMapInterfaceState GetMapState(Entity<FTLComponent?> shuttle)
+    public ShuttleMapInterfaceState GetMapState(Entity<FTLComponent?> shuttle, Entity<ShuttleConsoleComponent?> console)
     {
         FTLState ftlState = FTLState.Available;
         StartEndTime stateDuration = default;
+        Vector2? waypoint = null;
 
         if (Resolve(shuttle, ref shuttle.Comp, false) && shuttle.Comp.LifeStage < ComponentLifeStage.Stopped)
         {
             ftlState = shuttle.Comp.State;
             stateDuration = _shuttle.GetStateTime(shuttle.Comp);
+        }
+
+        if (Resolve(console, ref console.Comp, false))
+        {
+            waypoint = console.Comp.Waypoint;
         }
 
         List<ShuttleBeaconObject>? beacons = null;
@@ -575,7 +581,8 @@ public sealed partial class ShuttleConsoleSystem : SharedShuttleConsoleSystem
             stateDuration,
             beacons ?? new List<ShuttleBeaconObject>(),
             exclusions ?? new List<ShuttleExclusionObject>(),
-            _sectorWeather.GetHazardWeatherSnapshot());
+            _sectorWeather.GetHazardWeatherSnapshot(),
+            waypoint);
     }
 
     private void OnDampingMessage(Entity<ShuttleConsoleComponent> ent, ref ShuttleConsoleDampingMessage args)

--- a/Content.Shared/Shuttles/BUIStates/ShuttleMapInterfaceState.cs
+++ b/Content.Shared/Shuttles/BUIStates/ShuttleMapInterfaceState.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using Content.Shared.Sectors;
 using Content.Shared.Shuttles.Systems;
 using Content.Shared.Shuttles.UI.MapObjects;
@@ -28,17 +29,21 @@ public sealed class ShuttleMapInterfaceState
 
     public Dictionary<SpaceSector, string> SectorWeatherEvents;
 
+    public Vector2? Waypoint;
+
     public ShuttleMapInterfaceState(
         FTLState ftlState,
         StartEndTime ftlTime,
         List<ShuttleBeaconObject> destinations,
         List<ShuttleExclusionObject> exclusions,
-        Dictionary<SpaceSector, string>? sectorWeatherEvents = null)
+        Dictionary<SpaceSector, string>? sectorWeatherEvents = null,
+        Vector2? waypoint = null)
     {
         FTLState = ftlState;
         FTLTime = ftlTime;
         Destinations = destinations;
         Exclusions = exclusions;
         SectorWeatherEvents = sectorWeatherEvents ?? new Dictionary<SpaceSector, string>();
+        Waypoint = waypoint;
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed buggy behavior with the map screen waypoint from https://github.com/michaelchessall/SS14-Persistence/pull/434

## Why / Balance
Previously, hitting enter when inputting waypoint coordinates directly wiped out the value input in the other textbox, meaning you had to hit enter separately on both, this felt awkward.
Also, when setting a waypoint, closing the gui window, then reopening, the waypoint would still be visible on the nav screen but it would appear cleared on the map screen.
Both of these were minor oversights with the initial PR that this PR fixes

## Technical details
Moved waypoint textbox behavior into a shared helper function that takes both inputs into account
Added waypoint to ShuttleMapNavInterfaceState, although it is ignored if the client's waypoint is already set

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
ShuttleConsoleSystem.GetMapState() now takes the console entity as a parameter
ShuttleMapInterfaceState has a new property, albeit an optional parameter

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed shuttle console waypoint coordinate input only accepting one axis input at a time
- fix: Fixed shuttle console waypoint not being visible on the map screen after closing and reopening the window
