### PR TITLE
Update Epi and Inaprov for Soft and Hard Crit

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -346,9 +346,9 @@
         amount: -5
       - !type:HealthChange
         conditions:
-          # they gotta be in crit first
+          # they gotta be in soft or hard crit first
         - !type:MobStateCondition
-          mobstate: Critical
+          mobstate: SoftCritical
         - !type:ReagentCondition
           reagent: Epinephrine
           max: 20
@@ -358,9 +358,32 @@
             Poison: -0.5
       - !type:EvenHealthChange
         conditions:
-          # they gotta be in crit first
+          # they gotta be in soft or hard crit first
         - !type:MobStateCondition
-          mobstate: Critical
+          mobstate: SoftCritical
+        - !type:ReagentCondition
+          reagent: Epinephrine
+          max: 20
+        damage:
+          Brute: -0.5
+          Burn: -0.5
+      - !type:HealthChange
+        conditions:
+          # they gotta be in soft or hard crit first
+        - !type:MobStateCondition
+          mobstate: HardCritical
+        - !type:ReagentCondition
+          reagent: Epinephrine
+          max: 20
+        damage:
+          types:
+            Asphyxiation: -3
+            Poison: -0.5
+      - !type:EvenHealthChange
+        conditions:
+          # they gotta be in soft or hard crit first
+        - !type:MobStateCondition
+          mobstate: HardCritical
         - !type:ReagentCondition
           reagent: Epinephrine
           max: 20
@@ -478,9 +501,17 @@
       effects:
       - !type:HealthChange
         conditions:
-          # they gotta be in crit first
+          # they gotta be in soft or hard crit first
         - !type:MobStateCondition
-          mobstate: Critical
+          mobstate: SoftCritical
+        damage:
+          types:
+            Asphyxiation: -2
+      - !type:HealthChange
+        conditions:
+          # they gotta be in soft or hard crit first
+        - !type:MobStateCondition
+          mobstate: HardCritical
         damage:
           types:
             Asphyxiation: -2


### PR DESCRIPTION
Update Epi and Inaprov for thew new Soft and Hard Crit mobstates so that they correctly heals during them

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I updated Epi and Inaprov to be able to heal again (it was not working after soft/hard crit)

## Why / Balance
the game was not detecting just "critical" and thus was not applying the healing.

## Technical details
I updated Epi and Inaprov in the medicine.yml to include heathchanges for conditions in both soft and hard crit.

## Media
none

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- fix: Fixed Epi and Inaprov to heal again after addition of soft/hard crit.
-->
