### PR TITLE
fix missing ftl for using topicals when not in appropriate damage range

### DIFF
--- a/Content.Shared/Medical/Healing/HealingSystem.cs
+++ b/Content.Shared/Medical/Healing/HealingSystem.cs
@@ -200,7 +200,7 @@ public sealed class HealingSystem : EntitySystem
         }
         if (!TryConditions(healing, target))
         {
-            _popupSystem.PopupClient(Loc.GetString("topical-isn't-appropriate", ("item", healing.Owner)), healing, user);
+            _popupSystem.PopupClient(Loc.GetString("topical-isnt-appropriate", ("item", healing.Owner)), healing, user);
             return false;
         }
 

--- a/Resources/Locale/en-US/_Persistence14/items/topicals.ftl
+++ b/Resources/Locale/en-US/_Persistence14/items/topicals.ftl
@@ -1,1 +1,1 @@
-topical-isn't-appropriate = Can't use that now!
+topical-isnt-appropriate = Can't use that now!


### PR DESCRIPTION
## About the PR
With the current state of the repo, launching a dev server gives the following error message:
```
[ERRO] loc: /Locale/en-US/_Persistence14/items/topicals.ftl:
 1 |topical-isn't-appropriate = Can't use that now!
               ^ Expected a token starting with  "=" found "'" instead
[ERRO] loc: [/Locale/en-US/_Persistence14/items/topicals.ftl]: Expected a token starting with  "=" found "'" instead
```

Trying to use topicals in the wrong damage range also gives the text `topical-isn't-appropriate` instead of `Can't use that now!`

## Why / Balance
Bugfix