### PR TITLE
wall stains no longer make changes to entities while enumerating over…

### DIFF
--- a/Content.Server/_Funkystation/WallStains/Systems/WallStainSystem.cs
+++ b/Content.Server/_Funkystation/WallStains/Systems/WallStainSystem.cs
@@ -91,7 +91,7 @@ public sealed partial class WallStainSystem : EntitySystem
             return;
 
         var tilePos = _map.TileIndicesFor(gridUid.Value, grid, coords);
-
+        var stains = new Dictionary<EntityUid, Vector2i>();
         foreach (var offset in AdjacentTileOffsets)
         {
             var targetTile = tilePos + offset;
@@ -101,8 +101,13 @@ public sealed partial class WallStainSystem : EntitySystem
                 if (!IsWall(ent.Value))
                     continue;
 
-                ApplyStainToWall(ent.Value, solution, -offset, fraction: 0.25f);
+                stains.Add(ent.Value, offset);
             }
+        }
+
+        foreach ((var ent, var offset) in stains)
+        {
+            ApplyStainToWall(ent, solution, -offset, fraction: 0.25f);;
         }
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Below in the technical details section I'm going to pretend to know what I'm talking about. I don't really know what I'm talking about. I'm just pretending.

## Why / Balance
Thrown smoke-bomb tomatoes were becoming un-interactable& broken tomatoes upon colliding with a wall, which is not part of good cooking.

## Technical details
`WallStainSystem`'s `TrySplashOnWalls` uses an `AnchoredEntitiesEnumerator` when determining where to add a stain & to what entities. While enumerating over these entities, it was adding stains to them, which apparently is a big no-no for collections.
I added a dictionary of the important info we need from this loop & then we loop over that dictionary after the fact & apply the stains.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->