### PR TITLE
fix: GasGeyserComponent timer serialization

### DIFF
--- a/Content.Shared/_Persistence14/Atmos/Geyser/GasGeyserComponent.cs
+++ b/Content.Shared/_Persistence14/Atmos/Geyser/GasGeyserComponent.cs
@@ -1,6 +1,7 @@
 using Content.Shared.Atmos;
 using Content.Shared.MiningFluid.Components;
 using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
 namespace Content.Shared._Persistence14.Atmos.Geyser;
 
@@ -10,7 +11,7 @@ public sealed partial class GasGeyserComponent : Component
     /// <summary>
     /// Game time
     /// </summary>
-    [AutoPausedField, AutoNetworkedField]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField, AutoNetworkedField]
     public TimeSpan NextEruptionTime = TimeSpan.Zero;
 
     /// <summary>

--- a/Content.Shared/_Persistence14/Atmos/Geyser/GasGeyserComponent.cs
+++ b/Content.Shared/_Persistence14/Atmos/Geyser/GasGeyserComponent.cs
@@ -8,9 +8,9 @@ namespace Content.Shared._Persistence14.Atmos.Geyser;
 public sealed partial class GasGeyserComponent : Component
 {
     /// <summary>
-    /// Game time 
+    /// Game time
     /// </summary>
-    [DataField, AutoPausedField, AutoNetworkedField]
+    [AutoPausedField, AutoNetworkedField]
     public TimeSpan NextEruptionTime = TimeSpan.Zero;
 
     /// <summary>
@@ -20,13 +20,13 @@ public sealed partial class GasGeyserComponent : Component
     public TimeSpan EruptionDelay = TimeSpan.FromSeconds(60);
 
     /// <summary>
-    /// Amount of time added to <see cref="EruptionDelay"/> to get the maximum delay. 
+    /// Amount of time added to <see cref="EruptionDelay"/> to get the maximum delay.
     /// </summary>
     [DataField]
     public TimeSpan EruptionRangeDeltaPositive = TimeSpan.FromSeconds(0);
 
     /// <summary>
-    /// Amount of time subtracted from <see cref="EruptionDelay"/> to get the minimum delay. 
+    /// Amount of time subtracted from <see cref="EruptionDelay"/> to get the minimum delay.
     /// </summary>
     [DataField]
     public TimeSpan EruptionRangeDeltaNegative = TimeSpan.FromSeconds(0);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Preventing serialization of a round-timer based time field

## Why / Balance
Bugfix, this is a common issue with timer fields that are used for things like cooldowns.

## Technical details
Removed `Datafield` from `GasGeyserComponent`'s `NextEruptionTime`

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Gas geysers no longer get stuck in cooldown after save/load.
