### PR TITLE
tweak: allow wallmounts on non-directional windows

### DIFF
--- a/Content.Shared/Construction/Conditions/WallmountCondition.cs
+++ b/Content.Shared/Construction/Conditions/WallmountCondition.cs
@@ -62,7 +62,9 @@ namespace Content.Shared.Construction.Conditions
             // check that we didn't try to build wallmount that facing another adjacent wall
             var rAdjWall = new CollisionRay(objWorldPosition, directionWithOffset.Normalized(), (int)CollisionGroup.Impassable);
             var adjWallRaycastResults = physics.IntersectRayWithPredicate(entManager.GetComponent<TransformComponent>(user).MapID, rAdjWall, maxLength: 0.5f,
-               predicate: e => e == targetWall.Value.HitEntity || !tagSystem.HasTag(e, WallTag));
+               predicate: e => e == targetWall.Value.HitEntity || !tagSystem.HasTag(e, WallTag) &&
+                               !tagSystem.HasTag(e, WindowTag) || // Persistence: Prevent wallmounts facing windows
+                               tagSystem.HasTag(e, DirectionalWindowTag)); // Persistence: Unless they are directional windows
 
             return !adjWallRaycastResults.Any();
         }

--- a/Content.Shared/Construction/Conditions/WallmountCondition.cs
+++ b/Content.Shared/Construction/Conditions/WallmountCondition.cs
@@ -16,6 +16,8 @@ namespace Content.Shared.Construction.Conditions
     public sealed partial class WallmountCondition : IConstructionCondition
     {
         private static readonly ProtoId<TagPrototype> WallTag = "Wall";
+        private static readonly ProtoId<TagPrototype> WindowTag = "Window";
+        private static readonly ProtoId<TagPrototype> DirectionalWindowTag = "DirectionalWindow";
 
         public bool Condition(EntityUid user, EntityCoordinates location, Direction direction)
         {
@@ -45,7 +47,7 @@ namespace Content.Shared.Construction.Conditions
             var tagSystem = entManager.System<TagSystem>();
 
             var userToObjRaycastResults = physics.IntersectRayWithPredicate(entManager.GetComponent<TransformComponent>(user).MapID, rUserToObj, maxLength: length,
-                predicate: (e) => !tagSystem.HasTag(e, WallTag));
+                predicate: (e) => !tagSystem.HasTag(e, WallTag) && !tagSystem.HasTag(e, WindowTag) || tagSystem.HasTag(e, DirectionalWindowTag));
 
             var targetWall = userToObjRaycastResults.FirstOrNull();
 

--- a/Content.Shared/Construction/Conditions/WallmountCondition.cs
+++ b/Content.Shared/Construction/Conditions/WallmountCondition.cs
@@ -16,8 +16,10 @@ namespace Content.Shared.Construction.Conditions
     public sealed partial class WallmountCondition : IConstructionCondition
     {
         private static readonly ProtoId<TagPrototype> WallTag = "Wall";
+        // Start Persistence: Allow wallmounts on non-directional windows
         private static readonly ProtoId<TagPrototype> WindowTag = "Window";
         private static readonly ProtoId<TagPrototype> DirectionalWindowTag = "DirectionalWindow";
+        // End Persistence
 
         public bool Condition(EntityUid user, EntityCoordinates location, Direction direction)
         {
@@ -47,7 +49,9 @@ namespace Content.Shared.Construction.Conditions
             var tagSystem = entManager.System<TagSystem>();
 
             var userToObjRaycastResults = physics.IntersectRayWithPredicate(entManager.GetComponent<TransformComponent>(user).MapID, rUserToObj, maxLength: length,
-                predicate: (e) => !tagSystem.HasTag(e, WallTag) && !tagSystem.HasTag(e, WindowTag) || tagSystem.HasTag(e, DirectionalWindowTag));
+                predicate: (e) => !tagSystem.HasTag(e, WallTag) &&
+                    !tagSystem.HasTag(e, WindowTag) || // Persistence: Allow wallmounts on windows
+                    tagSystem.HasTag(e, DirectionalWindowTag)); // Persistence: Disallow wallmounts on directional windows
 
             var targetWall = userToObjRaycastResults.FirstOrNull();
 

--- a/Resources/Locale/en-US/construction/conditions/wallmount.ftl
+++ b/Resources/Locale/en-US/construction/conditions/wallmount.ftl
@@ -1,2 +1,2 @@
-<!--Persistence: Add "or window"->
+# Persistence: Add "or window"
 construction-step-condition-wallmount = You must build it on a wall or window.

--- a/Resources/Locale/en-US/construction/conditions/wallmount.ftl
+++ b/Resources/Locale/en-US/construction/conditions/wallmount.ftl
@@ -1,1 +1,2 @@
-construction-step-condition-wallmount = You must build it on a wall.
+<!--Persistence: Add "or window"->
+construction-step-condition-wallmount = You must build it on a wall or window.


### PR DESCRIPTION
<!-- Guidelines: docs/github-guidelines.md -->

## About the PR
Allows constructions that use WallmountCondition to be built on windows, while preventing construction on directional windows.

## Why / Balance
Wallmounts can already exist ontop of windows by going through the fun process of building a wall first, building your wallmount, then deconning the wall & building a window.

## Technical details
Added `Window` tag to `WallmountCondition`'s filters as a whitelist & `DirectionalWindow` tag to the filters as a blacklist.
 - this condition relies on raycasts that ignore any entity where the predicate evals to true
 - first raycast checks if we're placing on something we want to place on
 - second raycast checks if the next tile in the direction we're placing it is obstructed by those same things
Localization update to reflect ability to place on windows

## Media
<img width="474" height="439" alt="image" src="https://github.com/user-attachments/assets/0adb4ec1-068f-4a50-a5cc-8f710ced86dc" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Disclaimers
<!-- Per contribution guidelines, all contributions which use AI must disclose that use. Mark which section(s) best describe the use of AI in this PR. If AI was not used, this section may be skipped -->
- [ ] AI was used to aid in brainstorming, testing, or debugging of systems within this PR
- [ ] AI developed assets are included as parts of this PR. These assets are identified as AI developed in the file and are listed below:
    - N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
:cl:
- tweak: Wall-mounted constructions can now also be built on windows!