### PR TITLE
prevent infinite ammonia farms from rotting corpses

### DIFF
--- a/Content.Server/Atmos/Rotting/RottingSystem.cs
+++ b/Content.Server/Atmos/Rotting/RottingSystem.cs
@@ -108,7 +108,10 @@ public sealed class RottingSystem : SharedRottingSystem
                 continue;
             rotting.TotalRotTime += rotting.RotUpdateRate * GetRotRate(uid);
             if (rotting.TotalRotTime >= rotting.MaximumTotalRotTime)
+            {
                 rotting.TotalRotTime = rotting.MaximumTotalRotTime;
+                continue; // Persistence: Stop processing this entity so we don't infinitely generate ammonia
+            }
 
             if (rotting.DealDamage)
             {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Prevents rotting from continuing to produce ammonia past the maximum rotting threshold (2hrs currently)

## Why / Balance
Infinite ammonia production was mildly gamebreaking, especially when you consider that the it is produced with the same temperature as the gas already in the tile.

## Technical details
just a `continue;` in the pre-existing check for max rotting time that breaks us out of the loop before generating gas

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Corpses no longer generate infinite ammonia.