### PR TITLE
fixes: footprints & firebot interaction w/ reagent fires

### DIFF
--- a/Content.Server/NPC/Queries/Queries/ComponentQuery.cs
+++ b/Content.Server/NPC/Queries/Queries/ComponentQuery.cs
@@ -3,9 +3,18 @@ using Robust.Shared.Prototypes;
 namespace Content.Server.NPC.Queries.Queries;
 
 /// <summary>
-/// Returns nearby components that match the specified components.
+/// Returns nearby entities that match all of the specified components.
 /// </summary>
 public sealed partial class ComponentQuery : UtilityQuery
+{
+    [DataField("components", required: true)]
+    public ComponentRegistry Components = default!;
+}
+
+/// <summary>
+/// Persistence: Returns nearby entities that match any of the specified components
+/// </summary>
+public sealed partial class ComponentQueryAny : UtilityQuery
 {
     [DataField("components", required: true)]
     public ComponentRegistry Components = default!;

--- a/Content.Server/NPC/Systems/NPCUtilitySystem.cs
+++ b/Content.Server/NPC/Systems/NPCUtilitySystem.cs
@@ -35,6 +35,7 @@ using Robust.Server.Containers;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 using System.Linq;
+using Content.Shared.Tag; // Persistence: Firebots can target reagent fires
 
 namespace Content.Server.NPC.Systems;
 
@@ -383,6 +384,11 @@ public sealed class NPCUtilitySystem : EntitySystem
                 {
                     if (TryComp(targetUid, out FlammableComponent? fire) && fire.OnFire)
                         return 1f;
+
+                    // Persistence: Firebots can target reagent fires
+                    if (TryComp(targetUid, out TagComponent? tags) && tags.Tags.AsReadOnly().Contains((_proto.Index<TagPrototype>("ReagentFire"))))
+                        return 1f;
+
                     return 0f;
                 }
             case TargetIsStunnedCon:
@@ -505,6 +511,24 @@ public sealed class NPCUtilitySystem : EntitySystem
                     {
                         entities.Add(ent);
                     }
+                    break;
+                }
+            case ComponentQueryAny compQueryAny: // Persistence: Firebots can target reagent fires
+                {
+                    if (compQueryAny.Components.Count == 0)
+                        return;
+
+                    var mapPos = _transform.GetMapCoordinates(owner, xform: _xformQuery.GetComponent(owner));
+                    _compTypes.Clear();
+                    _entitySet.Clear();
+                    foreach (var comp in compQueryAny.Components.Values)
+                    {
+                        _lookup.GetEntitiesInRange(comp.Component.GetType(), mapPos, vision, _entitySet);
+                    }
+
+                    foreach (var ent in _entitySet)
+                        entities.Add(ent);
+
                     break;
                 }
             default:

--- a/Content.Server/_Funkystation/Footprints/FootprintSystem.cs
+++ b/Content.Server/_Funkystation/Footprints/FootprintSystem.cs
@@ -9,7 +9,7 @@ using Content.Shared.Fluids.Components;
 using Content.Shared.Gravity;
 using Content.Shared.Inventory;
 using Content.Shared.Standing;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Content.Shared.Maps; // Persistence: Prevent footprints on space tiles (lattice)
 using Robust.Server.GameObjects;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
@@ -27,6 +27,7 @@ public sealed class FootprintSystem : EntitySystem
     [Dependency] private readonly SharedPuddleSystem _puddle = null!;
     [Dependency] private readonly IPrototypeManager _prototypeManager = null!;
     [Dependency] private readonly IRobustRandom _random = null!;
+    [Dependency] private readonly TurfSystem _turf = default!; // Persistence: Prevent footprints on space tiles (lattice)
     [Dependency] private readonly InventorySystem _inventory = null!;
 
     private static readonly FixedPoint2 MaxVolumePerTile = 50;
@@ -115,6 +116,11 @@ public sealed class FootprintSystem : EntitySystem
 
         var xform = Transform(uid);
         if (xform.GridUid is not { } gridUid || !TryComp<MapGridComponent>(gridUid, out var grid))
+            return;
+
+        // Persistence: Prevent footprints on space tiles (lattice)
+        var tileRef = _map.GetTileRef(gridUid, grid, args.Component.Coordinates);
+        if (tileRef.Tile.IsEmpty || _turf.IsSpace(tileRef))
             return;
 
         var oldLocal = _map.WorldToLocal(gridUid, grid, prevPos);

--- a/Content.Server/_Funkystation/Footprints/FootprintSystem.cs
+++ b/Content.Server/_Funkystation/Footprints/FootprintSystem.cs
@@ -6,8 +6,10 @@ using Content.Shared.Chemistry.EntitySystems;
 using Content.Shared.FixedPoint;
 using Content.Shared.Fluids;
 using Content.Shared.Fluids.Components;
+using Content.Shared.Gravity;
 using Content.Shared.Inventory;
 using Content.Shared.Standing;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Robust.Server.GameObjects;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
@@ -85,6 +87,11 @@ public sealed class FootprintSystem : EntitySystem
     private void OnEntityMoved(EntityUid uid, FootprintOwnerComponent component, ref MoveEvent args)
     {
         if (HasComp<NoFootprintsComponent>(uid))
+            return;
+
+        // Persistence: Footprints shouldn't form when there's no gravity
+        if (TryComp<GravityAffectedComponent>(uid, out var gravityAffected) &&
+            gravityAffected.Weightless)
             return;
 
         if (_inventory.TryGetSlotEntity(uid, "shoes", out var shoes) && HasComp<NoFootprintsComponent>(shoes))

--- a/Content.Shared/Movement/Systems/SharedJumpAbilitySystem.cs
+++ b/Content.Shared/Movement/Systems/SharedJumpAbilitySystem.cs
@@ -1,6 +1,7 @@
 using Content.Shared.Actions;
 using Content.Shared.Actions.Components;
 using Content.Shared.Cloning.Events;
+using Content.Shared.Fluids.Components;
 using Content.Shared.Gravity;
 using Content.Shared.Movement.Components;
 using Content.Shared.Popups;
@@ -53,6 +54,10 @@ public sealed partial class SharedJumpAbilitySystem : EntitySystem
 
     private void OnLeaperCollide(Entity<ActiveLeaperComponent> entity, ref StartCollideEvent args)
     {
+        // Persistence: Leapers shouldn't collide with puddles or footprints.
+        if (TryComp<PuddleComponent>(args.OtherEntity, out _))
+            return;
+
         _stun.TryKnockdown(entity.Owner, entity.Comp.KnockdownDuration, force: true);
         RemCompDeferred<ActiveLeaperComponent>(entity);
     }

--- a/Resources/Prototypes/NPCs/utility_queries.yml
+++ b/Resources/Prototypes/NPCs/utility_queries.yml
@@ -176,7 +176,7 @@
             types:
               Heat: 0
         - type: ReagentPuddleFireEffect # Persistence: Firebots put out reagent fires
-#        - type: WallStainFireVisuals # Persistence: Firebots put out reagent fires # Commented because they can't seem to reach wall stain fires
+        - type: WallStainFireVisuals # Persistence: Firebots put out reagent fires # Commented because they can't seem to reach wall stain fires
   considerations:
     - !type:TargetDistanceCon
       curve: !type:PresetCurve

--- a/Resources/Prototypes/NPCs/utility_queries.yml
+++ b/Resources/Prototypes/NPCs/utility_queries.yml
@@ -168,13 +168,15 @@
 - type: utilityQuery
   id: NearbyOnFire
   query:
-    - !type:ComponentQuery
+    - !type:ComponentQueryAny # Persistence: Firebots can target reagent fires
       components:
         - type: Flammable
           # why does Flammable even have a required damage
           damage:
             types:
               Heat: 0
+        - type: ReagentPuddleFireEffect # Persistence: Firebots put out reagent fires
+#        - type: WallStainFireVisuals # Persistence: Firebots put out reagent fires # Commented because they can't seem to reach wall stain fires
   considerations:
     - !type:TargetDistanceCon
       curve: !type:PresetCurve

--- a/Resources/Prototypes/_Funkystation/Entities/Effects/reagent_fire.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Effects/reagent_fire.yml
@@ -13,6 +13,9 @@
     drawdepth: Overlays
   - type: Appearance
   - type: ReagentPuddleFireEffect
+  - type: Tag # Persistence: Firebots can target reagent fires
+    tags:
+    - ReagentFire
 
 - type: particleEffect
   id: ReagentFireContinuous

--- a/Resources/Prototypes/_Funkystation/Entities/Effects/wall_stains.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Effects/wall_stains.yml
@@ -42,9 +42,19 @@
     energy: 1.5
     color: "#FF5500"
     enabled: false
-#  - type: Tag # Persistence: Firebots can target reagent fires. Commented because they fail to reach wall fires
-#    tags:
-#    - ReagentFire
+  - type: Tag # Start Persistence: Firebots can target reagent fires. Commented because they fail to reach wall fires
+    tags:
+    - ReagentFire
+  - type: WallMount
+    arc: 360
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.5,-0.5,0.5,0.5"
+  - type: Physics
+    canCollide: false # End Persistence (I hate that HTN interacting with something on the same tile as a wall requires us to have a fixture, wallmount, and physics comp. Screaming!)
 
 - type: entity
   parent: PuddleSparkle

--- a/Resources/Prototypes/_Funkystation/Entities/Effects/wall_stains.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Effects/wall_stains.yml
@@ -42,6 +42,9 @@
     energy: 1.5
     color: "#FF5500"
     enabled: false
+#  - type: Tag # Persistence: Firebots can target reagent fires. Commented because they fail to reach wall fires
+#    tags:
+#    - ReagentFire
 
 - type: entity
   parent: PuddleSparkle

--- a/Resources/Prototypes/_Funkystation/Entities/Structures/Machines/washing_machine.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Structures/Machines/washing_machine.yml
@@ -22,9 +22,9 @@
   - type: WashingMachine
     washTime: 60
     cooldown: 10
-    bluntDamagePerSecond: 6
-    selfDamagePerSecond: 6
-    waterSprayAmount: 150
+    bluntDamagePerSecond: 1
+    selfDamagePerSecond: 1
+    waterSprayAmount: 15
     washLoopSound:
       path: /Audio/_Funkystation/Machines/washing_loop.ogg
       params:

--- a/Resources/Prototypes/_Funkystation/tags.yml
+++ b/Resources/Prototypes/_Funkystation/tags.yml
@@ -1,2 +1,5 @@
 - type: Tag # Funky Wall Stains
   id: DirectionalWindow
+
+- type: Tag # Persistence: Firebots can target reagent fires
+  id: ReagentFire


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- Footprints can no longer be formed in zero-gravity or on lattices
- Firebots are now _capable_ of putting out reagent fires & wall fires. _Capable_.
  - They occasionally get stuck trying to put out a fire on one wall while a neighboring wall blocks them. I don't know how to fix this
  - Regular reagent fires (puddles and footprints) are easily targeted by firebots, though it may take a lot of spraying to stop the fire.

These changes are fairly compartmentalized by commit for ease of review / cherry-pick

## Why / Balance
Bugfixes

## Technical details
- Early return from `OnEntityMoved` in `FootprintSystem` if we can find a `GravityAffectedComponent` that has `Weightless = false`
- Early return from `OnEntityMoved` in `FootprintSystem` if the current tile is considered space (no tile, lattice, maybe others?)
- New HTN query type `ComponentQueryAny`. This checks entities for any of the specified components.
- HTN condition `TargetOnFireCon` now checks for the tag `ReagentFire`. This tag has also been added to the puddle & wall fire entities.
- HTN utilityQuery NearbyOnFire now uses `ComponentQueryAny` & additionally checks for `ReagentPuddleFireEffect` & `WallStainFireVisuals`
- Wall fire prototype has had a few components (`WallMount`, `Fixtures`, `Physics`) added to it in order for the firebots to be able to properly target the fire. I hate this, and its not perfect, but its the only way I could get it working at all without making a mess out of the existing HTN code.

## Media


## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Footprints can no longer be formed in space or in zero-gravity.
- fix: Firebots are now capable of extinguishing reagent fires. Be warned they struggle with wall fires.
