### PR TITLE
Ensure mobs are assigned a bank account when injected with Job Network implant

### DIFF
--- a/Content.Server/CrewAssignments/Systems/JobNetSystem.cs
+++ b/Content.Server/CrewAssignments/Systems/JobNetSystem.cs
@@ -22,6 +22,7 @@ using Content.Shared.CrewRecords.Components;
 using Content.Shared.Cuffs;
 using Content.Shared.Cuffs.Components;
 using Content.Shared.DoAfter;
+using Content.Shared.Implants;
 using Content.Shared.Implants.Components;
 using Content.Shared.Interaction;
 using Content.Shared.Mobs;
@@ -98,6 +99,7 @@ public sealed partial class JobNetSystem : SharedJobNetSystem
         SubscribeLocalEvent<JobNetComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<JobNetComponent, ComponentStartup>(OnStartup);
         SubscribeLocalEvent<JobNetComponent, ComponentShutdown>(OnShutdown);
+        SubscribeLocalEvent<JobNetComponent, ImplantImplantedEvent>(OnJobNetImplantImplanted);
         SubscribeLocalEvent<JobNetComponent, OpenJobNetImplantEvent>(OnImplantActivate);
         SubscribeLocalEvent<JobNetComponent, JobNetSelectMessage>(OnSelect);
         SubscribeLocalEvent<JobNetComponent, JobNetPurchaseMessage>(OnPurchase);
@@ -656,6 +658,12 @@ public sealed partial class JobNetSystem : SharedJobNetSystem
     private void OnImplantActivate(EntityUid uid, JobNetComponent component, OpenJobNetImplantEvent args)
     {
         ToggleUi(args.Performer, uid, component);
+    }
+
+    private void OnJobNetImplantImplanted(Entity<JobNetComponent> ent, ref ImplantImplantedEvent args)
+    {
+        var mob = args.Implanted;
+        _bank.EnsureAccount(Name(mob), 50);
     }
 
     public void TryAssignRogueObjective(EntityUid user, JobNetComponent component)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The game now assigns a bank account if one is not present when mobs are injected with the Job Network implant.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Previously, any mob that spawns without the Job Network implant (including humanoids) would not be assigned a bank account upon receiving the implant. This means they could get assigned jobs but any wages would just go to the void & any attempts to deposit money would fail. Now upon receiving the implant they are assigned a persistent bank account.

## Technical details
<!-- Summary of code changes for easier review. -->
Calls _bank.EnsureAccount() when the Job Implanter is used on a mob.

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Previous behavior:
https://github.com/user-attachments/assets/5b958118-e9df-4bbc-a19d-ce35a092487f

New behavior:
https://github.com/user-attachments/assets/28c52a54-6925-4890-b93f-7132de018fec

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Mobs are assigned a bank account when injected with Job Network implant
