### PR TITLE
fix: Corrects usage of TimeOffsetSerializer for some component TimeSpan fields

### DIFF
--- a/Content.Server/Animals/Components/EggLayerComponent.cs
+++ b/Content.Server/Animals/Components/EggLayerComponent.cs
@@ -2,6 +2,7 @@ using Content.Server.Animals.Systems;
 using Content.Shared.Storage;
 using Robust.Shared.Audio;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom; // Persistence: TimeOffsetSerializer
 
 namespace Content.Server.Animals.Components;
 
@@ -51,6 +52,6 @@ public sealed partial class EggLayerComponent : Component
     /// <summary>
     ///     When to next try to produce.
     /// </summary>
-    [DataField, AutoPausedField]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField] // Persistence: TimeOffsetSerializer
     public TimeSpan NextGrowth = TimeSpan.Zero;
 }

--- a/Content.Server/Anomaly/Components/TechAnomalyComponent.cs
+++ b/Content.Server/Anomaly/Components/TechAnomalyComponent.cs
@@ -2,6 +2,7 @@ using Content.Server.Anomaly.Effects;
 using Content.Shared.Destructible.Thresholds;
 using Content.Shared.DeviceLinking;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom; // Persistence: TimeOffsetSerializer
 
 namespace Content.Server.Anomaly.Components;
 
@@ -53,7 +54,7 @@ public sealed partial class TechAnomalyComponent : Component
     /// <summary>
     /// time until the next activation of the timer ports
     /// </summary>
-    [DataField, AutoPausedField]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField] // Persistence: TimeOffsetSerializer
     public TimeSpan NextTimer = TimeSpan.Zero;
 
     [DataField]

--- a/Content.Server/Atmos/Piping/Unary/Components/GasVentPumpComponent.cs
+++ b/Content.Server/Atmos/Piping/Unary/Components/GasVentPumpComponent.cs
@@ -2,6 +2,7 @@ using Content.Shared.Atmos;
 using Content.Shared.Atmos.Piping.Unary.Components;
 using Content.Shared.DeviceLinking;
 using Content.Shared.Guidebook;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom; // Persistence: TimeOffsetSerializer
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
 namespace Content.Server.Atmos.Piping.Unary.Components
@@ -66,7 +67,7 @@ namespace Content.Server.Atmos.Piping.Unary.Components
         /// <summary>
         /// The time when the manual pressure lockout will be reenabled.
         /// </summary>
-        [DataField]
+        [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))] // Persistence: TimeOffsetSerializer
         [AutoPausedField]
         public TimeSpan ManualLockoutReenabledAt;
         /// <summary>

--- a/Content.Server/Ghost/Components/SpookySpeakerComponent.cs
+++ b/Content.Server/Ghost/Components/SpookySpeakerComponent.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Dataset;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom; // Persistence: TimeOffsetSerializer
 
 namespace Content.Server.Ghost.Components;
 
@@ -32,6 +33,6 @@ public sealed partial class SpookySpeakerComponent : Component
     /// <summary>
     /// Time when the cooldown will have elapsed and the entity can speak again.
     /// </summary>
-    [DataField, AutoPausedField]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField] // Persistence: TimeOffsetSerializer
     public TimeSpan NextSpeakTime;
 }

--- a/Content.Server/Kitchen/Components/MicrowaveComponent.cs
+++ b/Content.Server/Kitchen/Components/MicrowaveComponent.cs
@@ -3,6 +3,7 @@ using Content.Shared.Item;
 using Robust.Shared.Audio;
 using Robust.Shared.Containers;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom; // Persistence: TimeOffsetSerializer
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
 namespace Content.Server.Kitchen.Components
@@ -58,7 +59,7 @@ namespace Content.Server.Kitchen.Components
         /// <summary>
         /// Tracks the elapsed time of the current cook timer.
         /// </summary>
-        [DataField, ViewVariables(VVAccess.ReadWrite)]
+        [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), ViewVariables(VVAccess.ReadWrite)] // Persistence: TimeOffsetSerializer
         public TimeSpan CurrentCookTimeEnd = TimeSpan.Zero;
 
         /// <summary>

--- a/Content.Server/ParticleAccelerator/Components/ParticleAcceleratorControlBoxComponent.cs
+++ b/Content.Server/ParticleAccelerator/Components/ParticleAcceleratorControlBoxComponent.cs
@@ -74,7 +74,7 @@ public sealed partial class ParticleAcceleratorControlBoxComponent : Component
     /// <summary>
     /// The time at which the PA last fired a wave of particles.
     /// </summary>
-    [DataField("lastFire")]
+    [DataField("lastFire", customTypeSerializer: typeof(TimeOffsetSerializer))] // Persistence: TimeOffsetSerializer
     [ViewVariables(VVAccess.ReadWrite)]
     public TimeSpan LastFire;
 

--- a/Content.Server/Physics/Components/ChasingWalkComponent.cs
+++ b/Content.Server/Physics/Components/ChasingWalkComponent.cs
@@ -15,7 +15,7 @@ public sealed partial class ChasingWalkComponent : Component
     /// <summary>
     /// The next moment in time when the entity is pushed toward its goal
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), ViewVariables(VVAccess.ReadWrite)] // Persistence: TimeOffsetSerializer
     [AutoPausedField]
     public TimeSpan NextImpulseTime;
 

--- a/Content.Server/Singularity/Components/GravityWellComponent.cs
+++ b/Content.Server/Singularity/Components/GravityWellComponent.cs
@@ -1,4 +1,5 @@
 using Content.Server.Singularity.EntitySystems;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom; // Persistence: TimeOffsetSerializer
 
 namespace Content.Server.Singularity.Components;
 
@@ -51,7 +52,7 @@ public sealed partial class GravityWellComponent : Component
     /// <summary>
     /// The next time at which this gravity well should pulse.
     /// </summary>
-    [DataField, Access(typeof(GravityWellSystem)), AutoPausedField]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), Access(typeof(GravityWellSystem)), AutoPausedField] // Persistence: TimeOffsetSerializer
     public TimeSpan NextPulseTime { get; internal set; } = default!;
 
     /// <summary>

--- a/Content.Server/Tesla/Components/LightningArcShooterComponent.cs
+++ b/Content.Server/Tesla/Components/LightningArcShooterComponent.cs
@@ -1,5 +1,6 @@
 using Content.Server.Tesla.EntitySystems;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom; // Persistence: TimeOffsetSerializer
 
 namespace Content.Server.Tesla.Components;
 
@@ -44,7 +45,7 @@ public sealed partial class LightningArcShooterComponent : Component
     /// <summary>
     /// The time, upon reaching which the next batch of lightning bolts will be fired.
     /// </summary>
-    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), ViewVariables(VVAccess.ReadWrite)] // Persistence: TimeOffsetSerializer
     [AutoPausedField]
     public TimeSpan NextShootTime;
 

--- a/Content.Shared/Animals/UdderComponent.cs
+++ b/Content.Shared/Animals/UdderComponent.cs
@@ -47,7 +47,7 @@ public sealed partial class UdderComponent : Component
     /// <summary>
     ///     How long to wait before producing.
     /// </summary>
-    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField]
+    [DataField, AutoNetworkedField] // Persistence: Remove TimeOffsetSerializer
     public TimeSpan GrowthDelay = TimeSpan.FromMinutes(1);
 
     /// <summary>

--- a/Content.Shared/Animals/WoolyComponent.cs
+++ b/Content.Shared/Animals/WoolyComponent.cs
@@ -3,6 +3,7 @@ using Content.Shared.Chemistry.Reagent;
 using Content.Shared.FixedPoint;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom; // Persistence: TimeOffsetSerializer
 
 namespace Content.Shared.Animals;
 
@@ -52,6 +53,6 @@ public sealed partial class WoolyComponent : Component
     /// <summary>
     ///     When to next try growing wool.
     /// </summary>
-    [DataField, AutoPausedField, Access(typeof(WoolySystem))]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField, Access(typeof(WoolySystem))] // Persistence: TimeOffsetSerializer
     public TimeSpan NextGrowth = TimeSpan.Zero;
 }

--- a/Content.Shared/Turrets/DeployableTurretComponent.cs
+++ b/Content.Shared/Turrets/DeployableTurretComponent.cs
@@ -3,6 +3,7 @@ using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom; // Persistence: TimeOffsetSerializer
 
 namespace Content.Shared.Turrets;
 
@@ -20,13 +21,13 @@ public sealed partial class DeployableTurretComponent : Component
     public bool Enabled = false;
 
     /// <summary>
-    /// The current state of the turret. Used to inform the device network. 
+    /// The current state of the turret. Used to inform the device network.
     /// </summary>
     [DataField, AutoNetworkedField]
     public DeployableTurretState CurrentState = DeployableTurretState.Retracted;
 
     /// <summary>
-    /// The visual state of the turret. Used on the client-side. 
+    /// The visual state of the turret. Used on the client-side.
     /// </summary>
     [DataField]
     public DeployableTurretState VisualState = DeployableTurretState.Retracted;
@@ -88,7 +89,7 @@ public sealed partial class DeployableTurretComponent : Component
     /// <summary>
     /// The time that the current animation should complete (in seconds)
     /// </summary>
-    [DataField, AutoPausedField]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoPausedField]  // Persistence: TimeOffsetSerializer
     public TimeSpan AnimationCompletionTime = TimeSpan.Zero;
 
     /// <summary>

--- a/Content.Shared/_Persistence14/Requisitions/RequisitionsConsoleComponent.cs
+++ b/Content.Shared/_Persistence14/Requisitions/RequisitionsConsoleComponent.cs
@@ -4,6 +4,7 @@ using Content.Shared.Materials;
 using Content.Shared.Research.Prototypes;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom; // Persistence: TimeOffsetSerializer
 
 namespace Content.Shared._Persistence14.Requisitions;
 
@@ -108,7 +109,7 @@ public sealed partial class RequisitionsConsoleComponent : Component
     public string FlatpackStorageId = "requisitions-flatpack-storage";
 
     // Earliest time to retry feeding a flatpacker, so a stalled pack doesn't churn every tick.
-    [DataField]
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))] // Persistence: TimeOffsetSerializer
     public TimeSpan NextFlatpackTry;
 
     #endregion


### PR DESCRIPTION
## About the PR
Searched the project for all classes inheriting from Component that contain a variable of type `TimeSpan`, inspected related comments to make determination about whether these usages of `TimeSpan` need a `[DataField]`, or needs to use the `TimeOffsetSerializer`

Disclaimer: My search was done using a RegEx generated in part by Bonsai 27B (I'll learn RegEx one day I swear). 
All edits & determinations regarding which fields to edit were done by me

## Why / Balance
I learned about TimeOffsetSerializer recently & there are certainly a number of components that I've just ripped `[DataField]` off of in the past.

## Technical details
adding/removing `(customTypeSerializer: typeof(TimeOffsetSerializer))` from `[DataField]`
importing `using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;` when necessary

## Media
<!-- Attach media if the PR makes in-game changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
