### PR TITLE
changed some FrostOil recipes to use Fresium

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/frost_oil.yml
+++ b/Resources/Prototypes/Recipes/Reactions/frost_oil.yml
@@ -1,3 +1,6 @@
+#Persistence 14
+#Replacing some recipes with fresium
+
 - type: reaction
   id: SolidifyGold
   impact: Low
@@ -5,7 +8,7 @@
   reactants:
     Gold:
       amount: 10
-    FrostOil:
+    Fresium:
       amount: 5
   group: Precipitate
   effects:
@@ -19,7 +22,7 @@
   reactants:
     Silver:
       amount: 10
-    FrostOil:
+    Fresium:
       amount: 5
   group: Precipitate
   effects:
@@ -33,7 +36,7 @@
   reactants:
     Copper:
       amount: 10
-    FrostOil:
+    Fresium:
       amount: 5
   group: Precipitate
   effects:
@@ -47,7 +50,7 @@
   reactants:
     Tin:
       amount: 10
-    FrostOil:
+    Fresium:
       amount: 5
   group: Precipitate
   effects:
@@ -61,7 +64,7 @@
   reactants:
     Plasma:
       amount: 10
-    Fresium:
+    FrostOil:
       amount: 5
   group: Precipitate
   effects:
@@ -77,7 +80,7 @@
       amount: 9
     Carbon:
       amount: 1
-    FrostOil:
+    Fresium:
       amount: 5
   group: Precipitate
   effects:
@@ -158,7 +161,7 @@
   reactants:
     Aluminium:
       amount: 10
-    FrostOil:
+    Fresium:
       amount: 5
   group: Precipitate
   effects:
@@ -172,7 +175,7 @@
   reactants:
     Silicon:
       amount: 10
-    FrostOil:
+    Fresium:
       amount: 5
   group: Precipitate
   effects:


### PR DESCRIPTION
## About the PR
Changed some FrostOil recipes to use Fresium, this should allow for the bulk production of silicon and iron without the fear of bulk material creation.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
