### PR TITLE
Bugfix: Reverts testing change to root artifact nodes.

### DIFF
--- a/Resources/Prototypes/XenoArch/effect_tables.yml
+++ b/Resources/Prototypes/XenoArch/effect_tables.yml
@@ -3,7 +3,7 @@
   table: !type:GroupSelector
     children:
     - !type:NestedSelector
-      tableId: Debug
+      tableId: XenoArtifactEffectsRoot
       weight: 483.0 # Total weights of the table so distribution remains even
     # Eventually full size only artifact effects will go here
 
@@ -57,15 +57,6 @@
     - !type:NestedSelector
       tableId: XenoArtifactEffectsDeepHandheldOnly
       weight: 30.0 # Total weights of the table so distribution remains even
-
-- type: entityTable
-  id: Debug
-  table: !type:GroupSelector
-    children:
-    - id: XenoArtifactRadioactive
-      weight: 10
-    - id: XenoArtifactRadioactiveStrong
-      weight: 10
 
 - type: entityTable # Root Nodes (Depth 0)
   id: XenoArtifactEffectsRoot


### PR DESCRIPTION
<!-- Guidelines: docs/github-guidelines.md -->

## About the PR
<!-- What did you change? -->
Reverts the debug testing change 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Original PR (#688) did not properly save this correction and left in a debug table which causes all artifacts to have root radioactive nodes.

## Technical details
<!-- Summary of code changes for easier review. -->
* Removes the debug table from `effect-tables.yml`

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Disclaimers
<!-- Per contribution guidelines, all contributions which use AI must disclose that use. Mark which section(s) best describe the use of AI in this PR. If AI was not used, this section may be skipped -->
- [ ] AI was used to aid in brainstorming, testing, or debugging of systems within this PR
- [ ] AI developed assets are included as parts of this PR. These assets are identified as AI developed in the file and are listed below:
    - <!-- Add any AI generated file names here. --> 

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Artifacts now have proper root node generation again. Whoops.