### PR TITLE
Add Book tag to threshold survival guide tags override so it can be placed on bookshelves

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/books.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/books.yml
@@ -193,6 +193,7 @@
   - type: Tag
     tags:
     - Recyclable
+    - Book
 
 - type: entity
   id: BookFactionHandbook


### PR DESCRIPTION
<!-- Guidelines: docs/github-guidelines.md -->

## About the PR
Ensure the threshold guidebook can be placed on bookshelves.

## Why / Balance
This was the only guidebook unable to be placed on bookshelves.

## Technical details
Added `Book` tag to this guidebook.

## Media
Confirmed all guidebook items can be placed on shelves.  The threshold guidebook was the only one that overrode tags causing it to lose the `Book` tag, so was the only one needed to be fixed.
<img width="623" height="375" alt="image" src="https://github.com/user-attachments/assets/efe98530-d0e4-4cb5-b396-6a7e50f57e92" />

## Requirements
<!-- Confirm the following by placing an X in the brackets without spaces inside (for example: [X] ): -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Disclaimers
- [x] No AI used.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

## GitHub Links
<!-- Adds a link to any github issue resolved by this PR. All PRs should ideally resolve for contribute to at least one issue. If no issues currently match your PR, then
you may skip this section -->
- Fixes michaelchessall/SS14-Persistence#704
<!-- GitHub issues are identified in markdown via #123, you may also search for the name of the issue using #issue-name -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: threshold survival guide can be placed on bookshelves
