### PR TITLE
Feature: Radioactive Decay and Activation

### DIFF
--- a/Content.Server/Radiation/Systems/RadiationSystem.GridCast.cs
+++ b/Content.Server/Radiation/Systems/RadiationSystem.GridCast.cs
@@ -169,6 +169,10 @@ public partial class RadiationSystem
         if (source.Transform.MapID != destTrs.MapID)
             return null;
 
+        // Persistence14 - Prevents entities from irradiating themself.
+        if (source.Entity.Owner == destUid)
+            return null;
+
         var mapId = destTrs.MapID;
 
         // get direction from rad source to destination and its distance

--- a/Content.Server/Radiation/Systems/RadiationSystem.GridCast.cs
+++ b/Content.Server/Radiation/Systems/RadiationSystem.GridCast.cs
@@ -117,9 +117,11 @@ public partial class RadiationSystem
             // if no radiation rays reached target, that will set it to 0
             receiver.Comp.CurrentRadiation = rads;
 
-            // also send an event with combination of total rad
-            if (rads > 0)
-                IrradiateEntity(receiver, rads, GridcastUpdateRate);
+            if (rads <= 0)
+                continue;
+
+            IrradiateEntity(receiver, rads, GridcastUpdateRate);
+            IncreaseSourceIntensity(receiver.Owner, rads, GridcastUpdateRate);
         }
 
         // raise broadcast event that radiation system has updated
@@ -132,7 +134,7 @@ public partial class RadiationSystem
         if (interval <= 0f || interval <= GridcastUpdateRate)
             return true;
 
-        var now = (float) _timing.CurTime.TotalSeconds;
+        var now = (float)_timing.CurTime.TotalSeconds;
 
         if (!source.UpdateScheduleInitialized)
         {
@@ -140,7 +142,7 @@ public partial class RadiationSystem
 
             if (source.StaggerUpdates)
             {
-                var phase = (uint) uid.Id % 1024u;
+                var phase = (uint)uid.Id % 1024u;
                 var offset = interval * (phase / 1024f);
                 source.NextUpdateTime = now + offset;
             }

--- a/Content.Server/Radiation/Systems/RadiationSystem.cs
+++ b/Content.Server/Radiation/Systems/RadiationSystem.cs
@@ -48,6 +48,7 @@ public sealed partial class RadiationSystem : EntitySystem
 
         UpdateGridcast();
         UpdateResistanceDebugOverlay();
+        UpdateDecay(_accumulator);
         _accumulator = 0f;
     }
 

--- a/Content.Server/_Persistence14/EntityEffects/IrradiateEntityEffectSystem.cs
+++ b/Content.Server/_Persistence14/EntityEffects/IrradiateEntityEffectSystem.cs
@@ -29,7 +29,8 @@ public sealed partial class IrradiateEntityEffectSystem : EntityEffectSystem<Tra
         if (args.Effect.Activates)
         {
             EnsureComp<RadiationActivationComponent>(entity.Owner, out var activationComponent);
-            activationComponent.MaxIntensity = args.Effect.MaxIntensity;
+            if (activationComponent.MaxIntensity < args.Effect.MaxIntensity)
+                activationComponent.MaxIntensity = args.Effect.MaxIntensity;
         }
     }
 }

--- a/Content.Server/_Persistence14/EntityEffects/IrradiateEntityEffectSystem.cs
+++ b/Content.Server/_Persistence14/EntityEffects/IrradiateEntityEffectSystem.cs
@@ -1,0 +1,35 @@
+using Content.Shared._Persistence14.EntityEffects;
+using Content.Shared._Persistence14.Radiation;
+using Content.Shared.EntityEffects;
+using Content.Shared.Radiation.Components;
+using Robust.Shared.Physics;
+
+namespace Content.Server._Persistence14.EntityEffects;
+
+public sealed partial class IrradiateEntityEffectSystem : EntityEffectSystem<TransformComponent, Irradiate>
+{
+    protected override void Effect(Entity<TransformComponent> entity, ref EntityEffectEvent<Irradiate> args)
+    {
+        if (!TryComp<RadiationSourceComponent>(entity.Owner, out var sourceComponent))
+        {
+            if (!args.Effect.AddComponentIfAbsent)
+                return;
+
+            sourceComponent = AddComp<RadiationSourceComponent>(entity.Owner);
+            sourceComponent.Intensity = 0f;
+        }
+        sourceComponent.Intensity += args.Effect.Intensity;
+
+        if (args.Effect.Decays)
+        {
+            EnsureComp<RadioactiveDecayComponent>(entity.Owner, out var decayComponent);
+            decayComponent.HalfLife = args.Effect.HalfLife;
+        }
+
+        if (args.Effect.Activates)
+        {
+            EnsureComp<RadiationActivationComponent>(entity.Owner, out var activationComponent);
+            activationComponent.MaxIntensity = args.Effect.MaxIntensity;
+        }
+    }
+}

--- a/Content.Server/_Persistence14/Radiation/RadiationCommands.cs
+++ b/Content.Server/_Persistence14/Radiation/RadiationCommands.cs
@@ -38,13 +38,11 @@ public sealed partial class AddRadiationCommand : IConsoleCommand
         if (_entityManager.TryGetComponent<RadiationSourceComponent>(ent, out var source))
         {
             source.Intensity += intensity;
-            _entityManager.Dirty(ent, source);
             return;
         }
 
         source = _entityManager.AddComponent<RadiationSourceComponent>(ent);
         source.Intensity = intensity;
-        _entityManager.Dirty(ent, source);
         return;
     }
 }

--- a/Content.Server/_Persistence14/Radiation/RadiationCommands.cs
+++ b/Content.Server/_Persistence14/Radiation/RadiationCommands.cs
@@ -1,0 +1,78 @@
+using Content.Server.Administration;
+using Content.Shared.Radiation.Components;
+using Robust.Shared.Console;
+
+namespace Content.Server._Persistence14.Radiation;
+
+[AdminCommand(Shared.Administration.AdminFlags.Admin | Shared.Administration.AdminFlags.Debug)]
+public sealed partial class AddRadiationCommand : IConsoleCommand
+{
+    [Dependency] private IEntityManager _entityManager = default!;
+
+    public string Command => "addrad";
+    public string Description => "Adds radiation intensity to the target (even if they aren't radioactive already).";
+    public string Help => "addrad <EntityUid> <Intensity>";
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Length != 2)
+        {
+            shell.WriteError(Help);
+            return;
+        }
+
+        if (!NetEntity.TryParse(args[0], out var netEntity))
+        {
+            shell.WriteError($"Invalid Entity: {args[0]}");
+            return;
+        }
+
+        if (!float.TryParse(args[1], out var intensity) || intensity < 0f)
+        {
+            shell.WriteError($"Invalid numeric value: {args[1]}");
+            return;
+        }
+
+        var ent = _entityManager.GetEntity(netEntity);
+
+        if (_entityManager.TryGetComponent<RadiationSourceComponent>(ent, out var source))
+        {
+            source.Intensity += intensity;
+            _entityManager.Dirty(ent, source);
+            return;
+        }
+
+        source = _entityManager.AddComponent<RadiationSourceComponent>(ent);
+        source.Intensity = intensity;
+        _entityManager.Dirty(ent, source);
+        return;
+    }
+}
+
+[AdminCommand(Shared.Administration.AdminFlags.Admin | Shared.Administration.AdminFlags.Debug)]
+public sealed partial class ClearRadiationCommand : IConsoleCommand
+{
+    [Dependency] private IEntityManager _entityManager = default!;
+
+    public string Command => "clearrad";
+    public string Description => "Removes the radiation source component (and thus all radiation) from an entity.";
+    public string Help => "clearrad <EntityUid>";
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Length != 1)
+        {
+            shell.WriteError(Help);
+            return;
+        }
+
+        if (!NetEntity.TryParse(args[0], out var netEntity))
+        {
+            shell.WriteError($"Invalid Entity: {args[0]}");
+            return;
+        }
+
+        var ent = _entityManager.GetEntity(netEntity);
+        _entityManager.RemoveComponent<RadiationSourceComponent>(ent);
+    }
+}

--- a/Content.Server/_Persistence14/Radiation/RadiationSystem.Activation.cs
+++ b/Content.Server/_Persistence14/Radiation/RadiationSystem.Activation.cs
@@ -7,29 +7,21 @@ public sealed partial class RadiationSystem
 {
     private void IncreaseSourceIntensity(Entity<RadiationActivationComponent?> activation, float rads, float frameTime)
     {
-        if (!Resolve(activation, ref activation.Comp))
+        if (!Resolve(activation, ref activation.Comp, false))
             return;
 
         var increase = CalculateIntensityIncrease((activation, activation.Comp), rads, frameTime);
-
         if (increase <= 0f)
             return;
 
-
         if (!TryComp<RadiationSourceComponent>(activation, out var radiationSource))
         {
-            if (TryComp<RadioactiveDecayComponent>(activation.Owner, out var decay) && increase < decay.MinimumRadiationIntesnity)
-                return;
-
             radiationSource = AddComp<RadiationSourceComponent>(activation.Owner);
             radiationSource.Intensity = increase;
         }
-        else
-        {
-            if (TryComp<RadioactiveDecayComponent>(activation.Owner, out var decay) && radiationSource.Intensity + increase < decay.MinimumRadiationIntesnity)
-                return;
+        else if (rads > radiationSource.Intensity)
             radiationSource.Intensity += increase;
-        }
+
         if (radiationSource.Intensity > activation.Comp.MaxIntensity)
             radiationSource.Intensity = activation.Comp.MaxIntensity;
     }

--- a/Content.Server/_Persistence14/Radiation/RadiationSystem.Activation.cs
+++ b/Content.Server/_Persistence14/Radiation/RadiationSystem.Activation.cs
@@ -1,0 +1,42 @@
+using Content.Shared._Persistence14.Radiation;
+using Content.Shared.Radiation.Components;
+
+namespace Content.Server.Radiation.Systems;
+
+public sealed partial class RadiationSystem
+{
+    private void IncreaseSourceIntensity(Entity<RadiationActivationComponent?> activation, float rads, float frameTime)
+    {
+        if (!Resolve(activation, ref activation.Comp))
+            return;
+
+        var increase = CalculateIntensityIncrease((activation, activation.Comp), rads, frameTime);
+
+        if (increase <= 0f)
+            return;
+
+
+        if (!TryComp<RadiationSourceComponent>(activation, out var radiationSource))
+        {
+            if (TryComp<RadioactiveDecayComponent>(activation.Owner, out var decay) && increase < decay.MinimumRadiationIntesnity)
+                return;
+
+            radiationSource = AddComp<RadiationSourceComponent>(activation.Owner);
+            radiationSource.Intensity = increase;
+        }
+        else
+        {
+            if (TryComp<RadioactiveDecayComponent>(activation.Owner, out var decay) && radiationSource.Intensity + increase < decay.MinimumRadiationIntesnity)
+                return;
+            radiationSource.Intensity += increase;
+        }
+        if (radiationSource.Intensity > activation.Comp.MaxIntensity)
+            radiationSource.Intensity = activation.Comp.MaxIntensity;
+        Dirty(activation.Owner, radiationSource);
+    }
+
+    private float CalculateIntensityIncrease(Entity<RadiationActivationComponent> activation, float rads, float frameTime)
+    {
+        return rads * activation.Comp.ActivationRate * frameTime;
+    }
+}

--- a/Content.Server/_Persistence14/Radiation/RadiationSystem.Activation.cs
+++ b/Content.Server/_Persistence14/Radiation/RadiationSystem.Activation.cs
@@ -32,7 +32,6 @@ public sealed partial class RadiationSystem
         }
         if (radiationSource.Intensity > activation.Comp.MaxIntensity)
             radiationSource.Intensity = activation.Comp.MaxIntensity;
-        Dirty(activation.Owner, radiationSource);
     }
 
     private float CalculateIntensityIncrease(Entity<RadiationActivationComponent> activation, float rads, float frameTime)

--- a/Content.Server/_Persistence14/Radiation/RadiationSystem.Decay.cs
+++ b/Content.Server/_Persistence14/Radiation/RadiationSystem.Decay.cs
@@ -1,0 +1,23 @@
+using Content.Shared._Persistence14.Radiation;
+using Content.Shared.Radiation.Components;
+
+namespace Content.Server.Radiation.Systems; // Breaking the rules a bit, but need to extend this namespace to add to the RadiationSystem
+
+public sealed partial class RadiationSystem
+{
+    private void UpdateDecay(float deltaTime)
+    {
+        var decayEnts = EntityQueryEnumerator<RadioactiveDecayComponent, RadiationSourceComponent>();
+
+        while (decayEnts.MoveNext(out var uid, out var decay, out var source))
+        {
+            source.Intensity = CalculateDecay(source.Intensity, deltaTime, decay.HalfLife);
+        }
+    }
+
+    private static float CalculateDecay(float initialIntensity, float deltaTime, TimeSpan halfLife)
+    {
+        float ratio = deltaTime / (float)halfLife.TotalSeconds;
+        return initialIntensity * MathF.Pow(0.5f, ratio);
+    }
+}

--- a/Content.Shared/_Persistence14/EntityEffects/IrradiateEntityEffect.cs
+++ b/Content.Shared/_Persistence14/EntityEffects/IrradiateEntityEffect.cs
@@ -1,0 +1,24 @@
+using Content.Shared.EntityEffects;
+
+namespace Content.Shared._Persistence14.EntityEffects;
+
+/// <summary>
+///     An entity effect to add radiation intensity to an object. Automatically configures radioactive decay and activation components.
+///     Can be configured to add the RadiationSourceComponent if not already present.
+/// </summary>
+public sealed partial class Irradiate : EntityEffectBase<Irradiate>
+{
+    [DataField(required: true)]
+    public float Intensity;
+
+    [DataField]
+    public TimeSpan HalfLife = TimeSpan.Zero;
+    public bool Decays => HalfLife > TimeSpan.Zero;
+
+    [DataField]
+    public float MaxIntensity = 0f;
+    public bool Activates => MaxIntensity > Intensity;
+
+    [DataField]
+    public bool AddComponentIfAbsent = true;
+}

--- a/Content.Shared/_Persistence14/Radiation/RadiationActivationComponent.cs
+++ b/Content.Shared/_Persistence14/Radiation/RadiationActivationComponent.cs
@@ -14,7 +14,9 @@ public sealed partial class RadiationActivationComponent : Component
 
     /// <summary>
     /// How effectively incoming radiation becomes activity.
+    /// 
+    /// At default rate, constant exposure to a given radiation intensity will accumulate that same intensity over 5 hours, ignoring decay.
     /// </summary>
     [DataField]
-    public float ActivationRate = 0.01f;
+    public float ActivationRate = 1f / 18000f;
 }

--- a/Content.Shared/_Persistence14/Radiation/RadiationActivationComponent.cs
+++ b/Content.Shared/_Persistence14/Radiation/RadiationActivationComponent.cs
@@ -1,0 +1,20 @@
+namespace Content.Shared._Persistence14.Radiation;
+
+/// <summary>
+/// Allows an object to gain radioactive intensity by being exposed to radiation from other sources. This intensity is scaled 
+/// </summary>
+[RegisterComponent]
+public sealed partial class RadiationActivationComponent : Component
+{
+    /// <summary>
+    /// Maximum intensity this entity can accumulate.
+    /// </summary>
+    [DataField]
+    public float MaxIntensity = 10f;
+
+    /// <summary>
+    /// How effectively incoming radiation becomes activity.
+    /// </summary>
+    [DataField]
+    public float ActivationRate = 0.01f;
+}

--- a/Content.Shared/_Persistence14/Radiation/RadioactiveDecayComponent.cs
+++ b/Content.Shared/_Persistence14/Radiation/RadioactiveDecayComponent.cs
@@ -1,0 +1,19 @@
+namespace Content.Shared._Persistence14.Radiation;
+
+[RegisterComponent]
+public sealed partial class RadioactiveDecayComponent : Component
+{
+    /// <summary>
+    /// The amount of time it takes for the intensity of the <see cref="Content.Shared.Radiation.Components.RadiationSourceComponent.Intesity"/> to half in value.
+    /// Follows exponential decay.
+    /// </summary>
+    [DataField(required: true)]
+    public TimeSpan HalfLife;
+
+    /// <summary>
+    /// The threshold at which the RadiationSourceComponent will be removed from the entity.
+    /// Establishes the "minimum radioactiveness" to be considered.
+    /// </summary>
+    [DataField]
+    public float MinimumRadiationIntesnity = 0.1f;
+}

--- a/Content.Shared/_Persistence14/Radiation/RadioactiveDecayComponent.cs
+++ b/Content.Shared/_Persistence14/Radiation/RadioactiveDecayComponent.cs
@@ -4,16 +4,11 @@ namespace Content.Shared._Persistence14.Radiation;
 public sealed partial class RadioactiveDecayComponent : Component
 {
     /// <summary>
-    /// The amount of time it takes for the intensity of the <see cref="Content.Shared.Radiation.Components.RadiationSourceComponent.Intesity"/> to half in value.
+    /// The amount of time it takes for the intensity of the entity to half in value.
     /// Follows exponential decay.
+    /// 
+    /// With default values, the entity will half in intensity once every 5 hours (once a shift).
     /// </summary>
     [DataField(required: true)]
-    public TimeSpan HalfLife;
-
-    /// <summary>
-    /// The threshold at which the RadiationSourceComponent will be removed from the entity.
-    /// Establishes the "minimum radioactiveness" to be considered.
-    /// </summary>
-    [DataField]
-    public float MinimumRadiationIntesnity = 0.1f;
+    public TimeSpan HalfLife = TimeSpan.FromHours(5);
 }

--- a/Content.Shared/_Persistence14/Radiation/RadioactiveDecayComponent.cs
+++ b/Content.Shared/_Persistence14/Radiation/RadioactiveDecayComponent.cs
@@ -9,6 +9,6 @@ public sealed partial class RadioactiveDecayComponent : Component
     /// 
     /// With default values, the entity will half in intensity once every 5 hours (once a shift).
     /// </summary>
-    [DataField(required: true)]
+    [DataField]
     public TimeSpan HalfLife = TimeSpan.FromHours(5);
 }

--- a/Content.Shared/_Persistence14/Xenoarchaeology/Artifact/XAE/Components/XAEEntityEffectComponent.cs
+++ b/Content.Shared/_Persistence14/Xenoarchaeology/Artifact/XAE/Components/XAEEntityEffectComponent.cs
@@ -1,0 +1,71 @@
+using Content.Shared.EntityEffects;
+using Content.Shared.Whitelist;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._Persistence14.Xenoarcheology.Artifact.XAE.Components;
+
+[RegisterComponent, Access(typeof(XAEEntityEffectSystem))]
+public sealed partial class XAEEntityEffectComponent : Component
+{
+    /// <summary>
+    /// The effects to be applied and the flags to determine the target.
+    /// </summary>
+    [DataField(required: true)]
+    public List<ArtifactEntityEffect> Effects = new();
+}
+
+[DataDefinition, NetSerializable, Serializable]
+public sealed partial class ArtifactEntityEffect
+{
+    /// <summary>
+    /// Targeting flags for the entity effect;
+    /// </summary>
+    [DataField(required: true)]
+    public XAEEntityEffectTargetFlags Flags;
+
+    /// <summary>
+    /// A selection whitelist for nearest/nearby/random targeting flags.
+    /// </summary>
+    [DataField]
+    public EntityWhitelist? Whitelist = null;
+
+    /// <summary>
+    /// A selection blacklist for nearest/nearby/random targeting flags.
+    /// </summary>
+    [DataField]
+    public EntityWhitelist? Blacklist = null;
+
+    /// <summary>
+    /// The effect to be applied to the target(s) based on the flags.
+    /// </summary>
+    [DataField(required: true)]
+    public EntityEffect Effect;
+
+    /// <summary>
+    /// The number of times the effect should be applied.
+    /// </summary>
+    [DataField]
+    public int Count = 1;
+
+    /// <summary>
+    /// The minimum range in which nearby/nearest/random targeting flags may target.
+    /// </summary>
+    [DataField]
+    public float MinRange = 0f;
+
+    /// <summary>
+    /// The maximum range in which nearby/nearest/random targeting flags may target.
+    /// </summary>
+    [DataField]
+    public float MaxRange = 10f;
+}
+
+[Flags]
+public enum XAEEntityEffectTargetFlags : byte
+{
+    Artifact = 1 << 0,
+    User = 1 << 1,
+    Nearest = 1 << 2,
+    Nearby = 1 << 3,
+    Random = 1 << 4,
+}

--- a/Content.Shared/_Persistence14/Xenoarchaeology/Artifact/XAE/XAEEntityEffectSystem.cs
+++ b/Content.Shared/_Persistence14/Xenoarchaeology/Artifact/XAE/XAEEntityEffectSystem.cs
@@ -36,7 +36,7 @@ public sealed partial class XAEEntityEffectSystem : BaseXAESystem<XAEEntityEffec
         // Ignores all distance/whitelist restrictions
         if (effect.Flags.HasFlag(XAEEntityEffectTargetFlags.Artifact))
         {
-            yield return ent.Owner;
+            yield return args.Artifact;
         }
 
         /// Ignores whitelist and minimum distance restrictions

--- a/Content.Shared/_Persistence14/Xenoarchaeology/Artifact/XAE/XAEEntityEffectSystem.cs
+++ b/Content.Shared/_Persistence14/Xenoarchaeology/Artifact/XAE/XAEEntityEffectSystem.cs
@@ -9,7 +9,6 @@ using Robust.Shared.Random;
 
 namespace Content.Shared._Persistence14.Xenoarcheology.Artifact.XAE;
 
-[RegisterComponent]
 public sealed partial class XAEEntityEffectSystem : BaseXAESystem<XAEEntityEffectComponent>
 {
     [Dependency] private IRobustRandom _random = default!;

--- a/Content.Shared/_Persistence14/Xenoarchaeology/Artifact/XAE/XAEEntityEffectSystem.cs
+++ b/Content.Shared/_Persistence14/Xenoarchaeology/Artifact/XAE/XAEEntityEffectSystem.cs
@@ -1,0 +1,117 @@
+using System.Linq;
+using System.Numerics;
+using Content.Shared._Persistence14.Xenoarcheology.Artifact.XAE.Components;
+using Content.Shared.EntityEffects;
+using Content.Shared.Whitelist;
+using Content.Shared.Xenoarchaeology.Artifact;
+using Content.Shared.Xenoarchaeology.Artifact.XAE;
+using Robust.Shared.Random;
+
+namespace Content.Shared._Persistence14.Xenoarcheology.Artifact.XAE;
+
+[RegisterComponent]
+public sealed partial class XAEEntityEffectSystem : BaseXAESystem<XAEEntityEffectComponent>
+{
+    [Dependency] private IRobustRandom _random = default!;
+    [Dependency] private SharedEntityEffectsSystem _effects = default!;
+    [Dependency] private SharedTransformSystem _transform = default!;
+    [Dependency] private EntityLookupSystem _lookup = default!;
+    [Dependency] private EntityWhitelistSystem _whitelist = default!;
+
+    protected override void OnActivated(Entity<XAEEntityEffectComponent> ent, ref XenoArtifactNodeActivatedEvent args)
+    {
+        foreach (var effect in ent.Comp.Effects)
+        {
+            var targets = GetTargets(ent, effect, args).ToHashSet();
+            foreach (var target in targets)
+            {
+                _effects.ApplyEffect(target, effect.Effect, user: args.User);
+            }
+        }
+    }
+
+    private IEnumerable<EntityUid> GetTargets(Entity<XAEEntityEffectComponent> ent, ArtifactEntityEffect effect, XenoArtifactNodeActivatedEvent args)
+    {
+        var artifactPos = _transform.GetWorldPosition(ent.Owner);
+
+        // Ignores all distance/whitelist restrictions
+        if (effect.Flags.HasFlag(XAEEntityEffectTargetFlags.Artifact))
+        {
+            yield return ent.Owner;
+        }
+
+        /// Ignores whitelist and minimum distance restrictions
+        if (effect.Flags.HasFlag(XAEEntityEffectTargetFlags.User))
+        {
+            if (args.User is { } user)
+            {
+                var userPos = _transform.GetWorldPosition(user);
+                var dist = Vector2.DistanceSquared(artifactPos, userPos);
+                if (dist <= effect.MaxRange * effect.MaxRange)
+                {
+                    // User flag ignores minimum distance.
+                    yield return user;
+                }
+            }
+        }
+
+        var targets = GetInRange(ent.Owner, effect.MinRange, effect.MaxRange, effect.Whitelist, effect.Blacklist).ToList();
+        if (effect.Flags.HasFlag(XAEEntityEffectTargetFlags.Nearest))
+        {
+            targets.Sort((a, b) => a.distSquared.CompareTo(b.distSquared));
+            var count = Math.Min(effect.Count, targets.Count);
+            for (int i = count - 1; i >= 0; i--)
+            {
+                yield return targets[i].uid;
+                targets.RemoveAt(i);
+            }
+        }
+
+        if (effect.Flags.HasFlag(XAEEntityEffectTargetFlags.Nearby))
+        {
+            foreach (var (target, _) in targets)
+                yield return target;
+        }
+
+        if (effect.Flags.HasFlag(XAEEntityEffectTargetFlags.Random))
+        {
+            var count = Math.Min(effect.Count, targets.Count);
+            for (int i = 0; i < count; i++)
+                yield return _random.PickAndTake(targets).uid;
+        }
+    }
+
+    private IEnumerable<(EntityUid uid, float distSquared)> GetInRange(
+        EntityUid source,
+        float minRange, float maxRange,
+        EntityWhitelist? whitelist, EntityWhitelist? blacklist)
+    {
+        var sourceXform = Transform(source);
+        var sourcePos = _transform.GetWorldPosition(sourceXform);
+
+        var minRangeSquared = minRange * minRange;
+
+        foreach (var target in _lookup.GetEntitiesInRange(sourceXform.Coordinates, maxRange))
+        {
+            if (target == source)
+                continue;
+
+            if (_whitelist.IsWhitelistFail(whitelist, target) ||
+                _whitelist.IsWhitelistPass(blacklist, target))
+                continue;
+
+            var targetXform = Transform(target);
+
+            if (targetXform.MapID != sourceXform.MapID)
+                continue;
+
+            var targetPos = _transform.GetWorldPosition(targetXform);
+            var distanceSquared = Vector2.DistanceSquared(targetPos, sourcePos);
+
+            if (distanceSquared < minRangeSquared)
+                continue;
+
+            yield return (target, distanceSquared);
+        }
+    }
+}

--- a/Resources/Prototypes/Entities/Objects/Materials/scrap.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/scrap.yml
@@ -514,9 +514,11 @@
       Uranium: 2500 # 25 sheets
       Plastic: 500 # 5 sheets
   - type: RadiationSource
-    intensity: 3.0
+    intensity: 3
   - type: RadioactiveDecay
-    halfLife: 4h
+  - type: RadiationReceiver
+  - type: RadiationActivation
+    maxIntensity: 9
 
 - type: entity
   parent: BaseScrapLarge
@@ -542,7 +544,9 @@
   - type: RadiationSource
     intensity: 1.5
   - type: RadioactiveDecay
-    halfLife: 4h
+  - type: RadiationReceiver
+  - type: RadiationActivation
+    maxIntensity: 9.0 # Same as leaking generator
 
 - type: entity
   parent: BaseScrapLarge

--- a/Resources/Prototypes/Entities/Objects/Materials/scrap.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/scrap.yml
@@ -514,7 +514,9 @@
       Uranium: 2500 # 25 sheets
       Plastic: 500 # 5 sheets
   - type: RadiationSource
-    intensity: 1.0
+    intensity: 3.0
+  - type: RadioactiveDecay
+    halfLife: 4h
 
 - type: entity
   parent: BaseScrapLarge
@@ -538,7 +540,9 @@
       Uranium: 1000 # 10 sheets
       Plastic: 500 # 5 sheets
   - type: RadiationSource
-    intensity: 0.5
+    intensity: 1.5
+  - type: RadioactiveDecay
+    halfLife: 4h
 
 - type: entity
   parent: BaseScrapLarge

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/generators.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/generators.yml
@@ -296,7 +296,11 @@
     sprite: Structures/Power/Generation/rtg.rsi
     state: rtg_damaged
   - type: RadiationSource # ideally only when opened.
-    intensity: 2
+    intensity: 4
+  - type: RadioactiveDecay
+    halfLife: 4h
+  - type: RadiationActivation
+    maxIntensity: 10
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/generators.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/generators.yml
@@ -295,12 +295,12 @@
   - type: PowerMonitoringDevice
     sprite: Structures/Power/Generation/rtg.rsi
     state: rtg_damaged
-  - type: RadiationSource # ideally only when opened.
+  - type: RadiationSource
     intensity: 4
   - type: RadioactiveDecay
-    halfLife: 4h
   - type: RadiationActivation
-    maxIntensity: 10
+    maxIntensity: 12
+  - type: RadiationReceiver
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Structures/Storage/barrels.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/barrels.yml
@@ -64,8 +64,12 @@
   - type: Sprite
     state: radbarrel
   - type: RadiationSource
-    intensity: 1.0
+    intensity: 2.0
     slope: 0.25
+  - type: RadioactiveDecay
+    halfLife: 4h
+  - type: RadiationActivation
+    maxIntensity: 6
 
 - type: entityTable
   id: RandomChemicalBarrel

--- a/Resources/Prototypes/Entities/Structures/Storage/barrels.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/barrels.yml
@@ -65,11 +65,10 @@
     state: radbarrel
   - type: RadiationSource
     intensity: 2.0
-    slope: 0.25
   - type: RadioactiveDecay
-    halfLife: 4h
   - type: RadiationActivation
     maxIntensity: 6
+  - type: RadiationReceiver
 
 - type: entityTable
   id: RandomChemicalBarrel

--- a/Resources/Prototypes/XenoArch/effect_tables.yml
+++ b/Resources/Prototypes/XenoArch/effect_tables.yml
@@ -3,7 +3,7 @@
   table: !type:GroupSelector
     children:
     - !type:NestedSelector
-      tableId: XenoArtifactEffectsRoot
+      tableId: Debug
       weight: 483.0 # Total weights of the table so distribution remains even
     # Eventually full size only artifact effects will go here
 
@@ -57,6 +57,15 @@
     - !type:NestedSelector
       tableId: XenoArtifactEffectsDeepHandheldOnly
       weight: 30.0 # Total weights of the table so distribution remains even
+
+- type: entityTable
+  id: Debug
+  table: !type:GroupSelector
+    children:
+    - id: XenoArtifactRadioactive
+      weight: 10
+    - id: XenoArtifactRadioactiveStrong
+      weight: 10
 
 - type: entityTable # Root Nodes (Depth 0)
   id: XenoArtifactEffectsRoot

--- a/Resources/Prototypes/XenoArch/effects.yml
+++ b/Resources/Prototypes/XenoArch/effects.yml
@@ -758,8 +758,8 @@
     - flags: Artifact
       effect: !type:Irradiate
         intensity: 2.0
-        halfLife: 4h
-        maxIntensity: 2.0
+        halfLife: 5h
+        maxIntensity: 6.0
 
 - type: entity
   id: XenoArtifactChargeBatteryLow
@@ -1443,8 +1443,8 @@
     - flags: Artifact
       effect: !type:Irradiate
         intensity: 4
-        halfLife: 4h
-        maxIntensity: 4
+        halfLife: 5h
+        maxIntensity: 12
         
 
 - type: entity

--- a/Resources/Prototypes/XenoArch/effects.yml
+++ b/Resources/Prototypes/XenoArch/effects.yml
@@ -753,13 +753,13 @@
   parent: BaseOneTimeXenoArtifactEffect
   description: Becomes mildly radioactive
   components:
-  - type: XAEApplyComponents
-    applyIfAlreadyHave: true
-    refreshOnReactivate: true
-    components:
-    - type: RadiationSource
-      intensity: 1
-      slope: 0.3
+  - type: XAEEntityEffect
+    effects: 
+    - flags: Artifact
+      effect: !type:Irradiate
+        intensity: 2.0
+        halfLife: 4h
+        maxIntensity: 2.0
 
 - type: entity
   id: XenoArtifactChargeBatteryLow
@@ -1438,13 +1438,14 @@
   parent: BaseOneTimeXenoArtifactEffect
   description: Becomes highly radioactive
   components:
-  - type: XAEApplyComponents
-    applyIfAlreadyHave: true
-    refreshOnReactivate: true
-    components:
-    - type: RadiationSource
-      intensity: 2
-      slope: 0.3
+  - type: XAEEntityEffect
+    effects: 
+    - flags: Artifact
+      effect: !type:Irradiate
+        intensity: 4
+        halfLife: 4h
+        maxIntensity: 4
+        
 
 - type: entity
   id: XenoArtifactMaterialSpawnGlassFew


### PR DESCRIPTION
<!-- Guidelines: docs/github-guidelines.md -->

## About the PR
<!-- What did you change? -->
A major overhaul to how radiation works, allowing it to both increase *and* decrease over time under the right conditions. All radioactive items (excluding raw sources of radiation such as anomalies, singularities, etc) now decay with a half life set to 5 hours. All of these items may now also *gain* radiation when exposed to sources stronger than themselves.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Currently radioactive items are a "get and forget" kind of thing, which doesn't feel great in a persistent world. Radioactive decay and activation provide a semi-realistic means of balancing those forced turning them into a more interesting design challenge.

## Technical details
<!-- Summary of code changes for easier review. -->
* Adds the `RadioactiveDecayComponent` with a `HalfLife` field. Works with `RadiationSystem.Decay.cs` to handle radioactive decay on an update loop like other radiation effects.
* Adds `RadiationActivationComponent` with a `ActivationRate` and `MaxIntensity` field. Works with `RadiationSystem.Activation.cs` to increase source intensity when a `RadiationReceiverComponent` receives rads.
* Adds a new type of entity effect: Irradiate. It can add rads to an object, set up decay and activation on them, and set up a source component if none is already present.
* Adds two new commands:
    * addrad <EntityUid> <Intensity> - adds a given intensity to an entitiy, adding the necessary components if not present
    * clearrad <EntityUid> - removes the radiation source component from an entity, removing its rads
* New type of XAE, XAEEntityEffect, which allows the use of EntityEffects as artifact effects.
* Updates radiation node effects to use XAEEntityEffect with the Irradiate entity effect, instead of directly adding the radiation sources.

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Disclaimers
<!-- Per contribution guidelines, all contributions which use AI must disclose that use. Mark which section(s) best describe the use of AI in this PR. If AI was not used, this section may be skipped -->
- [X] AI was used to aid in brainstorming, testing, or debugging of systems within this PR
- [ ] AI developed assets are included as parts of this PR. These assets are identified as AI developed in the file and are listed below:
    - <!-- Add any AI generated file names here. --> 

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
No known breaking changes.

## GitHub Links
<!-- Adds a link to any github issue resolved by this PR. All PRs should ideally resolve for contribute to at least one issue. If no issues currently match your PR, then
you may skip this section -->
- #686 <!-- GitHub issues are identified in markdown via #123, you may also search for the name of the issue using #issue-name -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
