### PR TITLE
Revision: Salvage Magnet POI

### DIFF
--- a/Content.Server/Salvage/Magnet/SalvageMagnetDataComponent.cs
+++ b/Content.Server/Salvage/Magnet/SalvageMagnetDataComponent.cs
@@ -29,13 +29,13 @@ public sealed partial class SalvageMagnetDataComponent : Component
     /// How long salvage will be active for before despawning.
     /// </summary>
     [DataField]
-    public TimeSpan ActiveTime = TimeSpan.FromMinutes(15);
+    public TimeSpan ActiveTime = TimeSpan.FromMinutes(6);
 
     /// <summary>
     /// Cooldown between offerings after one ends.
     /// </summary>
     [DataField]
-    public TimeSpan OfferCooldown = TimeSpan.FromMinutes(15);
+    public TimeSpan OfferCooldown = TimeSpan.FromMinutes(3);
 
     /// <summary>
     /// Seeds currently offered

--- a/Content.Shared/Salvage/SharedSalvageSystem.Magnet.cs
+++ b/Content.Shared/Salvage/SharedSalvageSystem.Magnet.cs
@@ -1,10 +1,12 @@
 using Content.Shared.Destructible.Thresholds;
 using Content.Shared.Procedural;
+using Content.Shared.Procedural.DungeonLayers;
 using Content.Shared.Random;
 using Content.Shared.Random.Helpers;
 using Content.Shared.Salvage.Magnet;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
+using Robust.Shared.Utility;
 
 namespace Content.Shared.Salvage;
 
@@ -16,7 +18,7 @@ public abstract partial class SharedSalvageSystem
     {
         { new AsteroidOffering(), 4.5f },
         { new DebrisOffering(), 3.5f },
-        { new SalvageOffering(), 2.0f },
+        // { new SalvageOffering(), 2.0f }, Persistence14: Only roids and Debris available (for now).
     };
 
     private readonly List<ProtoId<DungeonConfigPrototype>> _asteroidConfigs = new()
@@ -38,70 +40,68 @@ public abstract partial class SharedSalvageSystem
 
     public ISalvageMagnetOffering GetSalvageOffering(int seed)
     {
-        var rand = new System.Random(seed);
+        var rand = IoCManager.Resolve<IRobustRandom>();
+        rand.SetSeed(seed);
 
-        var id = rand.Pick(_debrisConfigs);
-        return new DebrisOffering
+        var type = rand.Pick(_offeringWeights);
+        switch (type)
         {
-            Id = id
-        };
+            case AsteroidOffering:
+                var configId = _asteroidConfigs[rand.Next(_asteroidConfigs.Count)];
+                var configProto = _proto.Index(configId);
+                var layers = new Dictionary<string, int>();
 
-        // var type = SharedRandomExtensions.Pick(_offeringWeights, rand); // # Persistence: Magnet only spawns wrecks
-        // switch (type)
-        // {
-        //     case AsteroidOffering:
-        //         var configId = _asteroidConfigs[rand.Next(_asteroidConfigs.Count)];
-        //         var configProto =_proto.Index(configId);
-        //         var layers = new Dictionary<string, int>();
-        //
-        //         var config = new DungeonConfig
-        //         {
-        //             Layers = new(configProto.Layers),
-        //             MaxCount = configProto.MaxCount,
-        //             MaxOffset = configProto.MaxOffset,
-        //             MinCount = configProto.MinCount,
-        //             MinOffset = configProto.MinOffset,
-        //             ReserveTiles = configProto.ReserveTiles
-        //         };
-        //
-        //         var count = _asteroidOreCount.Next(rand);
-        //         var weightedProto = _proto.Index(_asteroidOreWeights);
-        //         for (var i = 0; i < count; i++)
-        //         {
-        //             var ore = weightedProto.Pick(rand);
-        //             config.Layers.Add(_proto.Index<OreDunGenPrototype>(ore));
-        //
-        //             var layerCount = layers.GetOrNew(ore);
-        //             layerCount++;
-        //             layers[ore] = layerCount;
-        //         }
-        //
-        //         return new AsteroidOffering
-        //         {
-        //             Id = configId,
-        //             DungeonConfig = config,
-        //             MarkerLayers = layers,
-        //         };
-        //     case DebrisOffering:
-        //         var id = rand.Pick(_debrisConfigs);
-        //         return new DebrisOffering
-        //         {
-        //             Id = id
-        //         };
-        //     case SalvageOffering:
-        //         // Salvage map seed
-        //         _salvageMaps.Clear();
-        //         _salvageMaps.AddRange(_proto.EnumeratePrototypes<SalvageMapPrototype>());
-        //         _salvageMaps.Sort((x, y) => string.Compare(x.ID, y.ID, StringComparison.Ordinal));
-        //         var mapIndex = rand.Next(_salvageMaps.Count);
-        //         var map = _salvageMaps[mapIndex];
-        //
-        //         return new SalvageOffering
-        //         {
-        //             SalvageMap = map,
-        //         };
-        //     default:
-        //         throw new NotImplementedException($"Salvage type {type} not implemented!");
-        // }
+                var config = new DungeonConfig
+                {
+                    Layers = [.. configProto.Layers],
+                    MaxCount = configProto.MaxCount,
+                    MaxOffset = configProto.MaxOffset,
+                    MinCount = configProto.MinCount,
+                    MinOffset = configProto.MinOffset,
+                    ReserveTiles = configProto.ReserveTiles
+                };
+
+                var count = _asteroidOreCount.Next(rand);
+                var weightedProto = _proto.Index(_asteroidOreWeights);
+                for (var i = 0; i < count; i++)
+                {
+                    var ore = weightedProto.Pick(rand);
+                    config.Layers.Add(_proto.Index<OreDunGenPrototype>(ore));
+
+                    var layerCount = layers.GetOrNew(ore);
+                    layerCount++;
+                    layers[ore] = layerCount;
+                }
+
+                return new AsteroidOffering
+                {
+                    Id = configId,
+                    DungeonConfig = config,
+                    MarkerLayers = layers,
+                };
+
+            case DebrisOffering:
+                var id = rand.Pick(_debrisConfigs);
+                return new DebrisOffering
+                {
+                    Id = id
+                };
+
+            case SalvageOffering:
+                // Salvage map seed
+                _salvageMaps.Clear();
+                _salvageMaps.AddRange(_proto.EnumeratePrototypes<SalvageMapPrototype>());
+                _salvageMaps.Sort((x, y) => string.Compare(x.ID, y.ID, StringComparison.Ordinal));
+                var mapIndex = rand.Next(_salvageMaps.Count);
+                var map = _salvageMaps[mapIndex];
+
+                return new SalvageOffering
+                {
+                    SalvageMap = map,
+                };
+
+            default:
+                throw new NotImplementedException($"Salvage type {type} not implemented!");
+        }
     }
 }

--- a/Resources/Prototypes/Entities/Structures/Machines/salvage.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/salvage.yml
@@ -1,9 +1,11 @@
 - type: entity
-  parent: [ BaseMachinePowered, ConstructibleMachine ]
+  parent: [ BaseMachinePowered ] # Persistence14: ConstructableMachine removed from parent. We don't want these being deconstructed...
   id: SalvageMagnet
   name: salvage magnet
   description: Pulls in salvage.
   components:
+  - type: Anchorable
+    flags: Anchorable
   - type: Sprite
     sprite: Structures/Machines/salvage.rsi
     layers:
@@ -41,8 +43,6 @@
   - type: SalvageMagnet
   - type: ApcPowerReceiver
     powerLoad: 2500 # TODO change this to a HV power draw that really hits the grid hard WHEN active
-  - type: Machine
-    board: SalvageMagnetMachineCircuitboard
 
 # For Knightship
 - type: entity
@@ -54,11 +54,3 @@
   - type: SalvageMagnet
   - type: ApcPowerReceiver
     powerLoad: 1000
-
-#- type: weightedRandomEntity # pleasing the linter, these protos dont  exist
-#  id: RandomAsteroidPool
-#  weights:
-#    AsteroidSalvageSmall: 3
-#    AsteroidSalvageMedium: 7
-#    AsteroidSalvageLarge: 5
-#    AsteroidSalvageHuge: 3

--- a/Resources/Prototypes/Recipes/Lathes/Packs/cargo.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/cargo.yml
@@ -12,7 +12,7 @@
   id: CargoBoardsStatic
   recipes:
   - OreProcessorMachineCircuitboard
-  - SalvageMagnetMachineCircuitboard
+  # - SalvageMagnetMachineCircuitboard Persistence14: Removed in place of magnet POIs
   - RecyclerMachineCircuitboard
   - CargoBountyComputerCircuitboard
   - SalvageJobBoardComputerCircuitboard


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Makes a few changes to salvage magnets to make them behave more like the POI they will eventually be mapped as. Changes include:
* Salvage magnets are no longer craftable/deconstructable
* Salvage magnets are no longer unanchorable
* Salvage magnets can now spawn asteroids in addition to salvage wrecks
* Reduces active time of salvage magnets from 15 minutes to 6 minutes (back to upstream duration)
* Reduces refresh time of salvage magnets from 15 minutes to 3 minutes (back to upstream duration)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This is part of the larger changes to mapping that will enable salvage magnets to be balanced around being a POI instead of a readily available and craftable machine.

## Technical details
<!-- Summary of code changes for easier review. -->
* Removed commented out sections in `GetSalvageOffer` method inside `SharedSalvageSystem.Magnet`
* Adjusted default values in `SalvageMagnetDataComponent`
* Removed `SalvageMagnetMachineCircuitboard` from `CargoBoardsStatic` recipe pack
* Removed `ConstructableMachine` parent from `SalvageMagnet` in `salvage.yml`

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Any existing salvage magnets will suddenly become unmovable and any existing boards will not work.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Salvage magnets are no longer craftable or movable
- tweak: Asteroids can be spawned from salvage magnets
- tweak: Reduced salvage magnet timers