### PR TITLE
fix: disable unused part of bloodpack visuals

### DIFF
--- a/Content.Client/_RMC14/Medical/IV/IVDripSystem.cs
+++ b/Content.Client/_RMC14/Medical/IV/IVDripSystem.cs
@@ -90,7 +90,8 @@ public sealed class IVDripSystem : SharedIVDripSystem
         if (!TryComp(pack, out SpriteComponent? sprite))
             return;
 
-        sprite.LayerSetVisible(BloodPackVisuals.Label, false);
+        // Persistence: Replaced this implementation with PaperLabel & related dependencies to allow custom labels
+        // sprite.LayerSetVisible(BloodPackVisuals.Label, false);
 
         if (sprite.LayerMapTryGet(BloodPackVisuals.Fill, out var fillLayer))
         {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
In #592 I removed some yaml sprite components that were related to RMC's bloodbag labels. This had C# trying to find and modify it which I wasn't aware of. This PR comments out that C# to prevent clientside log spam

## Why / Balance
Bug fix

## Technical details
Commented: `// sprite.LayerSetVisible(BloodPackVisuals.Label, false);`

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->