### PR TITLE
make more gas tanks craftable

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/engineering.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/engineering.yml
@@ -38,6 +38,14 @@
   recipes:
   - AirTank
   - GasAnalyzer
+# Persistence: make other gas tanks craftable
+  - OxygenTank
+  - NitrogenTank
+  - NitrousOxideTank
+  - PlasmaTank
+  - EmergencyOxygenTank
+  - EmergencyNitrogenTank
+  - EmergencyFunnyOxygenTank
 
 - type: latheRecipePack
   id: ElectronicsStatic

--- a/Resources/Prototypes/Recipes/Lathes/Packs/externalclothes.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/externalclothes.yml
@@ -12,6 +12,8 @@
   - Chiefengineersuit
   - Captainsuit
   - ClothingHandsGlovesCaptain
+  - ExtendedEmergencyOxygenTank
+  - ExtendedEmergencyNitrogenTank
 
 - type: latheRecipePack
   id: SecurityHardsuits

--- a/Resources/Prototypes/Recipes/Lathes/misc.yml
+++ b/Resources/Prototypes/Recipes/Lathes/misc.yml
@@ -134,6 +134,75 @@
   materials:
     Steel: 400
 
+# Start Persistence: make o2/n2/etc tanks craftable
+
+- type: latheRecipe
+  id: OxygenTank
+  result: OxygenTank
+  completetime: 4
+  materials:
+    Steel: 400
+
+- type: latheRecipe
+  id: NitrogenTank
+  result: NitrogenTank
+  completetime: 4
+  materials:
+    Steel: 400
+
+- type: latheRecipe
+  id: NitrousOxideTank
+  result: NitrousOxideTank
+  completetime: 4
+  materials:
+    Steel: 400
+
+- type: latheRecipe
+  id: PlasmaTank
+  result: PlasmaTank
+  completetime: 4
+  materials:
+    Steel: 400
+
+- type: latheRecipe
+  id: EmergencyOxygenTank
+  result: EmergencyOxygenTank
+  completetime: 2
+  materials:
+    Steel: 200
+
+- type: latheRecipe
+  id: EmergencyNitrogenTank
+  result: EmergencyNitrogenTank
+  completetime: 2
+  materials:
+    Steel: 200
+
+- type: latheRecipe
+  id: EmergencyFunnyOxygenTank
+  result: EmergencyFunnyOxygenTank
+  completetime: 2
+  materials:
+    Steel: 200
+
+- type: latheRecipe
+  id: ExtendedEmergencyOxygenTank
+  result: ExtendedEmergencyOxygenTank
+  completetime: 3
+  materials:
+    Steel: 250
+  unlockUses: 4
+
+- type: latheRecipe
+  id: ExtendedEmergencyNitrogenTank
+  result: ExtendedEmergencyNitrogenTank
+  completetime: 3
+  materials:
+    Steel: 250
+  unlockUses: 4
+
+# End Persistence
+
 - type: latheRecipe
   id: DoubleEmergencyOxygenTank
   result: DoubleEmergencyOxygenTank

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -233,6 +233,8 @@
   - Engineeringsuit
   - Atmossuit
   - Miningsuit
+  - ExtendedEmergencyOxygenTank
+  - ExtendedEmergencyNitrogenTank
   technologyPrerequisites:
   - EVAManufacturing
 


### PR DESCRIPTION
## About the PR
Normal O2, N2, nitrous, plasma and standard emergency tanks can be made at an autolathe with no research. Extended emergency tanks can be made at a protolathe after researching specialised EVA (tech that unlocks engi/atmos/mining hardsuits). The price of the research is unchanged, and 4 prints are unlocked per research. Double emergency tanks are unchanged (only obtainable through salvage).

## Technical details
Only yaml changes.