### PR TITLE
fix: Make health analyzer's status label aware of soft/hard-crit

### DIFF
--- a/Content.Client/HealthAnalyzer/UI/HealthAnalyzerControl.xaml.cs
+++ b/Content.Client/HealthAnalyzer/UI/HealthAnalyzerControl.xaml.cs
@@ -152,6 +152,8 @@ public sealed partial class HealthAnalyzerControl : BoxContainer
         {
             MobState.Alive => Loc.GetString("health-analyzer-window-entity-alive-text"),
             MobState.Critical => Loc.GetString("health-analyzer-window-entity-critical-text"),
+            MobState.SoftCritical => Loc.GetString("health-analyzer-window-entity-critical-text"), // Persistence: Make status label aware of soft-crit
+            MobState.HardCritical => Loc.GetString("health-analyzer-window-entity-critical-text"), // Persistence: Make status label aware of hard-crit
             MobState.Dead => Loc.GetString("health-analyzer-window-entity-dead-text"),
             _ => Loc.GetString("health-analyzer-window-entity-unknown-text"),
         };


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Small change in `HealthAnalyzerControl.xaml.cs` to use the proper localized string when the mob's state is either `MobState.SoftCritical` or `MobState.HardCritical`.

## Why / Balance
Bugfix. Without this change mobs that have soft-crit & are in either soft/hard crit would have "Status: Unknown" in the health analyzer

## Technical details
See changes, its small :)

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Health analyzer UI now properly displays critical status for mobs that have soft-crit.