### PR TITLE
Change directional/tiny fans to have machine boards

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
@@ -130,21 +130,21 @@
   group: market
 
 - type: cargoProduct
-  id: TinyFanCargo
+  id: TinyFanBoardCargo
   icon:
-    sprite: Objects/Devices/flatpack.rsi
-    state: fan
-  product: TinyFanFlatpack
+    sprite: Objects/Misc/module.rsi
+    state: engineering
+  product: AtmosDeviceFanTinyMachineCircuitBoard
   cost: 4000
   category: cargoproduct-category-name-engineering
   group: market
 
 - type: cargoProduct
-  id: DirectionalFanCargo
+  id: DirectionalFanBoardCargo
   icon:
-    sprite: Objects/Devices/flatpack.rsi
-    state: fan
-  product: DirectionalFanFlatpack
+    sprite: Objects/Misc/module.rsi
+    state: engineering
+  product: AtmosDeviceFanDirectionalMachineCircuitBoard
   cost: 4000
   category: cargoproduct-category-name-engineering
   group: market

--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -491,6 +491,30 @@
       Manipulator: 3
       Cable: 5
 
+# Start Persistence: make atmos fans into machines
+- type: entity
+  id: AtmosDeviceFanTinyMachineCircuitBoard
+  parent: BaseMachineCircuitboard
+  name: tiny fan machine board
+  description: A machine printed circuit board for a tiny fan.
+  components:
+  - type: Sprite
+    state: engineering
+  - type: MachineBoard
+    prototype: AtmosDeviceFanTiny
+
+- type: entity
+  id: AtmosDeviceFanDirectionalMachineCircuitBoard
+  parent: BaseMachineCircuitboard
+  name: directional fan machine board
+  description: A machine printed circuit board for a directional fan.
+  components:
+  - type: Sprite
+    state: engineering
+  - type: MachineBoard
+    prototype: AtmosDeviceFanDirectional
+# End Persistence
+
 - type: entity
   id: CloningPodMachineCircuitboard
   parent: BaseMachineCircuitboard

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/special.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/special.yml
@@ -1,5 +1,8 @@
 # Devices which are not portable but don't link up to anything
+
 - type: entity
+  # Persistence: make atmos fans into machines
+  parent: [ BaseMachinePowered, SmallConstructibleMachine ]
   id: AtmosDeviceFanTiny
   name: tiny fan
   description: A tiny fan, releasing a thin gust of air.
@@ -14,9 +17,10 @@
     bodyType: Static
   - type: ApcPowerReceiver
     powerLoad: 500
-  - type: ExtensionCableReceiver
-  - type: LightningTarget
-    priority: 1
+  # Persistence: make atmos fans into machines
+  #- type: ExtensionCableReceiver
+  #- type: LightningTarget
+  #  priority: 1
   - type: Sprite
     sprite: Structures/Piping/Atmospherics/tinyfan.rsi
     layers:
@@ -43,8 +47,15 @@
   - type: Tag
     tags:
       - SpreaderIgnore
+  # Persistence: make atmos fans into machines
+  - type: Machine
+    board: AtmosDeviceFanTinyMachineCircuitBoard
+  # Persistence: make atmos fans into machines
+  - type: WiresPanel
 
 - type: entity
+  # Persistence: make atmos fans into machines
+  parent: [ BaseMachinePowered, SmallConstructibleMachine ]
   id: AtmosDeviceFanDirectional
   name: directional fan
   description: A thin fan, stopping the movement of gases across it.
@@ -53,6 +64,8 @@
   components:
   - type: Transform
     anchored: true
+    # Persistence: make atmos fans into machines
+    noRot: false
   - type: Anchorable
   - type: Pullable
   - type: Rotatable
@@ -60,9 +73,10 @@
     bodyType: Static
   - type: ApcPowerReceiver
     powerLoad: 500
-  - type: ExtensionCableReceiver
-  - type: LightningTarget
-    priority: 1
+  # Persistence: make atmos fans into machines
+  #- type: ExtensionCableReceiver
+  #- type: LightningTarget
+  #  priority: 1
   - type: Sprite
     sprite: Structures/Piping/Atmospherics/directionalfan.rsi
     layers:
@@ -91,3 +105,8 @@
   - type: Tag
     tags:
       - SpreaderIgnore
+  # Persistence: make atmos fans into machines
+  - type: Machine
+    board: AtmosDeviceFanDirectionalMachineCircuitBoard
+  # Persistence: make atmos fans into machines
+  - type: WiresPanel


### PR DESCRIPTION
## About the PR
Directional fans and tiny fans now have respective machine boards. They can be bought from cargo.

## Why / Balance
After unflatpacking, moving them around was only possible by dragging which is slow and not fun if you had to move more than one.

## Technical details
yml only

## Breaking changes
No more cargo order for the flatpack (does that count as a breaking change?)