### PR TITLE
fix: makes coldplate craftable

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/medical.yml
@@ -89,6 +89,7 @@
   - ChemMasterMachineCircuitboard
   - CondenserMachineCircuitBoard
   - HotplateMachineCircuitboard
+  - ColdplateMachineCircuitboard # Persistence
   - CrewMonitoringComputerCircuitboard
   - MedicalRecordsComputerCircuitboard
   - BodyScannerComputerCircuitboard

--- a/Resources/Prototypes/Recipes/Lathes/machine_boards.yml
+++ b/Resources/Prototypes/Recipes/Lathes/machine_boards.yml
@@ -227,6 +227,11 @@
   id: HotplateMachineCircuitboard
   result: HotplateMachineCircuitboard
 
+- type: latheRecipe # Persistence
+  parent: [ BaseCircuitboardRecipe, BaseMedicalMachineRecipeCategory ]
+  id: ColdplateMachineCircuitboard
+  result: ColdplateMachineCircuitboard
+
 - type: latheRecipe
   parent: [ BaseCircuitboardRecipe, BaseMedicalMachineRecipeCategory ]
   id: ElectrolysisUnitMachineCircuitboard

--- a/Resources/Prototypes/_Persistence14/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/_Persistence14/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -14,3 +14,17 @@
         GlassBeaker:
           amount: 2
           defaultPrototype: Beaker
+
+- type: entity
+  id: ColdplateMachineCircuitboard
+  parent: BaseMachineCircuitboard
+  name: coldplate machine board
+  description: A machine printed circuit board for a coldplate.
+  components:
+  - type: Sprite
+    state: medical
+  - type: MachineBoard
+    prototype: ChemistryColdplate
+    stackRequirements:
+      Manipulator: 2
+      Glass: 1

--- a/Resources/Prototypes/_Persistence14/Entities/Structures/Machines/coldplate.yml
+++ b/Resources/Prototypes/_Persistence14/Entities/Structures/Machines/coldplate.yml
@@ -23,7 +23,7 @@
     placeCentered: true
     positionOffset: 0, 0.25
   - type: Machine
-    board: HotplateMachineCircuitboard
+    board: ColdplateMachineCircuitboard
   - type: Appearance
   - type: GenericVisualizer
     visuals:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I forgot to make coldplate craftable in #610
This PR corrects that

## Why / Balance
New feature was inaccessible

## Technical details
New board, new recipe, added to existing lathe recipe pack, coldplate yaml corrected to match new board

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Coldplates are now craftable