### PR TITLE
Added a point penalty for triggers unlocked via artefixium

### DIFF
--- a/Content.Shared/Xenoarchaeology/Artifact/Components/XenoArtifactNodeComponent.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/Components/XenoArtifactNodeComponent.cs
@@ -132,6 +132,25 @@ public sealed partial class XenoArtifactNodeComponent : Component
     /// </summary>
     [DataField, AutoNetworkedField]
     public int ConsumedResearchValue;
+
+    /// <summary>
+    /// Fraction (0-1) of this node's required triggers that artifexium filled in rather than being
+    /// triggered manually. 0 = unlocked normally. Drives the research penalty in UpdateNodeResearchValue.
+    /// </summary>
+    [DataField]
+    public float ArtifexiumUnlockFraction;
+
+    /// <summary>
+    /// Research reduction applied when this node was barely artifexium-assisted (fraction -> 0).
+    /// </summary>
+    [DataField]
+    public float ArtifexiumMinPenalty = 0.1f;
+
+    /// <summary>
+    /// Research reduction applied when this node was fully artifexium-unlocked (fraction = 1).
+    /// </summary>
+    [DataField]
+    public float ArtifexiumMaxPenalty = 0.5f;
     #endregion
 }
 

--- a/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Node.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Node.cs
@@ -407,6 +407,16 @@ public abstract partial class SharedXenoArtifactSystem
         var nodeDepth = node.Comp.Depth;
         var depthMultipler = Math.Pow(1.5f, Math.Pow(nodeDepth, 1.5f));
         nodeComponent.ResearchValue = (int)(nodeComponent.BasePointValue * depthMultipler * durabilityMultiplier);
+
+        // Nodes that were unlocked by artifexium wildcards instead of by satisfying their triggers
+        // yield fewer points, scaled by how much of the unlock the chemical actually covered.
+        if (nodeComponent.ArtifexiumUnlockFraction > 0f)
+        {
+            var artifexiumFraction = Math.Clamp(nodeComponent.ArtifexiumUnlockFraction, 0f, 1f);
+            var penalty = nodeComponent.ArtifexiumMinPenalty + (nodeComponent.ArtifexiumMaxPenalty - nodeComponent.ArtifexiumMinPenalty) * artifexiumFraction;
+            nodeComponent.ResearchValue = (int)(nodeComponent.ResearchValue * (1f - penalty));
+        }
+
         Dirty(node);
     }
 

--- a/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Unlock.cs
+++ b/Content.Shared/Xenoarchaeology/Artifact/SharedXenoArtifactSystem.Unlock.cs
@@ -70,8 +70,10 @@ public abstract partial class SharedXenoArtifactSystem
         XenoArtifactUnlockingComponent unlockingComponent = ent;
 
         SoundSpecifier? soundEffect;
-        if (TryGetNodeFromUnlockState(ent, out var node))
+        if (TryGetNodeFromUnlockState(ent, out var node, out var artifexiumFraction))
         {
+            // Record how much of this node's unlock artifexium covered before its point value is computed.
+            node.Value.Comp.ArtifexiumUnlockFraction = artifexiumFraction;
             SetNodeUnlocked((ent, artifactComponent), node.Value);
             ActivateNode((ent, ent), (node.Value, node.Value), null, null, Transform(ent).Coordinates, false);
             unlockAttemptResultMsg = "artifact-unlock-state-end-success";
@@ -107,11 +109,13 @@ public abstract partial class SharedXenoArtifactSystem
     /// </summary>
     public bool TryGetNodeFromUnlockState(
         Entity<XenoArtifactUnlockingComponent, XenoArtifactComponent> ent,
-        [NotNullWhen(true)] out Entity<XenoArtifactNodeComponent>? node
+        [NotNullWhen(true)] out Entity<XenoArtifactNodeComponent>? node,
+        out float artifexiumFraction
     )
     {
         node = null;
-        var potentialNodes = new ValueList<Entity<XenoArtifactNodeComponent>>();
+        artifexiumFraction = 0f;
+        var potentialNodes = new ValueList<(Entity<XenoArtifactNodeComponent> Node, float Fraction)>();
 
         var artifactUnlockingComponent = ent.Comp1;
         foreach (var nodeIndex in GetAllNodeIndices((ent, ent)))
@@ -132,6 +136,7 @@ public abstract partial class SharedXenoArtifactSystem
                     continue;
 
                 node = curNode;
+                artifexiumFraction = 0f; // unlocked normally, no penalty
                 return true; // exit early
             }
 
@@ -145,11 +150,17 @@ public abstract partial class SharedXenoArtifactSystem
             if (missingTriggers > wildcardsAvailable)
                 continue;
 
-            potentialNodes.Add(curNode);
+            // Fraction of this node's triggers that artifexium covered rather than being triggered manually.
+            var fraction = requiredIndices.Count > 0 ? (float) missingTriggers / requiredIndices.Count : 0f;
+            potentialNodes.Add((curNode, fraction));
         }
 
         if (potentialNodes.Count != 0)
-            node = RobustRandom.Pick(potentialNodes);
+        {
+            var picked = RobustRandom.Pick(potentialNodes);
+            node = picked.Node;
+            artifexiumFraction = picked.Fraction;
+        }
 
         return node != null;
     }


### PR DESCRIPTION
## About the PR
Xeno artifact nodes that are unlocked using artifexium now yield reduced
research points, scaled by how much of the unlock the chemical did the work for.

## Why / Balance
Artifexium lets you brute-force a node's unlock by paying for missing triggers
instead of solving them, bypassing the intended xenoarch gameplay loop, especially 
when it's done by bulk (shotgun research). This
adds an opportunity cost: force-unlocking with chem trades research value for
convenience. A node whose triggers were all satisfied manually is unaffected;
a fully chem-unlocked node loses the most. The penalty scales linearly with the
fraction of the node's required triggers that artifexium covered (default 10%
at minimum involvement up to 50% for a fully chemical unlock), so partial
assistance is only partially penalized.

## Technical details
- `XenoArtifactNodeComponent`: added `ArtifexiumUnlockFraction` (stored per node)
  plus tunable `ArtifexiumMinPenalty` (0.1) and `ArtifexiumMaxPenalty` (0.5).
- `TryGetNodeFromUnlockState` now reports the chosen node's artifexium fraction
  (`missingTriggers / requiredTriggers`), computed from the wildcard logic that
  already existed; the exact-match (non-artifexium) path returns 0.
- `FinishUnlockingState` stamps that fraction onto the node before points are
  computed (the unlocking component is temporary and deleted right after, so the
  value must be copied onto the surviving node here).
- `UpdateNodeResearchValue` multiplies the final `ResearchValue` by
  `(1 - penalty)`, where `penalty = min + (max - min) * fraction`. Because
  extraction and cargo pricing both derive from `ResearchValue`, the penalty
  flows through both with no double-counting.


## Breaking changes
`SharedXenoArtifactSystem.TryGetNodeFromUnlockState` gained an
`out float artifexiumFraction` parameter. Any external caller of this public
method must add the argument.

**Changelog**

:cl:
- tweak: Unlocking artifact nodes with artifexium now reduces the research points they're worth, scaling with how much of the unlock the chemical did for you.

# DISCLAIMER
AI used for the following: 
- Help me quickly identify the best places to hook the new feature
- Writing the PR
- Documentation of the code