### PR TITLE
make more eva suits craftable

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/engineering.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/engineering.yml
@@ -46,6 +46,8 @@
   - EmergencyOxygenTank
   - EmergencyNitrogenTank
   - EmergencyFunnyOxygenTank
+# Persistence: make emergency eva suit craftable
+  - EmergencyEVAsuit
 
 - type: latheRecipePack
   id: ElectronicsStatic

--- a/Resources/Prototypes/Recipes/Lathes/Packs/externalclothes.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/externalclothes.yml
@@ -6,6 +6,8 @@
   - EVAsuitHelmet
   - Engineeringsuit
   - Atmossuit
+  - AtmosFireSuit
+  - AtmosFireHelmet
   - Miningsuit
   - Luxuryminingsuit
   - Researchdirectorsuit
@@ -27,3 +29,4 @@
   id: MedicalHardsuits
   recipes:
   - Chiefmedicalsuit
+  - Paramedsuit

--- a/Resources/Prototypes/Recipes/Lathes/hardsuits.yml
+++ b/Resources/Prototypes/Recipes/Lathes/hardsuits.yml
@@ -10,6 +10,19 @@
     Gold: 300
   unlockUses: 2
 
+# Tier 0 (unlocked without any research)
+
+- type: latheRecipe
+  parent: BaseHardsuitRecipe
+  id: EmergencyEVAsuit
+  result: ClothingOuterSuitEmergency
+  materials:
+    Plastic: 500
+    Steel: 100
+    Cloth: 200
+    Plasteel: 200
+    Durathread: 500
+
 # Tier 1 (Spationauts and Standard EVA)
 
 - type: latheRecipe
@@ -74,6 +87,29 @@
 
 - type: latheRecipe
   parent: BaseHardsuitRecipe
+  id: AtmosFireSuit
+  result: ClothingOuterSuitAtmosFire
+  materials:
+    Plasteel: 1500
+    Durathread: 1000
+    Silver: 200
+    Gold: 200
+  completetime: 20
+
+- type: latheRecipe
+  parent: BaseHardsuitRecipe
+  id: AtmosFireHelmet
+  result: ClothingHeadHelmetAtmosFire
+  materials:
+    Plasteel: 500
+    Durathread: 500
+    Glass: 500
+    Silver: 100
+    Gold: 100
+  completetime: 20
+
+- type: latheRecipe
+  parent: BaseHardsuitRecipe
   id: Miningsuit
   result: ClothingOuterHardsuitSalvage
   materials:
@@ -83,6 +119,19 @@
     Silver: 500
     Gold: 500
     Uranium: 300
+  completetime: 20
+
+- type: latheRecipe
+  parent: BaseHardsuitRecipe
+  id: Paramedsuit
+  result: ClothingOuterHardsuitVoidParamed
+  materials:
+    Plasteel: 1500
+    Durathread: 2000
+    Silver: 200
+    Gold: 150
+    Glass: 500
+
   completetime: 20
 
 # Tier 3 (Head Departmental Suits)

--- a/Resources/Prototypes/Research/industrial.yml
+++ b/Resources/Prototypes/Research/industrial.yml
@@ -232,9 +232,12 @@
   recipeUnlocks:
   - Engineeringsuit
   - Atmossuit
+  - AtmosFireSuit
+  - AtmosFireHelmet
   - Miningsuit
   - ExtendedEmergencyOxygenTank
   - ExtendedEmergencyNitrogenTank
+  - Paramedsuit
   technologyPrerequisites:
   - EVAManufacturing
 


### PR DESCRIPTION
## About the PR
Make more eva suits craftable (emergency eva, atmos fire suit+helmet and paramed suit)

## Why / Balance
No idea how to balance the recipe costs. Emergency eva suit is craftable on an autolathe, the others need the same research as for the regular atmos/engi/mining hardsuit. 2 prints per research, same as the others.

## Technical details
only yaml